### PR TITLE
Silence the last Biome lint diagnostic

### DIFF
--- a/examples/04-a2a/04-authentication.ts
+++ b/examples/04-a2a/04-authentication.ts
@@ -82,7 +82,7 @@ const handler: AuthenticationHandler = {
     response.status === 401 ? { authorization: `Bearer ${await fetchToken()}` } : undefined,
   // The retry worked, so keep what worked instead of refreshing again on the next call.
   onSuccessfulRetry: async (headers) => {
-    cached = headers['authorization']?.replace('Bearer ', '') ?? cached;
+    cached = headers.authorization?.replace('Bearer ', '') ?? cached;
   },
 };
 


### PR DESCRIPTION
`biome check .` reported a single diagnostic across the workspace:

```
examples/04-a2a/04-authentication.ts:85:22  lint/complexity/useLiteralKeys  (info)
```

`onSuccessfulRetry` receives `HttpHeaders` from `@a2a-js/sdk/client`, which is declared as
`{ [key: string]: string }`. Dot access is therefore equivalent to the bracket form at both the
type and the runtime level, so the rewrite is behaviour-preserving. Biome labels the fix
"unsafe", but that label belongs to the rule as a whole rather than to this occurrence, so the
change was applied by hand after checking the declaration instead of through `--write --unsafe`.

## Verification

- `biome check .` — 229 files, no diagnostics
- `pnpm typecheck` — all 11 projects pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)