### PR TITLE
Raise branch coverage to 91% and fix reasoning-id folding parity

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "build": "pnpm -r build",
     "test": "pnpm -r test",
+    "test:coverage": "vitest run --coverage --testTimeout=30000",
     "typecheck": "pnpm -r typecheck",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.6",
     "@types/node": "^24.0.0",
+    "@vitest/coverage-v8": "4.1.10",
     "tsdown": "^0.22.14",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"

--- a/packages/a2a/src/convert.test.ts
+++ b/packages/a2a/src/convert.test.ts
@@ -200,6 +200,15 @@ describe('the message a turn sends', () => {
 });
 
 describe('payloads to response updates', () => {
+  it('rejects a payload kind this protocol version does not define', () => {
+    expect(() =>
+      updatesFromPayload(
+        { $case: 'hologram', value: {} } as unknown as Parameters<typeof updatesFromPayload>[0],
+        {},
+      ),
+    ).toThrow(/unsupported payload: 'hologram'/);
+  });
+
   it('turns a message payload into one finished assistant update', () => {
     const observed: ObservedTaskState = {};
 

--- a/packages/agentserver/src/validation.test.ts
+++ b/packages/agentserver/src/validation.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { ProtocolError } from './errors.js';
+import { conversationIdOf, parseCreateRequest, parseStartingAfter } from './validation.js';
+
+// The schema pass mirrors Python's generated `validate_create_response_payload`: every mistyped
+// field is reported together on one 400, as `$`-rooted JSON paths, before any semantic check
+// runs. These tests feed one wrong field at a time and assert the reported path.
+
+/** The field-level details of the schema-validation 400 for `body`. */
+function detailParams(body: unknown): string[] {
+  try {
+    parseCreateRequest(body);
+  } catch (error) {
+    if (error instanceof ProtocolError && error.details !== undefined) {
+      return error.details.map((detail) => detail.param ?? '');
+    }
+    throw error;
+  }
+  return [];
+}
+
+describe('schema validation paths', () => {
+  it.each([
+    [{ stream: 'yes' }, '$.stream'],
+    [{ background: 0 }, '$.background'],
+    [{ model: 42 }, '$.model'],
+    [{ instructions: [] }, '$.instructions'],
+    [{ temperature: 'hot' }, '$.temperature'],
+    [{ max_output_tokens: '100' }, '$.max_output_tokens'],
+    [{ stream_options: [] }, '$.stream_options'],
+    [{ text: 'plain' }, '$.text'],
+    [{ input: 42 }, '$.input'],
+    [{ input: [42] }, '$.input[0]'],
+    [{ input: [{ role: 'user' }] }, '$.input[0]'],
+    [{ conversation: 42 }, '$.conversation'],
+    [{ conversation: { id: 42 } }, '$.conversation.id'],
+    [{ metadata: [] }, '$.metadata'],
+    [{ metadata: { note: 42 } }, "$.metadata['note']"],
+    [{ tools: {} }, '$.tools'],
+    [{ tools: [42] }, '$.tools[0]'],
+    [{ include: {} }, '$.include'],
+    [{ include: [42] }, '$.include[0]'],
+    [{ agent_reference: 42 }, '$.agent_reference'],
+    [{ agent_reference: {} }, '$.agent_reference.name'],
+    [{ agent_reference: { name: 'a', version: 2 } }, '$.agent_reference.version'],
+  ])('reports %j at %s', (body, param) => {
+    expect(detailParams(body)).toContain(param);
+  });
+
+  it('reports every problem together rather than stopping at the first', () => {
+    expect(detailParams({ stream: 'yes', model: 42, input: [{}] })).toEqual([
+      '$.stream',
+      '$.model',
+      '$.input[0]',
+    ]);
+  });
+
+  it('accepts each field in its documented shape', () => {
+    const request = parseCreateRequest({
+      stream: true,
+      stream_options: { include_obfuscation: false },
+      model: 'gpt-4o',
+      temperature: 0.2,
+      input: [{ type: 'message', role: 'user', content: 'hi' }],
+      conversation: { id: 'conv_1' },
+      metadata: { note: 'ok' },
+      tools: [{ type: 'function' }],
+      include: ['message.output_text.logprobs'],
+      agent_reference: { name: 'assistant', version: '1' },
+    });
+    expect(request.model).toBe('gpt-4o');
+  });
+});
+
+describe('metadata limits', () => {
+  it('rejects more than 16 pairs', () => {
+    const metadata = Object.fromEntries(Array.from({ length: 17 }, (_, i) => [`k${i}`, 'v']));
+    expect(() => parseCreateRequest({ metadata })).toThrow(/at most 16 key-value pairs/);
+  });
+
+  it('accepts exactly 16 pairs', () => {
+    const metadata = Object.fromEntries(Array.from({ length: 16 }, (_, i) => [`k${i}`, 'v']));
+    expect(parseCreateRequest({ metadata }).metadata).toEqual(metadata);
+  });
+
+  it('rejects a key longer than 64 characters without echoing all of it', () => {
+    expect(() => parseCreateRequest({ metadata: { ['k'.repeat(65)]: 'v' } })).toThrow(
+      /exceeds maximum length of 64/,
+    );
+  });
+
+  it('rejects a value longer than 512 characters', () => {
+    expect(() => parseCreateRequest({ metadata: { note: 'v'.repeat(513) } })).toThrow(
+      /exceeds maximum length of 512/,
+    );
+  });
+});
+
+describe('conversation id shapes', () => {
+  it('treats an empty conversation id as absent in both wire shapes', () => {
+    expect(conversationIdOf({ conversation: '' })).toBeUndefined();
+    expect(conversationIdOf({ conversation: { id: '' } })).toBeUndefined();
+    // And parsing accepts it: an absent id is not a malformed one.
+    expect(parseCreateRequest({ conversation: '' }).conversation).toBe('');
+  });
+});
+
+describe('starting_after cursor', () => {
+  it('clamps a cursor beyond safe-integer range to the same replay effect as Python', () => {
+    // Python's int() is arbitrary-precision: a huge positive cursor replays nothing, a huge
+    // negative one replays everything.
+    expect(parseStartingAfter('99999999999999999999')).toBe(Number.MAX_SAFE_INTEGER);
+    expect(parseStartingAfter('-99999999999999999999')).toBe(-1);
+  });
+});

--- a/packages/anthropic/src/from-anthropic.ts
+++ b/packages/anthropic/src/from-anthropic.ts
@@ -109,14 +109,14 @@ function incrementalUsage(cumulative: UsageDetails, emitted: Record<string, numb
   return delta;
 }
 
-function usageContent(usage: unknown, emitted: Record<string, number> | undefined): Content | undefined {
+function usageContent(usage: unknown, emitted: Record<string, number>): Content | undefined {
   const details = parseUsage(usage);
   if (details === undefined) {
     return undefined;
   }
   return {
     type: 'usage',
-    usageDetails: emitted === undefined ? details : incrementalUsage(details, emitted),
+    usageDetails: incrementalUsage(details, emitted),
     rawRepresentation: usage,
   };
 }

--- a/packages/anthropic/src/from-anthropic.wire-fallbacks.test.ts
+++ b/packages/anthropic/src/from-anthropic.wire-fallbacks.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createStreamParseState,
+  parseContentBlocks,
+  parseMessage,
+  parseStreamEvent,
+} from './from-anthropic.js';
+
+// The Messages API wire is read defensively: blocks can omit fields, carry scalars where lists
+// are expected, or be of kinds this build does not model, and each form has a defined mapping.
+// These tests pin the mappings down one degenerate payload at a time.
+
+describe('response-level fallbacks', () => {
+  it('parses a non-object response to an empty assistant message', () => {
+    const response = parseMessage(42);
+    expect(response.messages).toEqual([expect.objectContaining({ role: 'assistant', contents: [] })]);
+    expect(response.responseId).toBeUndefined();
+  });
+
+  it('ignores non-string ids and models, non-list content and empty usage', () => {
+    const response = parseMessage({ id: 42, model: null, content: 'not a list', usage: {} });
+    expect(response.responseId).toBeUndefined();
+    expect(response.model).toBeUndefined();
+    expect(response.messages[0]?.contents).toEqual([]);
+    expect(response.usageDetails).toBeUndefined();
+  });
+
+  it('passes an unknown stop_reason through unchanged', () => {
+    expect(parseMessage({ stop_reason: 'model_context_window_exceeded' }).finishReason).toBe(
+      'model_context_window_exceeded',
+    );
+  });
+});
+
+describe('content block fallbacks', () => {
+  it('skips entries that are not objects', () => {
+    expect(parseContentBlocks([42, null, 'text'])).toEqual([]);
+  });
+
+  it('defaults the missing fields of text, thinking and signature blocks', () => {
+    const [text, thinking, signature] = parseContentBlocks([
+      { type: 'text' },
+      { type: 'thinking' },
+      { type: 'signature_delta' },
+    ]);
+    expect(text).toMatchObject({ type: 'text', text: '' });
+    expect(thinking).toMatchObject({ type: 'text_reasoning', text: '' });
+    expect(thinking).not.toHaveProperty('protectedData');
+    expect(signature).toMatchObject({ type: 'text_reasoning', protectedData: '' });
+  });
+
+  it('defaults the missing fields of a bare tool_use block outside streaming', () => {
+    expect(parseContentBlocks([{ type: 'tool_use' }])).toEqual([
+      expect.objectContaining({ type: 'function_call', callId: '', name: '', arguments: {} }),
+    ]);
+  });
+
+  it('renders a scalar mcp_tool_result content as one text output and a missing one as none', () => {
+    const [scalar, missing, noId] = parseContentBlocks([
+      { type: 'mcp_tool_result', tool_use_id: 'm1', content: 'found' },
+      { type: 'mcp_tool_result', tool_use_id: 'm2' },
+      { type: 'mcp_tool_result', content: null },
+    ]);
+    expect(scalar).toMatchObject({ callId: 'm1', output: [{ type: 'text', text: 'found' }] });
+    expect(missing).toMatchObject({ callId: 'm2', output: [] });
+    expect(noId).toMatchObject({ callId: '', output: [] });
+  });
+
+  it('maps provider-run search and fetch results onto the announcing server_tool_use call', () => {
+    const results = [{ type: 'web_search_result', url: 'https://a.example' }];
+    const [search, fetch] = parseContentBlocks([
+      { type: 'web_search_tool_result', tool_use_id: 'srvtoolu_1', content: results },
+      { type: 'web_fetch_tool_result' },
+    ]);
+    expect(search).toMatchObject({ type: 'function_result', callId: 'srvtoolu_1', result: results });
+    expect(fetch).toMatchObject({ type: 'function_result', callId: '' });
+  });
+});
+
+describe('streamed tool-call argument handling', () => {
+  it('opens a streamed call with empty string arguments so fragments can concatenate', () => {
+    // `content_block_start` carries `input: {}` as a placeholder; keeping the object would make
+    // the coalescer swallow every `input_json_delta` fragment that follows.
+    const state = createStreamParseState();
+    const update = parseStreamEvent(
+      { type: 'content_block_start', content_block: { type: 'tool_use', id: 't1', name: 'f', input: {} } },
+      state,
+    );
+    expect(update?.contents[0]).toMatchObject({ type: 'function_call', callId: 't1', arguments: '' });
+  });
+
+  it('keeps arguments that already arrived whole, even while streaming', () => {
+    const state = createStreamParseState();
+    const update = parseStreamEvent(
+      {
+        type: 'content_block_start',
+        content_block: { type: 'tool_use', id: 't1', name: 'f', input: { city: 'Osaka' } },
+      },
+      state,
+    );
+    expect(update?.contents[0]).toMatchObject({ arguments: { city: 'Osaka' } });
+  });
+
+  it('drops argument fragments of a server-side call instead of feeding them to the tool loop', () => {
+    const state = createStreamParseState();
+    parseStreamEvent(
+      {
+        type: 'content_block_start',
+        content_block: { type: 'server_tool_use', id: 's1', name: 'web_search' },
+      },
+      state,
+    );
+    expect(
+      parseStreamEvent(
+        { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: '{"q":' } },
+        state,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('drops an argument fragment that no call announced', () => {
+    expect(
+      parseStreamEvent(
+        { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: '{}' } },
+        createStreamParseState(),
+      ),
+    ).toBeUndefined();
+  });
+
+  it('maps a fragment without a payload to an empty arguments string', () => {
+    const state = createStreamParseState();
+    parseStreamEvent(
+      { type: 'content_block_start', content_block: { type: 'tool_use', id: 't1', name: 'f' } },
+      state,
+    );
+    const update = parseStreamEvent(
+      { type: 'content_block_delta', delta: { type: 'input_json_delta' } },
+      state,
+    );
+    expect(update?.contents[0]).toMatchObject({ callId: 't1', arguments: '' });
+  });
+
+  it('tracks a streamed MCP call the same way, defaulting its fields', () => {
+    const state = createStreamParseState();
+    const update = parseStreamEvent(
+      { type: 'content_block_start', content_block: { type: 'mcp_tool_use' } },
+      state,
+    );
+    expect(update?.contents[0]).toMatchObject({
+      type: 'mcp_server_tool_call',
+      callId: '',
+      toolName: '',
+      serverName: '',
+      arguments: '',
+    });
+  });
+});
+
+describe('stream event fallbacks', () => {
+  it('ignores events that are not objects or carry nothing', () => {
+    const state = createStreamParseState();
+    expect(parseStreamEvent(42, state)).toBeUndefined();
+    expect(parseStreamEvent({ type: 'ping' }, state)).toBeUndefined();
+    expect(parseStreamEvent({ type: 'content_block_start' }, state)).toBeUndefined();
+    expect(parseStreamEvent({ type: 'content_block_delta' }, state)).toBeUndefined();
+  });
+
+  it('parses a message_start without a message as an empty update', () => {
+    const update = parseStreamEvent({ type: 'message_start' }, createStreamParseState());
+    expect(update?.contents).toEqual([]);
+    expect(update?.responseId).toBeUndefined();
+  });
+
+  it('turns cumulative usage snapshots into increments across the stream', () => {
+    const state = createStreamParseState();
+    const start = parseStreamEvent(
+      { type: 'message_start', message: { id: 'msg_1', usage: { input_tokens: 3, output_tokens: 1 } } },
+      state,
+    );
+    expect(start?.contents).toEqual([
+      expect.objectContaining({
+        type: 'usage',
+        usageDetails: { inputTokenCount: 3, outputTokenCount: 1 },
+      }),
+    ]);
+
+    const delta = parseStreamEvent(
+      {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn' },
+        usage: { input_tokens: 3, output_tokens: 5 },
+      },
+      state,
+    );
+    expect(delta?.contents).toEqual([
+      expect.objectContaining({ usageDetails: { inputTokenCount: 0, outputTokenCount: 4 } }),
+    ]);
+    expect(delta?.finishReason).toBe('stop');
+  });
+
+  it('parses a message_delta without delta or usage as an empty update', () => {
+    const update = parseStreamEvent({ type: 'message_delta', usage: {} }, createStreamParseState());
+    expect(update?.contents).toEqual([]);
+    expect(update?.finishReason).toBeUndefined();
+  });
+});

--- a/packages/anthropic/src/to-anthropic.wire-fallbacks.test.ts
+++ b/packages/anthropic/src/to-anthropic.wire-fallbacks.test.ts
@@ -1,0 +1,201 @@
+import type { Message, Tool } from '@polymind-inc/agent-framework-core';
+import { describe, expect, it } from 'vitest';
+import {
+  toAnthropicMessages,
+  toAnthropicOutputFormat,
+  toAnthropicSystem,
+  toAnthropicTools,
+} from './to-anthropic.js';
+
+// The Messages API conversion absorbs transcript shapes that fall outside the happy path — folded
+// argument fragments, results carrying mixed content, blocks with no representation — and each has
+// a defined mapping rather than a 400 from the API. These tests pin those mappings down.
+
+/** Converts a single assistant message and returns the blocks of the first API message. */
+function blocksOf(contents: Message['contents']): Record<string, unknown>[] {
+  const [first] = toAnthropicMessages([{ role: 'assistant', contents }]);
+  if (first === undefined || typeof first.content === 'string') throw new Error('expected blocks');
+  return first.content;
+}
+
+describe('tool_use input parsing', () => {
+  function inputOf(args: Record<string, unknown> | string): unknown {
+    const [block] = blocksOf([{ type: 'function_call', callId: 'c1', name: 'f', arguments: args }]);
+    return block?.input;
+  }
+
+  it('parses a JSON object string back to the object the API wants', () => {
+    expect(inputOf('{"city":"Osaka"}')).toEqual({ city: 'Osaka' });
+  });
+
+  it('passes an already-structured argument object through', () => {
+    expect(inputOf({ city: 'Osaka' })).toEqual({ city: 'Osaka' });
+  });
+
+  it('maps empty and blank argument strings to an empty object', () => {
+    expect(inputOf('')).toEqual({});
+    expect(inputOf('   ')).toEqual({});
+  });
+
+  it('maps a JSON scalar to an empty object rather than sending a non-object input', () => {
+    expect(inputOf('"just a string"')).toEqual({});
+  });
+
+  it('maps a half-streamed fragment to an empty object instead of a 400', () => {
+    expect(inputOf('{"city":"Os')).toEqual({});
+  });
+});
+
+describe('tool_result content rendering', () => {
+  function resultContentOf(result: unknown): unknown {
+    const [block] = blocksOf([{ type: 'function_result', callId: 'c1', result }]);
+    return block?.content;
+  }
+
+  it('renders an absent result as an empty string', () => {
+    expect(resultContentOf(undefined)).toBe('');
+    expect(resultContentOf(null)).toBe('');
+  });
+
+  it('renders a content list as text and image blocks, dropping the unrepresentable', () => {
+    expect(
+      resultContentOf([
+        { type: 'text', text: 'measured' },
+        { type: 'data', uri: 'data:image/png;base64,AAAA', mediaType: 'image/png' },
+        { type: 'function_call', callId: 'nested', name: 'n', arguments: '' },
+        42,
+      ]),
+    ).toEqual([
+      { type: 'text', text: 'measured' },
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } },
+    ]);
+  });
+
+  it('renders a list with no representable item as an empty string', () => {
+    expect(resultContentOf([42])).toBe('');
+  });
+
+  it('renders a plain object result as its JSON', () => {
+    expect(resultContentOf({ ok: true })).toBe('{"ok":true}');
+  });
+});
+
+describe('image conversion limits', () => {
+  it('drops a data image whose URI is not base64-encoded', () => {
+    // `tool_result` image sources are base64 or URL; a percent-encoded data URI has neither shape.
+    expect(
+      toAnthropicMessages([
+        {
+          role: 'user',
+          contents: [{ type: 'data', uri: 'data:image/svg+xml,<svg/>', mediaType: 'image/svg+xml' }],
+        },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe('reasoning replay limits', () => {
+  it('drops a signature that has no thinking block to attach to', () => {
+    expect(
+      toAnthropicMessages([
+        { role: 'assistant', contents: [{ type: 'text_reasoning', text: '', protectedData: 'sig' }] },
+      ]),
+    ).toEqual([]);
+  });
+
+  it('replays an identified summary without a signature as plain text, not thinking', () => {
+    expect(blocksOf([{ type: 'text_reasoning', text: 'the gist', id: 'rs_1' }])).toEqual([
+      { type: 'text', text: 'the gist' },
+    ]);
+  });
+});
+
+describe('MCP block conversion', () => {
+  it('splits a provider-run MCP exchange into the roles the API requires', () => {
+    const messages = toAnthropicMessages([
+      {
+        role: 'assistant',
+        contents: [
+          {
+            type: 'mcp_server_tool_call',
+            callId: 'mc1',
+            toolName: 'lookup',
+            serverName: 'srv',
+            arguments: { q: 1 },
+          },
+          { type: 'mcp_server_tool_result', callId: 'mc1', output: [{ type: 'text', text: 'found' }] },
+        ],
+      },
+    ]);
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'mcp_tool_use', id: 'mc1', name: 'lookup', server_name: 'srv', input: { q: 1 } }],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'mcp_tool_result', tool_use_id: 'mc1', content: [{ type: 'text', text: 'found' }] },
+        ],
+      },
+    ]);
+  });
+
+  it('defaults the optional fields of a bare MCP call', () => {
+    expect(blocksOf([{ type: 'mcp_server_tool_call' }])).toEqual([
+      { type: 'mcp_tool_use', id: '', name: '', server_name: '', input: {} },
+    ]);
+  });
+});
+
+describe('framework-side content', () => {
+  it('sends nothing for content kinds that have no Messages API shape', () => {
+    expect(
+      toAnthropicMessages([
+        { role: 'assistant', contents: [{ type: 'usage', usageDetails: { inputTokenCount: 1 } }] },
+      ]),
+    ).toEqual([]);
+  });
+
+  it('maps an unrecognised role to user', () => {
+    const messages = toAnthropicMessages([
+      { role: 'developer', contents: [{ type: 'text', text: 'hi' }] } as unknown as Message,
+    ]);
+    expect(messages).toEqual([{ role: 'user', content: [{ type: 'text', text: 'hi' }] }]);
+  });
+});
+
+describe('system parameter', () => {
+  it('reports nothing when there is neither an instruction nor a system message', () => {
+    expect(
+      toAnthropicSystem([{ role: 'user', contents: [{ type: 'text', text: 'hi' }] }], undefined),
+    ).toBeUndefined();
+  });
+
+  it('uses the instructions alone when the transcript has no system message', () => {
+    expect(toAnthropicSystem([], 'be brief')).toBe('be brief');
+  });
+
+  it('ignores an empty instruction string', () => {
+    const messages: Message[] = [{ role: 'system', contents: [{ type: 'text', text: 'sys' }] }];
+    expect(toAnthropicSystem(messages, '')).toBe('sys');
+  });
+});
+
+describe('tool conversion limits', () => {
+  it('skips a tool that is neither a function tool nor a hosted tool', () => {
+    expect(toAnthropicTools([{ name: 'mystery' } as unknown as Tool])).toEqual({});
+  });
+});
+
+describe('output format limits', () => {
+  it('passes a non-object schema through without forcing additionalProperties onto it', () => {
+    // A converter is free to return any JSON Schema value, including an array form; forcing
+    // `additionalProperties` onto it would corrupt it.
+    const schema = { toJsonSchema: (): unknown[] => [{ type: 'object' }] };
+    expect(toAnthropicOutputFormat({ name: 'anything', schema })).toEqual({
+      type: 'json_schema',
+      schema: [{ type: 'object' }],
+    });
+  });
+});

--- a/packages/core/src/agent/continuation.test.ts
+++ b/packages/core/src/agent/continuation.test.ts
@@ -5,9 +5,14 @@ import { createResponseStream } from '../streaming/response-stream.js';
 import { textContent } from '../types/content.js';
 import type { Message } from '../types/message.js';
 import type { ChatResponse, ChatResponseUpdate, ContinuationToken } from '../types/response.js';
-import { chatResponse, chatResponseUpdate, mergeChatUpdates } from '../types/response.js';
+import {
+  agentResponseUpdate,
+  chatResponse,
+  chatResponseUpdate,
+  mergeChatUpdates,
+} from '../types/response.js';
 import { Agent } from './agent.js';
-import { isAgentContinuationToken } from './continuation.js';
+import { isAgentContinuationToken, parseContinuationToken, wrapContinuationToken } from './continuation.js';
 
 /** Narrows away undefined; a missing value fails the test with a clear error. */
 function must<T>(value: T | null | undefined): T {
@@ -67,6 +72,64 @@ function plain(text: string): ChatClient<ChatOptions> {
       }),
   };
 }
+
+describe('token payload round trip', () => {
+  it('carries every update field across the serialization boundary', () => {
+    const update = agentResponseUpdate({
+      contents: [textContent('partial')],
+      role: 'assistant',
+      authorName: 'writer',
+      responseId: 'resp_1',
+      messageId: 'msg_1',
+      createdAt: '2026-08-04T00:00:00Z',
+      finishReason: 'stop',
+      agentId: 'agent_1',
+      additionalProperties: { turn: 1 },
+    });
+    const token = wrapContinuationToken(
+      { responseId: 'resp_1' },
+      [{ role: 'user', contents: [textContent('question')] }],
+      [update],
+    );
+
+    const state = parseContinuationToken(token);
+    expect(state.innerToken).toEqual({ responseId: 'resp_1' });
+    expect(state.inputMessages).toEqual([
+      expect.objectContaining({ role: 'user', contents: [expect.objectContaining({ text: 'question' })] }),
+    ]);
+    const restored = must(state.updates[0]);
+    expect(restored.text).toBe('partial');
+    expect(restored.role).toBe('assistant');
+    expect(restored.authorName).toBe('writer');
+    expect(restored.responseId).toBe('resp_1');
+    expect(restored.messageId).toBe('msg_1');
+    expect(restored.createdAt).toBe('2026-08-04T00:00:00Z');
+    expect(restored.finishReason).toBe('stop');
+    expect(restored.agentId).toBe('agent_1');
+    expect(restored.additionalProperties).toEqual({ turn: 1 });
+  });
+
+  it('round-trips a bare update without inventing fields', () => {
+    const token = wrapContinuationToken(
+      { responseId: 'resp_1' },
+      [],
+      [agentResponseUpdate({ contents: [] })],
+    );
+    expect(token.inputMessages).toBeUndefined();
+
+    const restored = must(parseContinuationToken(token).updates[0]);
+    expect(restored.contents).toEqual([]);
+    expect(restored.authorName).toBeUndefined();
+    expect(restored.responseId).toBeUndefined();
+    expect(restored.finishReason).toBeUndefined();
+    expect(restored.additionalProperties).toBeUndefined();
+  });
+
+  it('parses an absent token to empty state and rejects a foreign one', () => {
+    expect(parseContinuationToken(undefined)).toEqual({ inputMessages: [], updates: [] });
+    expect(() => parseContinuationToken({ responseId: 'raw' })).toThrow(ConfigurationError);
+  });
+});
 
 describe('continuation tokens', () => {
   it('wraps the provider token so a resumed run can persist the whole exchange', async () => {

--- a/packages/core/src/observability/settings.test.ts
+++ b/packages/core/src/observability/settings.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { captureMessageContent, configureObservability } from './settings.js';
+
+const OTEL_ENV = 'OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT';
+const PYTHON_ENV = 'ENABLE_SENSITIVE_DATA';
+
+// Message content is sensitive; recording it is off unless the process opts in, either in code or
+// through the OTel GenAI env var (with Python's name honoured for polyglot deployments).
+describe('captureMessageContent', () => {
+  beforeEach(() => {
+    // The process running the tests may itself have opted in; every case here starts from the
+    // documented default of "unset", not from whatever the environment happens to carry.
+    vi.stubEnv(OTEL_ENV, undefined);
+    vi.stubEnv(PYTHON_ENV, undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    configureObservability({});
+  });
+
+  it('is off by default', () => {
+    expect(captureMessageContent()).toBe(false);
+  });
+
+  it('lets an explicit setting win over the environment, in both directions', () => {
+    vi.stubEnv(OTEL_ENV, 'true');
+    configureObservability({ captureMessageContent: false });
+    expect(captureMessageContent()).toBe(false);
+
+    vi.stubEnv(OTEL_ENV, 'false');
+    configureObservability({ captureMessageContent: true });
+    expect(captureMessageContent()).toBe(true);
+  });
+
+  it('accepts the boolean spellings of the OTel env var', () => {
+    for (const [value, expected] of [
+      ['true', true],
+      ['1', true],
+      ['YES', true],
+      ['false', false],
+      ['0', false],
+      ['no', false],
+      ['', false],
+      ['  True  ', true],
+    ] as const) {
+      vi.stubEnv(OTEL_ENV, value);
+      expect(captureMessageContent(), `value ${JSON.stringify(value)}`).toBe(expected);
+    }
+  });
+
+  it('falls back to the Python-named env var when the OTel one is unset or unparsable', () => {
+    vi.stubEnv(PYTHON_ENV, 'true');
+    expect(captureMessageContent()).toBe(true);
+
+    vi.stubEnv(OTEL_ENV, 'definitely');
+    expect(captureMessageContent()).toBe(true);
+  });
+
+  it('lets a parsable OTel value shadow the Python-named one', () => {
+    vi.stubEnv(OTEL_ENV, 'false');
+    vi.stubEnv(PYTHON_ENV, 'true');
+    expect(captureMessageContent()).toBe(false);
+  });
+
+  it('treats an unparsable value in both variables as off', () => {
+    vi.stubEnv(OTEL_ENV, 'definitely');
+    vi.stubEnv(PYTHON_ENV, 'maybe');
+    expect(captureMessageContent()).toBe(false);
+  });
+});

--- a/packages/core/src/types/coalesce.ts
+++ b/packages/core/src/types/coalesce.ts
@@ -162,12 +162,13 @@ function mergeTextRun(run: TextContent[]): TextContent {
 function mergeTextReasoningRun(run: TextReasoningContent[]): TextReasoningContent {
   const first = run[0] as TextReasoningContent;
   let text = '';
-  let id = first.id;
+  // The first *non-empty* id wins (Python folds ids with `self.id or other.id`, where an empty
+  // string is falsy). An id-less run keeps the first fragment's spelling of "no id".
+  const id = run.find((item) => item.id !== undefined && item.id !== '')?.id ?? first.id;
   let protectedData: string | undefined;
   let props = first.additionalProperties;
   for (const item of run) {
     text += item.text ?? '';
-    id ??= item.id;
     if (item.protectedData !== undefined) {
       protectedData = item.protectedData;
     }

--- a/packages/core/src/types/message-filters.test.ts
+++ b/packages/core/src/types/message-filters.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { textContent } from './content.js';
+import type { Message } from './message.js';
+import {
+  allOf,
+  anyOf,
+  externalOnly,
+  getMessageSource,
+  MESSAGE_SOURCE_KEY,
+  none,
+  notSourceIds,
+  notSourceTypes,
+  passThrough,
+  sourceIds,
+  sourceTypes,
+  withMessageSource,
+} from './message.js';
+
+// The filter semantics are the TypeScript form of Go's `messagefilter` package: an unstamped
+// message counts as external, composition never mutates the input, and `anyOf` keeps the
+// original message order.
+
+function msg(text: string): Message {
+  return { role: 'user', contents: [textContent(text)] };
+}
+
+const external = msg('from the caller');
+const stamped = withMessageSource(msg('from history'), { sourceType: 'ChatHistory' });
+const fromProvider = withMessageSource(msg('from memory'), {
+  sourceType: 'AIContextProvider',
+  sourceId: 'memory-1',
+});
+const all = [external, stamped, fromProvider];
+
+describe('source attribution', () => {
+  it('reads back what withMessageSource stamped, with and without a provider id', () => {
+    expect(getMessageSource(stamped)).toEqual({ sourceType: 'ChatHistory' });
+    expect(getMessageSource(fromProvider)).toEqual({ sourceType: 'AIContextProvider', sourceId: 'memory-1' });
+  });
+
+  it('stamps a copy and leaves the original message untouched', () => {
+    expect(external.additionalProperties).toBeUndefined();
+    expect(getMessageSource(external)).toBeUndefined();
+  });
+
+  it('treats a malformed attribution as unstamped', () => {
+    expect(
+      getMessageSource({ ...msg('x'), additionalProperties: { [MESSAGE_SOURCE_KEY]: 'text' } }),
+    ).toBeUndefined();
+    expect(
+      getMessageSource({ ...msg('x'), additionalProperties: { [MESSAGE_SOURCE_KEY]: { sourceType: 42 } } }),
+    ).toBeUndefined();
+    expect(
+      getMessageSource({
+        ...msg('x'),
+        additionalProperties: { [MESSAGE_SOURCE_KEY]: { sourceType: 'ChatHistory', sourceId: 42 } },
+      }),
+    ).toEqual({ sourceType: 'ChatHistory' });
+  });
+});
+
+describe('elementary filters', () => {
+  it('passThrough keeps everything in a fresh array', () => {
+    const result = passThrough(all);
+    expect(result).toEqual(all);
+    expect(result).not.toBe(all);
+  });
+
+  it('none drops everything', () => {
+    expect(none(all)).toEqual([]);
+  });
+
+  it('externalOnly keeps unstamped and External messages', () => {
+    const explicitExternal = withMessageSource(msg('stamped external'), { sourceType: 'External' });
+    expect(externalOnly([...all, explicitExternal])).toEqual([external, explicitExternal]);
+  });
+
+  it('sourceTypes keeps only stamped matches, so unstamped messages drop out', () => {
+    expect(sourceTypes('ChatHistory')(all)).toEqual([stamped]);
+  });
+
+  it('notSourceTypes keeps unstamped messages', () => {
+    expect(notSourceTypes('ChatHistory')(all)).toEqual([external, fromProvider]);
+  });
+
+  it('sourceIds matches only messages a named provider stamped', () => {
+    expect(sourceIds('memory-1')(all)).toEqual([fromProvider]);
+    expect(sourceIds('other')(all)).toEqual([]);
+  });
+
+  it('notSourceIds keeps messages with no provider id at all', () => {
+    expect(notSourceIds('memory-1')(all)).toEqual([external, stamped]);
+  });
+});
+
+describe('composition', () => {
+  it('allOf requires a message to survive every filter in turn', () => {
+    expect(allOf(notSourceTypes('ChatHistory'), notSourceIds('memory-1'))(all)).toEqual([external]);
+    expect(allOf()(all)).toEqual(all);
+  });
+
+  it('anyOf unions matches while preserving the original order', () => {
+    // The union matches in filter order, but the result follows the transcript order.
+    expect(anyOf(sourceIds('memory-1'), sourceTypes('ChatHistory'))(all)).toEqual([stamped, fromProvider]);
+    expect(anyOf()(all)).toEqual([]);
+  });
+});

--- a/packages/core/src/types/response.test.ts
+++ b/packages/core/src/types/response.test.ts
@@ -237,6 +237,16 @@ describe('coalesceContents', () => {
     ]);
   });
 
+  it('gives the merged reasoning item the first non-empty id, treating an empty one as absent', () => {
+    // Python folds ids with `self.id or other.id`, so an empty string never wins over a real id;
+    // an empty-id fragment followed by an identified one must not strip the id the replay needs.
+    const merged = coalesceContents([
+      { type: 'text_reasoning', id: '', text: 'thin' },
+      { type: 'text_reasoning', id: 'r1', text: 'king' },
+    ]);
+    expect(merged).toEqual([{ type: 'text_reasoning', id: 'r1', text: 'thinking' }]);
+  });
+
   it('carries the trailing protected payload onto the merged reasoning item', () => {
     const merged = coalesceContents([
       { type: 'text_reasoning', id: 'r1', text: 'a' },

--- a/packages/foundry/src/chat-client.test.ts
+++ b/packages/foundry/src/chat-client.test.ts
@@ -106,6 +106,28 @@ describe('FoundryChatClient', () => {
     expect(deployment.metadata).toEqual({ providerName: 'azure.ai.foundry', modelId: 'gpt-4o' });
   });
 
+  it('exposes the SDK client and the hosted tool declarations of the inner client', () => {
+    const client = new FoundryChatClient({
+      projectEndpoint: PROJECT,
+      target: { modelDeployment: 'gpt-4o' },
+      credential: fakeCredential(),
+    });
+
+    // Thin delegations, but public API: each must reach the inner OpenAI client rather than
+    // throw or return a Foundry-shaped stub.
+    expect(client.client).toBeDefined();
+    expect(client.getWebSearchTool().spec).toMatchObject({ type: 'web_search' });
+    expect(client.getFileSearchTool({ vectorStoreIds: ['vs_1'] }).spec).toMatchObject({
+      type: 'file_search',
+      vector_store_ids: ['vs_1'],
+    });
+    expect(client.getCodeInterpreterTool().spec).toMatchObject({ type: 'code_interpreter' });
+    expect(client.getMCPTool({ serverLabel: 'docs', serverUrl: 'https://mcp.example' }).spec).toMatchObject({
+      type: 'mcp',
+      server_label: 'docs',
+    });
+  });
+
   it('does not invent a model for a server agent', () => {
     // A server agent's model is a service-side detail chosen by the agent definition. .NET removes
     // `$.model` from the request and Go leaves it unset; reporting a made-up name here would put

--- a/packages/foundry/src/hosting/converters.wire-fallbacks.test.ts
+++ b/packages/foundry/src/hosting/converters.wire-fallbacks.test.ts
@@ -1,0 +1,318 @@
+import type { OutputItem } from '@polymind-inc/agent-framework-agentserver';
+import type { Message } from '@polymind-inc/agent-framework-core';
+import { describe, expect, it } from 'vitest';
+import {
+  approvalResponseTarget,
+  decodeFunctionOutput,
+  encodeFunctionOutput,
+  inputToMessages,
+  itemToMessage,
+  usageToResponseUsage,
+} from './converters.js';
+
+// The Responses wire is produced by arbitrary clients, not just this framework, so every read in
+// the converters is guarded: fields can be missing, empty, or of the wrong type, and each of
+// those forms has a defined mapping instead of a crash or a silently dropped turn. These tests
+// pin the guards down one omitted field at a time.
+
+/** Converts, then narrows away the undefined case with a clear failure. */
+function messageOf(item: OutputItem): Message {
+  const message = itemToMessage(item);
+  if (message === undefined) throw new Error('expected a message');
+  return message;
+}
+
+describe('function output codec fallbacks', () => {
+  it('encodes a value JSON.stringify cannot represent as an empty string', () => {
+    expect(encodeFunctionOutput(Symbol('opaque'))).toBe('""');
+  });
+
+  it('decodes an absent payload to an empty string', () => {
+    expect(decodeFunctionOutput(undefined)).toBe('');
+    expect(decodeFunctionOutput(null)).toBe('');
+    expect(decodeFunctionOutput('')).toBe('');
+  });
+
+  it('stringifies a non-string payload from a legacy producer', () => {
+    expect(decodeFunctionOutput(42)).toBe('42');
+  });
+
+  it('passes a string that is not valid JSON through unchanged', () => {
+    expect(decodeFunctionOutput('{oops')).toBe('{oops');
+  });
+});
+
+describe('message item content fallbacks', () => {
+  it('replays a plain-string content as one text content', () => {
+    const message = messageOf({ type: 'message', role: 'user', content: 'hello' });
+    expect(message.contents).toEqual([expect.objectContaining({ type: 'text', text: 'hello' })]);
+  });
+
+  it('defaults a missing role to user and omits a missing message id', () => {
+    const message = messageOf({ type: 'message', content: 'hello' });
+    expect(message.role).toBe('user');
+    expect(message.messageId).toBeUndefined();
+  });
+
+  it('replays a message whose content is neither string nor list as empty text', () => {
+    const message = messageOf({ type: 'message', role: 'user', content: 42 });
+    expect(message.contents).toEqual([expect.objectContaining({ type: 'text', text: '' })]);
+  });
+
+  it('falls back to the concatenated part text when no part is representable', () => {
+    // The parts carry types the converter does not know, but their text is still the words the
+    // model was shown; deleting the turn would be worse than replaying it flattened.
+    const message = messageOf({
+      type: 'message',
+      role: 'user',
+      content: [
+        { type: 'mystery_part', text: 'kept ' },
+        { type: 'other_part', refusal: 'and this' },
+        { type: 'wordless_part' },
+      ],
+    });
+    expect(message.contents).toEqual([expect.objectContaining({ type: 'text', text: 'kept and this' })]);
+  });
+
+  it('drops a file part with no url, id or data', () => {
+    const message = messageOf({
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_file' }, { type: 'input_text', text: 'still here' }],
+    });
+    expect(message.contents).toEqual([expect.objectContaining({ type: 'text', text: 'still here' })]);
+  });
+
+  it('maps a refusal part to text', () => {
+    const message = messageOf({
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'refusal', refusal: 'cannot help' }],
+    });
+    expect(message.contents).toEqual([expect.objectContaining({ type: 'text', text: 'cannot help' })]);
+  });
+
+  it('maps a summary_text part to text', () => {
+    const message = messageOf({
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'summary_text', text: 'the gist' }],
+    });
+    expect(message.contents).toEqual([expect.objectContaining({ type: 'text', text: 'the gist' })]);
+  });
+
+  it('keeps the declared media type of a data-URI image and generalises a plain URL', () => {
+    const message = messageOf({
+      type: 'message',
+      role: 'user',
+      content: [
+        { type: 'input_image', image_url: 'data:image/jpeg;base64,AAAA' },
+        { type: 'input_image', image_url: 'https://img.example/cat' },
+      ],
+    });
+    expect(message.contents[0]).toMatchObject({ mediaType: 'image/jpeg' });
+    expect(message.contents[1]).toMatchObject({ uri: 'https://img.example/cat', mediaType: 'image/*' });
+  });
+
+  it('replays an image that only has a file id as a hosted file', () => {
+    const message = messageOf({
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_image', file_id: 'file_1' }, { type: 'input_image' }],
+    });
+    // The second, empty part is unrepresentable and drops out.
+    expect(message.contents).toEqual([expect.objectContaining({ type: 'hosted_file', fileId: 'file_1' })]);
+  });
+
+  it('replays a file by url, by id with and without filename, and by raw base64 data', () => {
+    const message = messageOf({
+      type: 'message',
+      role: 'user',
+      content: [
+        { type: 'input_file', file_url: 'https://files.example/doc.pdf' },
+        { type: 'input_file', file_id: 'file_1', filename: 'doc.pdf' },
+        { type: 'input_file', file_id: 'file_2' },
+        { type: 'input_file', file_data: 'data:application/pdf;base64,AAAA' },
+        { type: 'input_file', file_data: 'QUFBQQ==' },
+      ],
+    });
+    expect(message.contents[0]).toMatchObject({ uri: 'https://files.example/doc.pdf' });
+    expect(message.contents[1]).toMatchObject({
+      type: 'hosted_file',
+      fileId: 'file_1',
+      additionalProperties: { filename: 'doc.pdf' },
+    });
+    expect(message.contents[2]).toMatchObject({ type: 'hosted_file', fileId: 'file_2' });
+    expect(message.contents[2]?.additionalProperties).toBeUndefined();
+    expect(message.contents[3]).toMatchObject({ mediaType: 'application/pdf' });
+    // Bare base64 has no self-declared media type; it is wrapped as an opaque octet stream.
+    expect(message.contents[4]).toMatchObject({
+      type: 'data',
+      uri: 'data:application/octet-stream;base64,QUFBQQ==',
+      mediaType: 'application/octet-stream',
+    });
+  });
+});
+
+describe('call and result item fallbacks', () => {
+  it('falls back to the item id, then empty, when a function call omits call_id', () => {
+    expect(messageOf({ type: 'function_call', id: 'fc_1' }).contents[0]).toMatchObject({
+      callId: 'fc_1',
+      name: '',
+      arguments: '',
+    });
+    expect(messageOf({ type: 'function_call' }).contents[0]).toMatchObject({ callId: '' });
+  });
+
+  it('passes structured function-call arguments through and blanks unusable ones', () => {
+    const structured = messageOf({ type: 'function_call', call_id: 'c', arguments: { city: 'Osaka' } });
+    expect(structured.contents[0]).toMatchObject({ arguments: { city: 'Osaka' } });
+    const unusable = messageOf({ type: 'function_call', call_id: 'c', arguments: 42 });
+    expect(unusable.contents[0]).toMatchObject({ arguments: '' });
+  });
+
+  it('maps a function_call_output without call_id to an empty one', () => {
+    expect(messageOf({ type: 'function_call_output', output: '"ok"' }).contents[0]).toMatchObject({
+      type: 'function_result',
+      callId: '',
+      result: 'ok',
+    });
+  });
+
+  it('reads reasoning text from content when there is no summary', () => {
+    const message = messageOf({
+      type: 'reasoning',
+      content: [{ type: 'reasoning_text', text: 'thought' }],
+    });
+    expect(message.contents[0]).toMatchObject({ type: 'text_reasoning', text: 'thought' });
+    expect(message.contents[0]).not.toHaveProperty('id');
+    expect(message.contents[0]).not.toHaveProperty('protectedData');
+  });
+
+  it('reads reasoning text from a plain-string summary', () => {
+    const message = messageOf({ type: 'reasoning', summary: 'the gist' });
+    expect(message.contents[0]).toMatchObject({ type: 'text_reasoning', text: 'the gist' });
+  });
+
+  it('maps a bare mcp_call with no output to the call alone', () => {
+    const message = messageOf({ type: 'mcp_call' });
+    expect(message.contents).toEqual([
+      expect.objectContaining({ type: 'mcp_server_tool_call', callId: '', toolName: '', serverName: '' }),
+    ]);
+  });
+
+  it('falls back to call_id when an mcp_call has an empty id', () => {
+    const message = messageOf({ type: 'mcp_call', id: '', call_id: 'mc_1' });
+    expect(message.contents[0]).toMatchObject({ callId: 'mc_1' });
+  });
+
+  it('maps a custom_tool_call_output without call_id or output to empty strings', () => {
+    expect(messageOf({ type: 'custom_tool_call_output' }).contents[0]).toMatchObject({
+      type: 'function_result',
+      callId: '',
+      result: '',
+    });
+  });
+
+  it('stringifies a non-string custom tool output', () => {
+    expect(messageOf({ type: 'custom_tool_call_output', output: 7 }).contents[0]).toMatchObject({
+      result: '7',
+    });
+  });
+});
+
+describe('approval and consent item fallbacks', () => {
+  it('does not replay an approval request without a server label', () => {
+    expect(itemToMessage({ type: 'mcp_approval_request', id: 'apr_1' })).toBeUndefined();
+  });
+
+  it('replays a hosted approval request, defaulting its missing fields', () => {
+    const message = messageOf({ type: 'mcp_approval_request', server_label: 'external' });
+    expect(message.contents[0]).toMatchObject({
+      type: 'function_approval_request',
+      id: '',
+      functionCall: expect.objectContaining({
+        callId: '',
+        name: '',
+        arguments: '',
+        additionalProperties: { server_label: 'external' },
+      }),
+    });
+  });
+
+  it('replays a consent request without a link as an empty one', () => {
+    const message = messageOf({ type: 'oauth_consent_request' });
+    expect(message.contents[0]).toMatchObject({ type: 'oauth_consent_request', consentLink: '' });
+  });
+
+  it('resolves an approval response, treating anything but approve:true as denial', () => {
+    expect(approvalResponseTarget({ type: 'mcp_approval_response', approval_request_id: 'apr_1' })).toEqual({
+      id: 'apr_1',
+      approved: false,
+    });
+    expect(approvalResponseTarget({ type: 'mcp_approval_response' })).toBeUndefined();
+    expect(approvalResponseTarget({ type: 'message' })).toBeUndefined();
+  });
+});
+
+describe('shell item fallbacks', () => {
+  it('maps a bare shell_call to an empty command list without a status', () => {
+    const message = messageOf({ type: 'shell_call', id: 'sh_1' });
+    expect(message.contents[0]).toMatchObject({ type: 'shell_tool_call', callId: 'sh_1', commands: [] });
+    expect((message.contents[0] as { status?: string }).status).toBeUndefined();
+  });
+
+  it('keeps only the string commands of a shell_call action', () => {
+    const message = messageOf({
+      type: 'shell_call',
+      call_id: 'sh_1',
+      action: { commands: ['ls', 42, 'pwd'] },
+    });
+    expect(message.contents[0]).toMatchObject({ commands: ['ls', 'pwd'] });
+  });
+
+  it('maps a bare shell_call_output to an empty result', () => {
+    const message = messageOf({ type: 'shell_call_output' });
+    expect(message.contents[0]).toMatchObject({ type: 'shell_tool_result', callId: '', outputs: [] });
+    expect((message.contents[0] as { maxOutputLength?: number }).maxOutputLength).toBeUndefined();
+  });
+
+  it('defaults the streams of an empty shell output entry and drops a non-numeric exit code', () => {
+    const message = messageOf({
+      type: 'shell_call_output',
+      call_id: 'sh_1',
+      output: [{}, { stdout: 'out', stderr: 'err', outcome: { exit_code: 'zero' } }],
+    });
+    const [result] = message.contents;
+    if (result?.type !== 'shell_tool_result') throw new Error('expected a shell_tool_result');
+    expect(result.outputs?.[0]).toMatchObject({ stdout: '', stderr: '' });
+    expect(result.outputs?.[1]).toMatchObject({ stdout: 'out', stderr: 'err' });
+    expect(result.outputs?.[1]).not.toHaveProperty('exitCode');
+  });
+});
+
+describe('image generation item fallbacks', () => {
+  it('omits the image id when the item has none', () => {
+    const message = messageOf({ type: 'image_generation_call' });
+    expect(message.contents[0]?.type).toBe('image_generation_tool_call');
+    expect((message.contents[0] as { imageId?: string }).imageId).toBeUndefined();
+  });
+});
+
+describe('usage and input fallbacks', () => {
+  it('reports zeroes for usage that was never accumulated', () => {
+    expect(usageToResponseUsage({})).toEqual({
+      input_tokens: 0,
+      output_tokens: 0,
+      total_tokens: 0,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    });
+  });
+
+  it('maps an empty or unusable request input to no messages', () => {
+    expect(inputToMessages('')).toEqual([]);
+    expect(inputToMessages(42)).toEqual([]);
+    expect(inputToMessages(undefined)).toEqual([]);
+  });
+});

--- a/packages/mcp/src/client.test.ts
+++ b/packages/mcp/src/client.test.ts
@@ -116,6 +116,13 @@ describe('tool enumeration', () => {
     await mcp.close();
   });
 
+  it('applies a constant approval mode to every tool', async () => {
+    const mcp = new MCPClient({ transport: server(), approvalMode: 'always_require' });
+    const tools = await mcp.getTools();
+    expect(new Set(tools.map((t) => t.approvalMode))).toEqual(new Set(['always_require']));
+    await mcp.close();
+  });
+
   it('refuses a configuration without exactly one connection source', () => {
     expect(() => new MCPClient({})).toThrow(ConfigurationError);
     expect(() => new MCPClient({ url: 'https://example.com/mcp', transport: server() })).toThrow(
@@ -146,6 +153,20 @@ describe('tool invocation', () => {
     const explode = tools.find((t) => t.name === 'explode');
 
     await expect(explode?.execute?.({}, { callId: 'call_1' })).rejects.toThrow('the tool is broken');
+    await mcp.close();
+  });
+
+  it('supplies a generic message when an error result carries no text', async () => {
+    const mcp = new MCPClient({
+      transport: new TestMcpServer([
+        { name: 'mute-failure', description: 'fails silently', call: () => ({ content: [], isError: true }) },
+      ]),
+    });
+    const [muteFailure] = await mcp.getTools();
+
+    await expect(muteFailure?.execute?.({}, { callId: 'call_1' })).rejects.toThrow(
+      'MCP tool "mute-failure" reported an error.',
+    );
     await mcp.close();
   });
 

--- a/packages/openai/src/from-openai.wire-fallbacks.test.ts
+++ b/packages/openai/src/from-openai.wire-fallbacks.test.ts
@@ -1,0 +1,602 @@
+import type { ChatResponseUpdate, Content, Message } from '@polymind-inc/agent-framework-core';
+import { describe, expect, it } from 'vitest';
+import {
+  createStreamParseState,
+  parseFinishReason,
+  parseResponse,
+  parseStreamEvent,
+  parseUsage,
+} from './from-openai.js';
+
+// The Responses API wire is read defensively: the service can send items with fields missing,
+// empty, or shaped differently from what the SDK types declare, and each of those degenerate
+// forms has a defined mapping (matching `_parse_response_from_openai` and
+// `_parse_chunk_from_openai` in Python's `_chat_client.py`). These tests pin the fallbacks down
+// with payloads that omit exactly the field whose absence the mapping has to absorb.
+
+/** All contents of a parsed response, flattened. */
+function contentsOf(response: { messages: Message[] }): Content[] {
+  return response.messages.flatMap((msg) => msg.contents);
+}
+
+/** Parses a single stream event against fresh stream state. */
+function parseOne(event: unknown): ChatResponseUpdate | undefined {
+  return parseStreamEvent(event, createStreamParseState());
+}
+
+describe('parseUsage fallbacks', () => {
+  it('returns undefined for a missing usage object', () => {
+    expect(parseUsage(undefined)).toBeUndefined();
+    expect(parseUsage(null)).toBeUndefined();
+  });
+
+  it('returns undefined when the usage object carries no numeric field', () => {
+    expect(parseUsage({})).toBeUndefined();
+    // Non-numeric values are not usage numbers; each guarded read must skip them.
+    expect(parseUsage({ input_tokens: 'many', output_tokens: null, total_tokens: {} })).toBeUndefined();
+  });
+
+  it('maps cache and reasoning token details onto both framework and provider keys', () => {
+    expect(
+      parseUsage({
+        input_tokens: 10,
+        output_tokens: 5,
+        total_tokens: 15,
+        input_tokens_details: { cached_tokens: 4, cache_write_tokens: 3 },
+        output_tokens_details: { reasoning_tokens: 2 },
+      }),
+    ).toEqual({
+      inputTokenCount: 10,
+      outputTokenCount: 5,
+      totalTokenCount: 15,
+      cacheReadInputTokenCount: 4,
+      'openai.cached_input_tokens': 4,
+      cacheCreationInputTokenCount: 3,
+      'openai.cache_write_tokens': 3,
+      reasoningOutputTokenCount: 2,
+      'openai.reasoning_tokens': 2,
+    });
+  });
+});
+
+describe('parseFinishReason', () => {
+  // Python `_get_finish_reason_from_openai_response` (`_chat_client.py:2513-2520`): the
+  // incomplete reason wins over the status, a completed response reports `tool_calls` only when
+  // its output contains a function call, and anything still in flight reports nothing.
+  it('maps an incomplete content_filter response', () => {
+    expect(parseFinishReason({ incomplete_details: { reason: 'content_filter' } })).toBe('content_filter');
+  });
+
+  it('maps an incomplete max_output_tokens response to length', () => {
+    expect(parseFinishReason({ incomplete_details: { reason: 'max_output_tokens' } })).toBe('length');
+  });
+
+  it('reports nothing while the response is still in flight', () => {
+    expect(parseFinishReason({ status: 'in_progress' })).toBeUndefined();
+    expect(parseFinishReason(undefined)).toBeUndefined();
+  });
+
+  it('reports stop for a completed response without output', () => {
+    expect(parseFinishReason({ status: 'completed' })).toBe('stop');
+  });
+
+  it('reports tool_calls when the completed output contains a function call', () => {
+    expect(parseFinishReason({ status: 'completed', output: [{ type: 'function_call' }] })).toBe(
+      'tool_calls',
+    );
+  });
+});
+
+describe('conversation id', () => {
+  // Python `_get_conversation_id` (`_chat_client.py:924-936`): `store=False` suppresses the id
+  // entirely, a non-empty conversation id wins over the response id, and an empty one falls
+  // through to the response id.
+  it('suppresses the conversation id when the request opted out of storage', () => {
+    const response = parseResponse({ id: 'resp_1', conversation: { id: 'conv_1' } }, { store: false });
+    expect(response.conversationId).toBeUndefined();
+  });
+
+  it('prefers a non-empty conversation id over the response id', () => {
+    const response = parseResponse({ id: 'resp_1', conversation: { id: 'conv_1' } });
+    expect(response.conversationId).toBe('conv_1');
+  });
+
+  it('falls back to the response id when the conversation id is empty', () => {
+    const response = parseResponse({ id: 'resp_1', conversation: { id: '' } });
+    expect(response.conversationId).toBe('resp_1');
+  });
+});
+
+describe('media type detection of generated images', () => {
+  // The detection table is a port of Python `detect_media_type_from_base64` (`_types.py`): only
+  // the magic bytes decide, and an unrecognised signature falls back to png on this call path.
+  const pad = (bytes: number[], length = 16): number[] => [
+    ...bytes,
+    ...Array(Math.max(0, length - bytes.length)).fill(0),
+  ];
+  const ascii = (text: string): number[] => [...text].map((ch) => ch.charCodeAt(0));
+
+  const cases: Array<{ name: string; bytes: number[]; expected: string }> = [
+    { name: 'png', bytes: pad([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), expected: 'image/png' },
+    { name: 'jpeg', bytes: pad([0xff, 0xd8, 0xff]), expected: 'image/jpeg' },
+    { name: 'gif87a', bytes: pad(ascii('GIF87a')), expected: 'image/gif' },
+    { name: 'gif89a', bytes: pad(ascii('GIF89a')), expected: 'image/gif' },
+    { name: 'webp', bytes: pad([...ascii('RIFF'), 0, 0, 0, 0, ...ascii('WEBP')]), expected: 'image/webp' },
+    { name: 'bmp', bytes: pad(ascii('BM')), expected: 'image/bmp' },
+    { name: 'svg tag', bytes: pad(ascii('<svg xmlns=')), expected: 'image/svg+xml' },
+    { name: 'xml prolog', bytes: pad(ascii('<?xml versi')), expected: 'image/svg+xml' },
+    { name: 'pdf', bytes: pad(ascii('%PDF-1.7')), expected: 'application/pdf' },
+    { name: 'wav', bytes: pad([...ascii('RIFF'), 0, 0, 0, 0, ...ascii('WAVE')]), expected: 'audio/wav' },
+    { name: 'mp3 id3', bytes: pad(ascii('ID3')), expected: 'audio/mpeg' },
+    { name: 'mp3 frame fb', bytes: pad([0xff, 0xfb]), expected: 'audio/mpeg' },
+    { name: 'mp3 frame f3', bytes: pad([0xff, 0xf3]), expected: 'audio/mpeg' },
+    { name: 'ogg', bytes: pad(ascii('OggS')), expected: 'audio/ogg' },
+    { name: 'flac', bytes: pad(ascii('fLaC')), expected: 'audio/flac' },
+    { name: 'unrecognised signature', bytes: pad(ascii('ZZZZZZ')), expected: 'image/png' },
+  ];
+
+  it.each(cases)('detects $name', ({ bytes, expected }) => {
+    const result = Buffer.from(bytes).toString('base64');
+    const contents = contentsOf(
+      parseResponse({ output: [{ type: 'image_generation_call', id: 'ig_1', result }] }),
+    );
+    const output = contents.find((content) => content.type === 'image_generation_tool_result');
+    if (output?.type !== 'image_generation_tool_result') throw new Error('expected an image result');
+    expect(output.outputs?.[0]).toMatchObject({
+      mediaType: expected,
+      uri: `data:${expected};base64,${result}`,
+    });
+  });
+
+  it('emits no image output when the item carries no result', () => {
+    const contents = contentsOf(parseResponse({ output: [{ type: 'image_generation_call' }] }));
+    expect(contents).toEqual([
+      expect.objectContaining({ type: 'image_generation_tool_call', imageId: '' }),
+      expect.objectContaining({ type: 'image_generation_tool_result', imageId: '', outputs: [] }),
+    ]);
+  });
+});
+
+describe('awaited message parts', () => {
+  it('maps a refusal part to text, as Python does', () => {
+    // Python `_parse_response_from_openai` (`_chat_client.py:2636-2639`).
+    const contents = contentsOf(
+      parseResponse({
+        output: [{ type: 'message', content: [{ type: 'refusal', refusal: 'cannot help' }] }],
+      }),
+    );
+    expect(contents).toEqual([expect.objectContaining({ type: 'text', text: 'cannot help' })]);
+  });
+
+  it('skips message parts of an unknown type', () => {
+    const contents = contentsOf(
+      parseResponse({ output: [{ type: 'message', content: [{ type: 'mystery_part' }] }] }),
+    );
+    expect(contents).toEqual([]);
+  });
+
+  it('maps a message without content to no contents at all', () => {
+    expect(contentsOf(parseResponse({ output: [{ type: 'message' }] }))).toEqual([]);
+  });
+
+  it('maps a missing output list to an empty assistant message', () => {
+    const response = parseResponse(undefined);
+    expect(response.messages).toEqual([expect.objectContaining({ role: 'assistant', contents: [] })]);
+  });
+});
+
+describe('annotation forms', () => {
+  function annotationsOf(annotations: unknown[]): Content['annotations'] {
+    const contents = contentsOf(
+      parseResponse({
+        output: [{ type: 'message', content: [{ type: 'output_text', text: 'cited', annotations }] }],
+      }),
+    );
+    return contents[0]?.annotations;
+  }
+
+  it('keeps the index of a file_path annotation and drops a missing file id', () => {
+    expect(annotationsOf([{ type: 'file_path', index: 3 }])).toEqual([
+      {
+        type: 'citation',
+        rawRepresentation: { type: 'file_path', index: 3 },
+        additionalProperties: { index: 3 },
+      },
+    ]);
+  });
+
+  it('maps a file_path annotation with a file id', () => {
+    const [annotation] = annotationsOf([{ type: 'file_path', file_id: 'file_1' }]) ?? [];
+    expect(annotation).toMatchObject({
+      type: 'citation',
+      fileId: 'file_1',
+      additionalProperties: { index: null },
+    });
+  });
+
+  it('maps a bare file_citation without filename or file id', () => {
+    expect(annotationsOf([{ type: 'file_citation' }])).toEqual([
+      {
+        type: 'citation',
+        rawRepresentation: { type: 'file_citation' },
+        additionalProperties: { index: null },
+      },
+    ]);
+  });
+
+  it('maps a bare url_citation without title, url or span', () => {
+    expect(annotationsOf([{ type: 'url_citation' }])).toEqual([
+      { type: 'citation', rawRepresentation: { type: 'url_citation' } },
+    ]);
+  });
+
+  it('maps a bare container_file_citation without file id, filename or span', () => {
+    expect(annotationsOf([{ type: 'container_file_citation' }])).toEqual([
+      {
+        type: 'citation',
+        rawRepresentation: { type: 'container_file_citation' },
+        additionalProperties: { container_id: null },
+      },
+    ]);
+  });
+
+  it('drops annotation forms the framework does not know', () => {
+    // Python debug-logs and drops them (`_parse_response_from_openai`); when every annotation is
+    // dropped the content carries none at all.
+    expect(annotationsOf([{ type: 'mystery_citation' }])).toBeUndefined();
+  });
+});
+
+describe('reasoning item fallbacks', () => {
+  it('preserves an encrypted-only reasoning item as a single empty fragment', () => {
+    const contents = contentsOf(
+      parseResponse({ output: [{ type: 'reasoning', id: 'rs_1', encrypted_content: 'enc' }] }),
+    );
+    expect(contents).toEqual([
+      expect.objectContaining({ type: 'text_reasoning', id: 'rs_1', text: '', protectedData: 'enc' }),
+    ]);
+  });
+
+  it('attaches the opaque payload only to the first fragment', () => {
+    const contents = contentsOf(
+      parseResponse({
+        output: [
+          {
+            type: 'reasoning',
+            id: 'rs_1',
+            encrypted_content: 'enc',
+            content: [
+              { type: 'reasoning_text', text: 'first' },
+              { type: 'reasoning_text', text: 'second' },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(contents.map((content) => content.type === 'text_reasoning' && content.protectedData)).toEqual([
+      'enc',
+      undefined,
+    ]);
+  });
+
+  it('maps a reasoning fragment without text to an empty string', () => {
+    const contents = contentsOf(
+      parseResponse({ output: [{ type: 'reasoning', id: 'rs_1', content: [{ type: 'reasoning_text' }] }] }),
+    );
+    expect(contents[0]).toMatchObject({ type: 'text_reasoning', text: '' });
+  });
+});
+
+describe('function and hosted tool call fallbacks', () => {
+  it('falls back to the item id when a function call has no call_id', () => {
+    const contents = contentsOf(parseResponse({ output: [{ type: 'function_call', id: 'fc_1' }] }));
+    expect(contents[0]).toMatchObject({ type: 'function_call', callId: 'fc_1', name: '', arguments: '' });
+  });
+
+  it('maps a bare file_search_call to empty queries with no status', () => {
+    const contents = contentsOf(parseResponse({ output: [{ type: 'file_search_call' }] }));
+    expect(contents[0]).toMatchObject({
+      type: 'search_tool_call',
+      callId: '',
+      toolName: 'file_search',
+      arguments: { queries: [] },
+    });
+    expect(contents[0]?.additionalProperties).toBeUndefined();
+  });
+
+  it('keeps a wire call_id on a search call the SDK does not declare one for', () => {
+    const contents = contentsOf(
+      parseResponse({
+        output: [{ type: 'web_search_call', call_id: 'ws_1', action: { type: 'search', query: 'q' } }],
+      }),
+    );
+    expect(contents[0]).toMatchObject({
+      type: 'search_tool_call',
+      callId: 'ws_1',
+      toolName: 'web_search',
+      arguments: { type: 'search', query: 'q' },
+    });
+  });
+
+  it('maps a code interpreter item without code to a result only', () => {
+    const contents = contentsOf(
+      parseResponse({
+        output: [
+          {
+            type: 'code_interpreter_call',
+            id: 'ci_1',
+            outputs: [{ type: 'logs' }, { type: 'image' }, { type: 'image', url: 'https://img.example/1' }],
+          },
+        ],
+      }),
+    );
+    // No `code_interpreter_tool_call` without code; a logs output without text becomes an empty
+    // string, and an image output without a url has nothing to point at.
+    expect(contents).toEqual([
+      expect.objectContaining({
+        type: 'code_interpreter_tool_result',
+        callId: 'ci_1',
+        outputs: [
+          expect.objectContaining({ type: 'text', text: '' }),
+          expect.objectContaining({ type: 'uri', uri: 'https://img.example/1', mediaType: 'image' }),
+        ],
+      }),
+    ]);
+  });
+
+  it('maps a bare mcp_call without output to a call and no result', () => {
+    const contents = contentsOf(parseResponse({ output: [{ type: 'mcp_call' }] }));
+    expect(contents).toEqual([
+      expect.objectContaining({
+        type: 'mcp_server_tool_call',
+        callId: '',
+        toolName: '',
+        serverName: '',
+        arguments: '',
+      }),
+    ]);
+  });
+
+  it('treats a null mcp_call output as no result', () => {
+    const contents = contentsOf(parseResponse({ output: [{ type: 'mcp_call', id: 'mc_1', output: null }] }));
+    expect(contents.map((content) => content.type)).toEqual(['mcp_server_tool_call']);
+  });
+
+  it('surfaces an mcp_call output as a text result', () => {
+    const contents = contentsOf(
+      parseResponse({ output: [{ type: 'mcp_call', call_id: 'mc_1', output: 'result text' }] }),
+    );
+    expect(contents[1]).toMatchObject({
+      type: 'mcp_server_tool_result',
+      callId: 'mc_1',
+      output: [expect.objectContaining({ type: 'text', text: 'result text' })],
+    });
+  });
+
+  it('maps a bare mcp_approval_request with every field defaulted', () => {
+    const contents = contentsOf(parseResponse({ output: [{ type: 'mcp_approval_request' }] }));
+    expect(contents[0]).toMatchObject({
+      type: 'function_approval_request',
+      id: '',
+      userInputRequest: true,
+      functionCall: expect.objectContaining({ callId: '', name: '', arguments: '' }),
+    });
+  });
+});
+
+describe('stream event fallbacks', () => {
+  it('maps a refusal delta to text', () => {
+    // Python `_parse_chunk_from_openai` (`_chat_client.py:2913-2914`).
+    const update = parseOne({ type: 'response.refusal.delta', delta: 'cannot help' });
+    expect(update?.contents).toEqual([expect.objectContaining({ type: 'text', text: 'cannot help' })]);
+  });
+
+  it('maps a refusal delta without a payload to empty text', () => {
+    const update = parseOne({ type: 'response.refusal.delta' });
+    expect(update?.contents).toEqual([expect.objectContaining({ type: 'text', text: '' })]);
+  });
+
+  it('emits the initial refusal text of a streamed content part', () => {
+    const update = parseOne({
+      type: 'response.content_part.added',
+      part: { type: 'refusal', refusal: 'nope' },
+    });
+    expect(update?.contents).toEqual([expect.objectContaining({ type: 'text', text: 'nope' })]);
+  });
+
+  it('skips a streamed content part of an unknown type', () => {
+    expect(parseOne({ type: 'response.content_part.added', part: { type: 'mystery_part' } })).toBeUndefined();
+  });
+
+  it('maps a text delta without a payload to empty text', () => {
+    const update = parseOne({ type: 'response.output_text.delta' });
+    expect(update?.contents).toEqual([expect.objectContaining({ type: 'text', text: '' })]);
+  });
+
+  it('skips a streamed annotation the framework does not know', () => {
+    expect(
+      parseOne({ type: 'response.output_text.annotation.added', annotation: { type: 'mystery_citation' } }),
+    ).toBeUndefined();
+  });
+
+  it('emits a reasoning done event only when no delta preceded it', () => {
+    // The done event repeats the full text; after a delta it would fold up as a duplicate.
+    const state = createStreamParseState();
+    const first = parseStreamEvent(
+      { type: 'response.reasoning_text.done', item_id: 'rs_1', text: 'thought' },
+      state,
+    );
+    expect(first?.contents).toEqual([
+      expect.objectContaining({
+        type: 'text_reasoning',
+        id: 'rs_1',
+        text: 'thought',
+        additionalProperties: { reasoning_text: true },
+      }),
+    ]);
+
+    parseStreamEvent({ type: 'response.reasoning_text.delta', item_id: 'rs_2', delta: 'thought' }, state);
+    expect(
+      parseStreamEvent({ type: 'response.reasoning_text.done', item_id: 'rs_2', text: 'thought' }, state),
+    ).toBeUndefined();
+  });
+
+  it('emits a summary done event without the private-text marker', () => {
+    const update = parseOne({
+      type: 'response.reasoning_summary_text.done',
+      item_id: 'rs_1',
+      text: 'summary',
+    });
+    expect(update?.contents).toEqual([
+      expect.objectContaining({ type: 'text_reasoning', id: 'rs_1', text: 'summary' }),
+    ]);
+    expect(update?.contents[0]?.additionalProperties).toBeUndefined();
+  });
+
+  it('emits a reasoning done event without an item id and with no text as an empty fragment', () => {
+    const update = parseOne({ type: 'response.reasoning_text.done' });
+    expect(update?.contents).toEqual([
+      expect.objectContaining({
+        type: 'text_reasoning',
+        text: '',
+        additionalProperties: { reasoning_text: true },
+      }),
+    ]);
+    expect(update?.contents[0]).not.toHaveProperty('id');
+  });
+
+  it('falls back to the item id and an empty name when a streamed function call omits them', () => {
+    const state = createStreamParseState();
+    parseStreamEvent(
+      { type: 'response.output_item.added', output_index: 0, item: { type: 'function_call', id: 'fc_1' } },
+      state,
+    );
+    const update = parseStreamEvent(
+      { type: 'response.function_call_arguments.delta', output_index: 0, delta: '{}' },
+      state,
+    );
+    expect(update?.contents[0]).toMatchObject({ type: 'function_call', callId: 'fc_1', name: '' });
+  });
+
+  it('maps an announced reasoning fragment without text to an empty string', () => {
+    const update = parseOne({
+      type: 'response.output_item.added',
+      output_index: 0,
+      item: { type: 'reasoning', content: [{ type: 'reasoning_text' }] },
+    });
+    expect(update?.contents).toEqual([expect.objectContaining({ type: 'text_reasoning', text: '' })]);
+    expect(update?.contents[0]).not.toHaveProperty('id');
+  });
+
+  it('carries the opaque payload on every announced reasoning fragment', () => {
+    const update = parseOne({
+      type: 'response.output_item.added',
+      output_index: 0,
+      item: {
+        type: 'reasoning',
+        id: 'rs_1',
+        encrypted_content: 'enc',
+        content: [{ type: 'reasoning_text', text: 'thought' }],
+      },
+    });
+    expect(update?.contents).toEqual([
+      expect.objectContaining({ type: 'text_reasoning', id: 'rs_1', text: 'thought', protectedData: 'enc' }),
+    ]);
+  });
+
+  it('announces a reasoning item without id or payload as a bare marker', () => {
+    const update = parseOne({
+      type: 'response.output_item.added',
+      output_index: 0,
+      item: { type: 'reasoning' },
+    });
+    expect(update?.contents).toEqual([expect.objectContaining({ type: 'text_reasoning', text: '' })]);
+    expect(update?.contents[0]).not.toHaveProperty('id');
+    expect(update?.contents[0]).not.toHaveProperty('protectedData');
+  });
+
+  it('preserves a done reasoning payload even when the item has no id', () => {
+    const update = parseOne({
+      type: 'response.output_item.done',
+      item: { type: 'reasoning', encrypted_content: 'enc' },
+    });
+    expect(update?.contents).toEqual([
+      expect.objectContaining({ type: 'text_reasoning', text: '', protectedData: 'enc' }),
+    ]);
+    expect(update?.contents[0]).not.toHaveProperty('id');
+  });
+
+  it('skips an arguments delta whose output_index announced no function call', () => {
+    expect(
+      parseOne({ type: 'response.function_call_arguments.delta', output_index: 7, delta: '{}' }),
+    ).toBeUndefined();
+  });
+
+  it('maps an arguments delta without a payload to an empty arguments fragment', () => {
+    const state = createStreamParseState();
+    parseStreamEvent(
+      {
+        type: 'response.output_item.added',
+        output_index: 0,
+        item: { type: 'function_call', call_id: 'call_1', name: 'lookup' },
+      },
+      state,
+    );
+    const update = parseStreamEvent(
+      { type: 'response.function_call_arguments.delta', output_index: 0 },
+      state,
+    );
+    expect(update?.contents).toEqual([
+      expect.objectContaining({ type: 'function_call', callId: 'call_1', name: 'lookup', arguments: '' }),
+    ]);
+  });
+
+  it('maps a partial image without a payload to an empty png frame', () => {
+    const update = parseOne({ type: 'response.image_generation_call.partial_image' });
+    expect(update?.contents[1]).toMatchObject({
+      type: 'image_generation_tool_result',
+      imageId: '',
+      outputs: [
+        expect.objectContaining({
+          uri: 'data:image/png;base64,',
+          mediaType: 'image/png',
+          additionalProperties: expect.objectContaining({ is_partial_image: true }),
+        }),
+      ],
+    });
+  });
+
+  it('skips the done echo of an item type that streamed its own deltas', () => {
+    expect(
+      parseOne({
+        type: 'response.output_item.done',
+        item: { type: 'function_call', call_id: 'call_1', name: 'lookup', arguments: '{}' },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('skips the done echo of a reasoning item without an opaque payload', () => {
+    expect(
+      parseOne({ type: 'response.output_item.done', item: { type: 'reasoning', id: 'rs_1' } }),
+    ).toBeUndefined();
+  });
+
+  it('reports no response id or continuation token when response.created carries none', () => {
+    const update = parseOne({ type: 'response.created', response: {} });
+    expect(update?.responseId).toBeUndefined();
+    expect(update?.continuationToken).toBeUndefined();
+  });
+
+  it('offers a continuation token as soon as a queued response has an id', () => {
+    const update = parseOne({ type: 'response.created', response: { id: 'resp_1', status: 'queued' } });
+    expect(update?.continuationToken).toEqual({ responseId: 'resp_1' });
+  });
+
+  it('maps a terminal event without id, model or usage to a bare update', () => {
+    const update = parseOne({ type: 'response.completed', response: { status: 'completed' } });
+    expect(update).toBeDefined();
+    expect(update?.responseId).toBeUndefined();
+    expect(update?.contents).toEqual([]);
+    expect(update?.finishReason).toBe('stop');
+  });
+});

--- a/packages/openai/src/to-openai.ts
+++ b/packages/openai/src/to-openai.ts
@@ -668,7 +668,7 @@ export function toResponsesTools(tools: readonly Tool[] | undefined): ResponsesI
       strict: false,
     });
   }
-  return mapped.length === 0 ? undefined : mapped;
+  return mapped;
 }
 
 /** Converts a {@link ToolChoice} into the Responses API `tool_choice` value. */

--- a/packages/openai/src/to-openai.wire-fallbacks.test.ts
+++ b/packages/openai/src/to-openai.wire-fallbacks.test.ts
@@ -1,0 +1,310 @@
+import type { Message, Tool } from '@polymind-inc/agent-framework-core';
+import { ChatClientError } from '@polymind-inc/agent-framework-core';
+import { describe, expect, it } from 'vitest';
+import {
+  toResponsesInput,
+  toResponsesTextFormat,
+  toResponsesToolChoice,
+  toResponsesTools,
+} from './to-openai.js';
+
+// The request-side conversion has to render transcript shapes the happy path never produces —
+// results without values, MCP outputs in every payload form, annotations rebuilt after
+// persistence — and each has a defined wire form. These tests pin them down.
+
+describe('function result rendering', () => {
+  function outputOf(result: unknown): unknown {
+    const items = toResponsesInput([
+      { role: 'tool', contents: [{ type: 'function_result', callId: 'c1', result }] },
+    ]);
+    return items[0]?.output;
+  }
+
+  it('renders an absent result as an empty string', () => {
+    expect(outputOf(undefined)).toBe('');
+    expect(outputOf(null)).toBe('');
+  });
+
+  it('renders a structured result as its JSON', () => {
+    expect(outputOf({ ok: true })).toBe('{"ok":true}');
+  });
+
+  it('falls back to the string result when rich items carry nothing sendable', () => {
+    // The rich-output gate needs a data/uri item, but conversion can still drop it (here: an
+    // unsupported audio codec); the string result is what remains.
+    const items = toResponsesInput([
+      {
+        role: 'tool',
+        contents: [
+          {
+            type: 'function_result',
+            callId: 'c1',
+            result: 'plain answer',
+            items: [{ type: 'uri', uri: 'https://a.example/x.ogg', mediaType: 'audio/ogg' }],
+          },
+        ],
+      },
+    ]);
+    expect(items[0]?.output).toBe('plain answer');
+  });
+
+  it('keeps the string form when the rich items are text only', () => {
+    const items = toResponsesInput([
+      {
+        role: 'tool',
+        contents: [
+          {
+            type: 'function_result',
+            callId: 'c1',
+            result: 'summary',
+            items: [{ type: 'text', text: 'summary' }],
+          },
+        ],
+      },
+    ]);
+    expect(items[0]?.output).toBe('summary');
+  });
+});
+
+describe('MCP call replay', () => {
+  function mcpItems(output: unknown): Record<string, unknown>[] {
+    return toResponsesInput([
+      {
+        role: 'assistant',
+        contents: [
+          { type: 'mcp_server_tool_call', callId: 'mcp_1', toolName: 't', serverName: 's', arguments: '{}' },
+          { type: 'mcp_server_tool_result', callId: 'mcp_1', output },
+        ],
+      },
+    ]);
+  }
+
+  it('folds a missing result payload onto the call as an empty string', () => {
+    expect(mcpItems(undefined)).toEqual([expect.objectContaining({ type: 'mcp_call', output: '' })]);
+  });
+
+  it('concatenates text-bearing entries and JSON-encodes the rest', () => {
+    const output = [{ type: 'text', text: 'a' }, 'b', { k: 1 }];
+    expect(mcpItems(output)[0]?.output).toBe('ab{"k":1}');
+  });
+
+  it('JSON-encodes a structured result payload', () => {
+    expect(mcpItems({ k: 1 })[0]?.output).toBe('{"k":1}');
+  });
+
+  it('drops a call without an id and its fallbacks default the rest', () => {
+    const items = toResponsesInput([
+      {
+        role: 'assistant',
+        contents: [{ type: 'mcp_server_tool_call' }, { type: 'mcp_server_tool_call', callId: 'mcp_2' }],
+      },
+    ]);
+    expect(items).toEqual([{ type: 'mcp_call', id: 'mcp_2', server_label: '', name: '', arguments: '' }]);
+  });
+
+  it('drops an orphan MCP result rather than sending the shape the API rejects', () => {
+    const items = toResponsesInput([
+      { role: 'assistant', contents: [{ type: 'mcp_server_tool_result', callId: 'mcp_gone', output: 'x' }] },
+    ]);
+    expect(items).toEqual([]);
+  });
+});
+
+describe('annotation reconstruction after persistence', () => {
+  function wireAnnotations(annotations: NonNullable<Message['contents'][number]['annotations']>): unknown {
+    const items = toResponsesInput([
+      { role: 'assistant', contents: [{ type: 'text', text: 'cited', annotations }] },
+    ]);
+    const message = items[0] as { content: Array<{ annotations: unknown }> };
+    return message.content[0]?.annotations;
+  }
+
+  it('rebuilds a file-id-only citation as file_path, keeping a stored index', () => {
+    expect(
+      wireAnnotations([{ type: 'citation', fileId: 'file_1', additionalProperties: { index: 3 } }]),
+    ).toEqual([{ type: 'file_path', file_id: 'file_1', index: 3 }]);
+  });
+
+  it('omits the index of a file_path citation that never had one', () => {
+    expect(wireAnnotations([{ type: 'citation', fileId: 'file_1' }])).toEqual([
+      { type: 'file_path', file_id: 'file_1' },
+    ]);
+  });
+
+  it('defaults a url citation title to an empty string', () => {
+    expect(
+      wireAnnotations([
+        {
+          type: 'citation',
+          url: 'https://a.example',
+          annotatedRegions: [{ type: 'text_span', startIndex: 0, endIndex: 5 }],
+        },
+      ]),
+    ).toEqual([{ type: 'url_citation', url: 'https://a.example', title: '', start_index: 0, end_index: 5 }]);
+  });
+
+  it('drops annotation kinds that have no wire reconstruction', () => {
+    expect(wireAnnotations([{ type: 'mystery' }])).toEqual([]);
+  });
+});
+
+describe('media input forms', () => {
+  function partsOf(contents: Message['contents']): unknown[] {
+    const items = toResponsesInput([{ role: 'user', contents }]);
+    return items.length === 0 ? [] : (items[0] as { content: unknown[] }).content;
+  }
+
+  it('sends wav and mp3 audio as input_audio and drops other codecs', () => {
+    expect(
+      partsOf([
+        { type: 'data', uri: 'data:audio/wav;base64,AA', mediaType: 'audio/wav' },
+        { type: 'data', uri: 'data:audio/mp3;base64,BB', mediaType: 'audio/mp3' },
+        { type: 'data', uri: 'data:audio/ogg;base64,CC', mediaType: 'audio/ogg' },
+      ]),
+    ).toEqual([
+      { type: 'input_audio', input_audio: { data: 'data:audio/wav;base64,AA', format: 'wav' } },
+      { type: 'input_audio', input_audio: { data: 'data:audio/mp3;base64,BB', format: 'mp3' } },
+    ]);
+  });
+
+  it('sends application data as input_file, carrying a name when there is one', () => {
+    expect(
+      partsOf([
+        {
+          type: 'data',
+          uri: 'data:application/pdf;base64,AA',
+          mediaType: 'application/pdf',
+          name: 'doc.pdf',
+        },
+        { type: 'data', uri: 'data:application/pdf;base64,BB', mediaType: 'application/pdf' },
+      ]),
+    ).toEqual([
+      { type: 'input_file', file_data: 'data:application/pdf;base64,AA', filename: 'doc.pdf' },
+      { type: 'input_file', file_data: 'data:application/pdf;base64,BB' },
+    ]);
+  });
+
+  it('drops media the API has no input form for, and the message when nothing is left', () => {
+    expect(partsOf([{ type: 'uri', uri: 'https://a.example/notes.txt', mediaType: 'text/plain' }])).toEqual(
+      [],
+    );
+  });
+});
+
+describe('reasoning replay fallbacks', () => {
+  it('reads the opaque payload from additionalProperties when protectedData is empty', () => {
+    const items = toResponsesInput([
+      {
+        role: 'assistant',
+        contents: [
+          {
+            type: 'text_reasoning',
+            id: 'rs_1',
+            text: 'public summary',
+            additionalProperties: { encrypted_content: 'enc', status: 'completed' },
+          },
+        ],
+      },
+    ]);
+    expect(items).toEqual([
+      {
+        type: 'reasoning',
+        id: 'rs_1',
+        summary: [{ type: 'summary_text', text: 'public summary' }],
+        encrypted_content: 'enc',
+        status: 'completed',
+      },
+    ]);
+  });
+
+  it('uses a string reasoning_text marker as the private text itself', () => {
+    const items = toResponsesInput([
+      {
+        role: 'assistant',
+        contents: [
+          {
+            type: 'text_reasoning',
+            id: 'rs_1',
+            text: '',
+            protectedData: 'enc',
+            additionalProperties: { reasoning_text: 'private thought' },
+          },
+        ],
+      },
+    ]);
+    expect(items[0]?.content).toEqual([{ type: 'reasoning_text', text: 'private thought' }]);
+  });
+});
+
+describe('stateless replay validation', () => {
+  it('fails fast when a tool call is bound to reasoning that cannot be replayed', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        contents: [
+          { type: 'text_reasoning', id: 'rs_1', text: 'thought' },
+          { type: 'function_call', callId: 'c1', name: 'f', arguments: '{}' },
+        ],
+      },
+      { role: 'tool', contents: [{ type: 'function_result', callId: 'c1', result: 'ok' }] },
+    ];
+    expect(() => toResponsesInput(messages)).toThrow(ChatClientError);
+    expect(() => toResponsesInput(messages)).toThrow(/rs_1/);
+  });
+
+  it('fails fast when a compacted group declares reasoning it no longer carries', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        contents: [{ type: 'function_call', callId: 'c1', name: 'f', arguments: '{}' }],
+        additionalProperties: { _group: { id: 'g1', has_reasoning: true } },
+      },
+      { role: 'tool', contents: [{ type: 'function_result', callId: 'c1', result: 'ok' }] },
+    ];
+    expect(() => toResponsesInput(messages)).toThrow(/compacted group g1/);
+  });
+
+  it('skips the validation entirely under service storage', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        contents: [
+          { type: 'text_reasoning', id: 'rs_1', text: 'thought' },
+          { type: 'function_call', callId: 'c1', name: 'f', arguments: '{}' },
+        ],
+      },
+      { role: 'tool', contents: [{ type: 'function_result', callId: 'c1', result: 'ok' }] },
+    ];
+    // The service already holds the reasoning item; only the result goes back.
+    expect(toResponsesInput(messages, { serviceStorage: true })).toEqual([
+      { type: 'function_call_output', call_id: 'c1', output: 'ok' },
+    ]);
+  });
+});
+
+describe('tool declarations and choices', () => {
+  it('passes a non-function tool without a spec through as itself', () => {
+    const opaque = { type: 'web_search' } as unknown as Tool;
+    expect(toResponsesTools([opaque])).toEqual([{ type: 'web_search' }]);
+  });
+
+  it('maps each tool-choice form onto its wire value', () => {
+    expect(toResponsesToolChoice(undefined)).toBeUndefined();
+    expect(toResponsesToolChoice('auto')).toBe('auto');
+    expect(toResponsesToolChoice({ required: ['a'] })).toEqual({ type: 'function', name: 'a' });
+    expect(toResponsesToolChoice({ required: ['a', 'b'] })).toEqual({
+      type: 'allowed_tools',
+      mode: 'required',
+      tools: [
+        { type: 'function', name: 'a' },
+        { type: 'function', name: 'b' },
+      ],
+    });
+  });
+
+  it('carries a response-format description onto the wire', () => {
+    expect(
+      toResponsesTextFormat({ name: 'answer', description: 'the shape', schema: { type: 'object' } }),
+    ).toMatchObject({ type: 'json_schema', name: 'answer', description: 'the shape' });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3
+      '@vitest/coverage-v8':
+        specifier: 4.1.10
+        version: 4.1.10(vitest@4.1.10)
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
@@ -22,7 +25,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
 
   examples/01-get-started:
     dependencies:
@@ -103,7 +106,7 @@ importers:
     dependencies:
       '@a2a-js/sdk':
         specifier: ^1.0.1
-        version: 1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1)
+        version: 1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1(supports-color@7.2.0))
       '@polymind-inc/agent-framework-a2a':
         specifier: workspace:^
         version: link:../../packages/a2a
@@ -119,7 +122,7 @@ importers:
         version: 24.13.3
       express:
         specifier: ^5.1.0
-        version: 5.2.1
+        version: 5.2.1(supports-color@7.2.0)
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
@@ -131,7 +134,7 @@ importers:
     dependencies:
       '@a2a-js/sdk':
         specifier: ^1.0.1
-        version: 1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1)
+        version: 1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1(supports-color@7.2.0))
       '@polymind-inc/agent-framework-core':
         specifier: workspace:^
         version: link:../core
@@ -144,16 +147,16 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
 
   packages/agentserver:
     dependencies:
       '@azure/identity':
         specifier: ^4.13.1
-        version: 4.13.1
+        version: 4.13.1(supports-color@7.2.0)
       '@azure/monitor-opentelemetry-exporter':
         specifier: 1.0.0-beta.44
-        version: 1.0.0-beta.44
+        version: 1.0.0-beta.44(supports-color@7.2.0)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -193,7 +196,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
 
   packages/anthropic:
     dependencies:
@@ -212,7 +215,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
 
   packages/core:
     dependencies:
@@ -240,13 +243,13 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
 
   packages/foundry:
     dependencies:
       '@azure/identity':
         specifier: ^4.13.1
-        version: 4.13.1
+        version: 4.13.1(supports-color@7.2.0)
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
@@ -283,7 +286,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
 
   packages/mcp:
     dependencies:
@@ -311,7 +314,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
 
   packages/openai:
     dependencies:
@@ -330,7 +333,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
 
 packages:
 
@@ -410,9 +413,30 @@ packages:
     resolution: {integrity: sha512-tumCMmzrRhKmTbYQg/7OlfbrIKcKaf8Ed0Fw3suUpRT3owFYljznVgxcfHe8RycQXY9uyROGiLD1GjhpF45AwA==}
     engines: {node: '>=20'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.5.6':
     resolution: {integrity: sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==}
@@ -654,8 +678,15 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
@@ -1199,6 +1230,15 @@ packages:
     resolution: {integrity: sha512-bLMpVcWZNzq6lYOybwFwOAR1IXKcHnhUNqYeHjl1bET/qE3jFPFH+p8Wrh3rU4xwdnifPxmKNESBYnvnmc75aA==}
     engines: {node: '>=22.0.0'}
 
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
@@ -1376,6 +1416,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
@@ -1610,6 +1653,10 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -1620,6 +1667,9 @@ packages:
 
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -1672,8 +1722,23 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jose@6.2.5:
     resolution: {integrity: sha512-2E5L2yRp03FnwreJLJX8/r7mHiZICCf8kG7fAsTWkSQTDAcc46NIZoQLKy+EJ8sPoJlxyS4OQR5H70LjIZZlIQ==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
@@ -1792,6 +1857,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2035,6 +2107,10 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -2265,13 +2341,13 @@ packages:
 
 snapshots:
 
-  '@a2a-js/sdk@1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1)':
+  '@a2a-js/sdk@1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1(supports-color@7.2.0))':
     dependencies:
       jose: 6.2.5
       uuid: 11.1.1
     optionalDependencies:
       '@grpc/grpc-js': 1.14.4
-      express: 5.2.1
+      express: 5.2.1(supports-color@7.2.0)
 
   '@anthropic-ai/sdk@0.115.0(zod@4.4.3)':
     dependencies:
@@ -2280,13 +2356,13 @@ snapshots:
     optionalDependencies:
       zod: 4.4.3
 
-  '@azure-rest/core-client@2.8.0':
+  '@azure-rest/core-client@2.8.0(supports-color@7.2.0)':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-auth': 1.11.0
-      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
+      '@azure/core-rest-pipeline': 1.25.0(supports-color@7.2.0)
       '@azure/core-tracing': 1.4.0
-      '@typespec/ts-http-runtime': 0.3.8
+      '@typespec/ts-http-runtime': 0.3.8(supports-color@7.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -2295,34 +2371,34 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-auth@1.11.0':
+  '@azure/core-auth@1.11.0(supports-color@7.2.0)':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-util': 1.14.0
+      '@azure/core-util': 1.14.0(supports-color@7.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-client@1.11.0':
+  '@azure/core-client@1.11.0(supports-color@7.2.0)':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-auth': 1.11.0
-      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
+      '@azure/core-rest-pipeline': 1.25.0(supports-color@7.2.0)
       '@azure/core-tracing': 1.4.0
-      '@azure/core-util': 1.14.0
-      '@azure/logger': 1.4.0
+      '@azure/core-util': 1.14.0(supports-color@7.2.0)
+      '@azure/logger': 1.4.0(supports-color@7.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-rest-pipeline@1.25.0':
+  '@azure/core-rest-pipeline@1.25.0(supports-color@7.2.0)':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-auth': 1.11.0
+      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
       '@azure/core-tracing': 1.4.0
-      '@azure/core-util': 1.14.0
-      '@azure/logger': 1.4.0
-      '@typespec/ts-http-runtime': 0.3.8
+      '@azure/core-util': 1.14.0(supports-color@7.2.0)
+      '@azure/logger': 1.4.0(supports-color@7.2.0)
+      '@typespec/ts-http-runtime': 0.3.8(supports-color@7.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -2331,23 +2407,23 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-util@1.14.0':
+  '@azure/core-util@1.14.0(supports-color@7.2.0)':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@typespec/ts-http-runtime': 0.3.8
+      '@typespec/ts-http-runtime': 0.3.8(supports-color@7.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/identity@4.13.1':
+  '@azure/identity@4.13.1(supports-color@7.2.0)':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-auth': 1.11.0
-      '@azure/core-client': 1.11.0
-      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
+      '@azure/core-client': 1.11.0(supports-color@7.2.0)
+      '@azure/core-rest-pipeline': 1.25.0(supports-color@7.2.0)
       '@azure/core-tracing': 1.4.0
-      '@azure/core-util': 1.14.0
-      '@azure/logger': 1.4.0
+      '@azure/core-util': 1.14.0(supports-color@7.2.0)
+      '@azure/logger': 1.4.0(supports-color@7.2.0)
       '@azure/msal-browser': 5.17.3
       '@azure/msal-node': 5.4.3
       open: 10.2.0
@@ -2355,20 +2431,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/logger@1.4.0':
+  '@azure/logger@1.4.0(supports-color@7.2.0)':
     dependencies:
-      '@typespec/ts-http-runtime': 0.3.8
+      '@typespec/ts-http-runtime': 0.3.8(supports-color@7.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.44':
+  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.44(supports-color@7.2.0)':
     dependencies:
-      '@azure-rest/core-client': 2.8.0
-      '@azure/core-auth': 1.11.0
-      '@azure/core-client': 1.11.0
-      '@azure/core-rest-pipeline': 1.25.0
-      '@azure/core-util': 1.14.0
+      '@azure-rest/core-client': 2.8.0(supports-color@7.2.0)
+      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
+      '@azure/core-client': 1.11.0(supports-color@7.2.0)
+      '@azure/core-rest-pipeline': 1.25.0(supports-color@7.2.0)
+      '@azure/core-util': 1.14.0(supports-color@7.2.0)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.220.0
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
@@ -2392,7 +2468,22 @@ snapshots:
       '@azure/msal-common': 16.11.3
       jsonwebtoken: 9.0.3
 
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
   '@babel/runtime@7.29.7': {}
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.5.6':
     optionalDependencies:
@@ -2551,7 +2642,14 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.3
 
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
@@ -2967,13 +3065,27 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@typespec/ts-http-runtime@0.3.8':
+  '@typespec/ts-http-runtime@0.3.8(supports-color@7.2.0)':
     dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@7.2.0)
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.5
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.4
+      obug: 2.1.4
+      std-env: 4.2.0
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -3101,11 +3213,17 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  body-parser@2.3.0:
+  ast-v8-to-istanbul@1.0.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
+  body-parser@2.3.0(supports-color@7.2.0):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
@@ -3167,9 +3285,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   default-browser-id@5.0.1: {}
 
@@ -3263,20 +3383,20 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  express@5.2.1:
+  express@5.2.1(supports-color@7.2.0):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@7.2.0)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@7.2.0)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -3287,9 +3407,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.3.0
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@7.2.0)
+      send: 1.2.1(supports-color@7.2.0)
+      serve-static: 2.2.1(supports-color@7.2.0)
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -3302,9 +3422,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -3348,6 +3468,8 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.4:
@@ -3355,6 +3477,8 @@ snapshots:
       function-bind: 1.1.2
 
   hookable@6.1.1: {}
+
+  html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -3364,17 +3488,17 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3404,7 +3528,22 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jose@6.2.5: {}
+
+  js-tokens@10.0.0: {}
 
   json-schema-to-ts@3.1.1:
     dependencies:
@@ -3505,6 +3644,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.4:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   math-intrinsics@1.1.0: {}
 
@@ -3662,9 +3811,9 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.1
       '@rolldown/binding-win32-x64-msvc': 1.2.1
 
-  router@2.2.0:
+  router@2.2.0(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -3680,9 +3829,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -3696,12 +3845,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@7.2.0):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3765,6 +3914,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   tinybench@2.9.0: {}
 
@@ -3874,7 +4027,7 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.23.1
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
@@ -3899,6 +4052,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.13.3
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Each package keeps its own vitest.config.ts; this root config only
+    // aggregates them so a single run can produce a merged coverage report.
+    // The aggregated run schedules every package's suites onto one worker pool, so a cold start
+    // can push an individual test past the 5s default; `test:coverage` passes --testTimeout for
+    // that reason.
+    projects: ['packages/*'],
+    coverage: {
+      provider: 'v8',
+      include: ['packages/*/src/**'],
+      exclude: [
+        '**/*.test.ts',
+        // Test doubles shipped for consumers and used only from tests here.
+        'packages/core/src/testing.ts',
+        'packages/core/src/client/test-support.ts',
+        'packages/a2a/src/test-support.ts',
+        'packages/mcp/src/test-server.ts',
+      ],
+      reporter: ['text', 'html', 'json-summary'],
+      reportsDirectory: 'coverage',
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Adds a root vitest config that aggregates all seven packages, so `pnpm test:coverage` produces one merged report (`@vitest/coverage-v8`). The aggregated run passes `--testTimeout=30000` because it schedules every suite onto one worker pool; per-package runs keep the 5s default.
- Adds ~250 tests pinning down the wire-level fallbacks where branch coverage was thinnest — the openai/anthropic/foundry conversions, agentserver request validation, and smaller core gaps (message filters, observability settings, continuation tokens). Each degenerate payload's mapping is checked against the Python/.NET reference behaviour. Coverage: statements 92.9% → 96.1%, branches 83.1% → 91.2%.
- Fixes a folding parity bug found while reviewing: merged reasoning fragments kept an empty-string id over a later real one (`??=` vs Python's falsy `or`), which could drop the encrypted payload a stateless resume needs. Reproduction-first, with a negative control.
- Removes two unreachable defensive branches (`toResponsesTools` empty check, Anthropic `usageContent` undefined-state branch).

## Test plan

- `pnpm check` (lint, build, typecheck, all package tests, pack check) is green.
- `pnpm test:coverage` runs all 1,221 tests green and reports the numbers above.
- The observability settings tests pin both opt-in env vars to unset in `beforeEach`, so they pass in an environment that has opted in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)