### PR TITLE
Add the @polymind-inc/agent-framework umbrella package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ set. During 0.x, **minor releases may contain breaking changes**; patch releases
 
 ## Unreleased
 
-Fixes only — no change to any published API.
+One new package; no change to any existing published API.
 
+- **`@polymind-inc/agent-framework`** — new umbrella package, mirroring the Python
+  `agent-framework` distribution. It depends on every granular package and re-exports each
+  under a subpath: the root entry is the core, and `/testing`, `/openai`, `/anthropic`, `/mcp`,
+  `/a2a`, `/foundry`, `/foundry/hosting`, `/agentserver`, `/agentserver/node` and
+  `/agentserver/observability` map one-to-one onto the packages they re-export. The granular
+  packages are unchanged and remain the smaller install.
 - **`@polymind-inc/agent-framework-agentserver`** — routing no longer trims the trailing slash of a
   request path with a backtracking regular expression. The old pattern cost time quadratic in the
   length of a run of slashes, so an unauthenticated `GET` on a path such as `/////…/a` could hold

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,9 @@ The points below are the ones most often gotten wrong.
 Node.js 24+ · TypeScript 7 · pnpm · ESM only · target ES2024 with `isolatedDeclarations` · Biome
 for lint and format · tsdown for builds · Vitest for tests.
 
-Seven packages under `packages/`, published as `@polymind-inc/agent-framework-*` and versioned in
-lockstep. `pnpm check` runs the same gate as CI.
+The packages under `packages/` are published as `@polymind-inc/agent-framework-*`, plus the
+umbrella `@polymind-inc/agent-framework`, which depends on all of them and re-exports each under a
+subpath. All are versioned in lockstep. `pnpm check` runs the same gate as CI.
 
 ## Status
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ gh release create v0.2.0 --title v0.2.0 --notes "$(sed -n '/^## 0.2.0/,/^## 0.1/
 ```
 
 Either way the release workflow re-runs the full gate, verifies the tag matches the package
-version, and publishes all seven packages to npm with provenance. A version carrying a prerelease
+version, and publishes every package to npm with provenance. A version carrying a prerelease
 suffix (`0.2.0-rc.1`) goes to the `next` dist-tag instead of `latest`.
 
 Prerequisites for publishing:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ All packages are published under the `@polymind-inc/` scope and released in lock
 
 | Package                                     | Purpose                                                                                                                                               |
 | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@polymind-inc/agent-framework`             | Umbrella package — installs every package below and re-exports each under a subpath (`/openai`, `/anthropic`, `/mcp`, `/a2a`, `/foundry`, `/agentserver`) |
 | `@polymind-inc/agent-framework-core`        | `Agent`, `AgentSession`, the `Message`/`Content` model, `tool()`, middleware, and the `ChatClient` seam. Sole runtime dependency: `@opentelemetry/api` |
 | `@polymind-inc/agent-framework-openai`      | OpenAI and Azure OpenAI chat client (Responses API)                                                                                                   |
 | `@polymind-inc/agent-framework-anthropic`   | Anthropic chat client (Messages API)                                                                                                                  |
@@ -90,8 +91,10 @@ All packages are published under the `@polymind-inc/` scope and released in lock
 | `@polymind-inc/agent-framework-foundry`     | Microsoft Foundry chat client and Hosted Agent hosting adapter                                                                                        |
 | `@polymind-inc/agent-framework-agentserver` | Foundry Responses container protocol v2.0.0 server, independent of the rest of the framework                                                          |
 
-The names mirror the Python distribution layout (`agent-framework-core`, `agent-framework-openai`,
-…) so that a move to a first-party scope is a mechanical rename.
+The names mirror the Python distribution layout (`agent-framework` as the everything-included
+umbrella, `agent-framework-core`, `agent-framework-openai`, …) so that a move to a first-party
+scope is a mechanical rename. The granular packages remain the recommended install when size
+matters; the umbrella pulls in every provider SDK.
 
 ## Parity with the reference implementations
 
@@ -211,7 +214,7 @@ environment variables each one needs.
 ## Stability and versioning
 
 The public API is frozen as **Baseline v0.1**. During `0.x`, **minor releases may contain breaking
-changes**; patch releases are fixes only. All seven packages are versioned and released in
+changes**; patch releases are fixes only. All packages are versioned and released in
 lockstep, so a single [`CHANGELOG.md`](CHANGELOG.md) entry covers the set. Releases are published
 from CI with [npm provenance][provenance].
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ All packages are published under the `@polymind-inc/` scope and released in lock
 
 | Package                                     | Purpose                                                                                                                                               |
 | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@polymind-inc/agent-framework`             | Umbrella package — installs every package below and re-exports each under a subpath (`/openai`, `/anthropic`, `/mcp`, `/a2a`, `/foundry`, `/agentserver`) |
+| `@polymind-inc/agent-framework`             | Umbrella package — installs every package below and re-exports each of their entry points under a subpath (the full mapping is in [its README](packages/meta/README.md)) |
 | `@polymind-inc/agent-framework-core`        | `Agent`, `AgentSession`, the `Message`/`Content` model, `tool()`, middleware, and the `ChatClient` seam. Sole runtime dependency: `@opentelemetry/api` |
 | `@polymind-inc/agent-framework-openai`      | OpenAI and Azure OpenAI chat client (Responses API)                                                                                                   |
 | `@polymind-inc/agent-framework-anthropic`   | Anthropic chat client (Messages API)                                                                                                                  |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,9 @@ days; please allow a reasonable disclosure window before publishing.
 
 ## Supported versions
 
-Only the latest published 0.x release line receives security fixes. All
-`@polymind-inc/agent-framework*` packages are released in lockstep — a fix bumps them together.
+Only the latest published 0.x release line receives security fixes. The umbrella
+`@polymind-inc/agent-framework` package and all `@polymind-inc/agent-framework-*` packages are
+released in lockstep — a fix bumps them together.
 
 ## Deployment notes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ days; please allow a reasonable disclosure window before publishing.
 
 ## Supported versions
 
-Only the latest published 0.x release line receives security fixes. All seven
-`@polymind-inc/agent-framework-*` packages are released in lockstep — a fix bumps them together.
+Only the latest published 0.x release line receives security fixes. All
+`@polymind-inc/agent-framework*` packages are released in lockstep — a fix bumps them together.
 
 ## Deployment notes
 

--- a/packages/meta/LICENSE
+++ b/packages/meta/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 shibayan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/meta/README.md
+++ b/packages/meta/README.md
@@ -1,0 +1,38 @@
+# @polymind-inc/agent-framework
+
+Umbrella package for the Agent Framework for TypeScript. One install brings in the whole family —
+the runtime-agnostic core, the OpenAI / Azure OpenAI, Anthropic and Microsoft Foundry providers,
+the MCP and A2A clients, and the Foundry hosting pieces — mirroring what `pip install
+agent-framework` gives you in the Python implementation. ESM only.
+
+```sh
+npm install @polymind-inc/agent-framework
+```
+
+The root entry is the core; everything else lives under a subpath:
+
+| Import | Re-exports |
+| ------ | ---------- |
+| `@polymind-inc/agent-framework` | [`@polymind-inc/agent-framework-core`](https://www.npmjs.com/package/@polymind-inc/agent-framework-core) — `Agent`, `AgentSession`, `tool()`, middleware, the `ChatClient` seam |
+| `@polymind-inc/agent-framework/testing` | `@polymind-inc/agent-framework-core/testing` — `MockChatClient` |
+| `@polymind-inc/agent-framework/openai` | [`@polymind-inc/agent-framework-openai`](https://www.npmjs.com/package/@polymind-inc/agent-framework-openai) |
+| `@polymind-inc/agent-framework/anthropic` | [`@polymind-inc/agent-framework-anthropic`](https://www.npmjs.com/package/@polymind-inc/agent-framework-anthropic) |
+| `@polymind-inc/agent-framework/mcp` | [`@polymind-inc/agent-framework-mcp`](https://www.npmjs.com/package/@polymind-inc/agent-framework-mcp) |
+| `@polymind-inc/agent-framework/a2a` | [`@polymind-inc/agent-framework-a2a`](https://www.npmjs.com/package/@polymind-inc/agent-framework-a2a) |
+| `@polymind-inc/agent-framework/foundry` | [`@polymind-inc/agent-framework-foundry`](https://www.npmjs.com/package/@polymind-inc/agent-framework-foundry) |
+| `@polymind-inc/agent-framework/foundry/hosting` | `@polymind-inc/agent-framework-foundry/hosting` |
+| `@polymind-inc/agent-framework/agentserver` | [`@polymind-inc/agent-framework-agentserver`](https://www.npmjs.com/package/@polymind-inc/agent-framework-agentserver) |
+| `@polymind-inc/agent-framework/agentserver/node` | `@polymind-inc/agent-framework-agentserver/node` |
+| `@polymind-inc/agent-framework/agentserver/observability` | `@polymind-inc/agent-framework-agentserver/observability` |
+
+```ts
+import { Agent, tool } from '@polymind-inc/agent-framework';
+import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
+```
+
+The subpaths are plain static re-exports, so a bundler tree-shakes whatever you do not import.
+If install size matters more than convenience — this package pulls in every provider SDK and the
+hosting server's OpenTelemetry dependencies — install the individual packages instead; they are
+the same code, and the two styles can be mixed freely.
+
+Requirements: Node.js >= 24, ESM only (no CommonJS build).

--- a/packages/meta/package.json
+++ b/packages/meta/package.json
@@ -1,0 +1,109 @@
+{
+  "name": "@polymind-inc/agent-framework",
+  "version": "0.1.1",
+  "description": "Umbrella package for the Agent Framework (TypeScript): one install for the core, the OpenAI / Anthropic / Foundry providers, MCP, A2A and hosting, each re-exported under a subpath.",
+  "keywords": [
+    "agent",
+    "ai",
+    "llm",
+    "agent-framework",
+    "openai",
+    "anthropic",
+    "mcp",
+    "a2a",
+    "foundry",
+    "typescript"
+  ],
+  "homepage": "https://github.com/polymind-inc/agent-framework-js/tree/master/packages/meta#readme",
+  "bugs": "https://github.com/polymind-inc/agent-framework-js/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/polymind-inc/agent-framework-js.git",
+    "directory": "packages/meta"
+  },
+  "license": "MIT",
+  "author": "shibayan <me@shibayan.jp>",
+  "type": "module",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=24"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "default": "./dist/testing.js"
+    },
+    "./openai": {
+      "types": "./dist/openai.d.ts",
+      "default": "./dist/openai.js"
+    },
+    "./anthropic": {
+      "types": "./dist/anthropic.d.ts",
+      "default": "./dist/anthropic.js"
+    },
+    "./mcp": {
+      "types": "./dist/mcp.d.ts",
+      "default": "./dist/mcp.js"
+    },
+    "./a2a": {
+      "types": "./dist/a2a.d.ts",
+      "default": "./dist/a2a.js"
+    },
+    "./foundry": {
+      "types": "./dist/foundry.d.ts",
+      "default": "./dist/foundry.js"
+    },
+    "./foundry/hosting": {
+      "types": "./dist/foundry/hosting.d.ts",
+      "default": "./dist/foundry/hosting.js"
+    },
+    "./agentserver": {
+      "types": "./dist/agentserver.d.ts",
+      "default": "./dist/agentserver.js"
+    },
+    "./agentserver/node": {
+      "types": "./dist/agentserver/node.d.ts",
+      "default": "./dist/agentserver/node.js"
+    },
+    "./agentserver/observability": {
+      "types": "./dist/agentserver/observability.d.ts",
+      "default": "./dist/agentserver/observability.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.config.json --noEmit"
+  },
+  "dependencies": {
+    "@polymind-inc/agent-framework-a2a": "workspace:*",
+    "@polymind-inc/agent-framework-agentserver": "workspace:*",
+    "@polymind-inc/agent-framework-anthropic": "workspace:*",
+    "@polymind-inc/agent-framework-core": "workspace:*",
+    "@polymind-inc/agent-framework-foundry": "workspace:*",
+    "@polymind-inc/agent-framework-mcp": "workspace:*",
+    "@polymind-inc/agent-framework-openai": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "tsdown": "^0.22.14",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/meta/src/a2a.ts
+++ b/packages/meta/src/a2a.ts
@@ -1,0 +1,2 @@
+// `@polymind-inc/agent-framework/a2a` — re-export of `@polymind-inc/agent-framework-a2a`.
+export * from '@polymind-inc/agent-framework-a2a';

--- a/packages/meta/src/agentserver.ts
+++ b/packages/meta/src/agentserver.ts
@@ -1,0 +1,2 @@
+// `@polymind-inc/agent-framework/agentserver` — re-export of `@polymind-inc/agent-framework-agentserver`.
+export * from '@polymind-inc/agent-framework-agentserver';

--- a/packages/meta/src/agentserver/node.ts
+++ b/packages/meta/src/agentserver/node.ts
@@ -1,0 +1,2 @@
+// `@polymind-inc/agent-framework/agentserver/node` — re-export of `@polymind-inc/agent-framework-agentserver/node`.
+export * from '@polymind-inc/agent-framework-agentserver/node';

--- a/packages/meta/src/agentserver/observability.ts
+++ b/packages/meta/src/agentserver/observability.ts
@@ -1,0 +1,2 @@
+// `@polymind-inc/agent-framework/agentserver/observability` — re-export of `@polymind-inc/agent-framework-agentserver/observability`.
+export * from '@polymind-inc/agent-framework-agentserver/observability';

--- a/packages/meta/src/anthropic.ts
+++ b/packages/meta/src/anthropic.ts
@@ -1,0 +1,2 @@
+// `@polymind-inc/agent-framework/anthropic` — re-export of `@polymind-inc/agent-framework-anthropic`.
+export * from '@polymind-inc/agent-framework-anthropic';

--- a/packages/meta/src/exports.test.ts
+++ b/packages/meta/src/exports.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as sourceA2a from '@polymind-inc/agent-framework-a2a';
+import * as sourceAgentserver from '@polymind-inc/agent-framework-agentserver';
+import * as sourceAgentserverNode from '@polymind-inc/agent-framework-agentserver/node';
+import * as sourceAgentserverObservability from '@polymind-inc/agent-framework-agentserver/observability';
+import * as sourceAnthropic from '@polymind-inc/agent-framework-anthropic';
+import * as sourceCore from '@polymind-inc/agent-framework-core';
+import * as sourceTesting from '@polymind-inc/agent-framework-core/testing';
+import * as sourceFoundry from '@polymind-inc/agent-framework-foundry';
+import * as sourceFoundryHosting from '@polymind-inc/agent-framework-foundry/hosting';
+import * as sourceMcp from '@polymind-inc/agent-framework-mcp';
+import * as sourceOpenai from '@polymind-inc/agent-framework-openai';
+import { describe, expect, it } from 'vitest';
+import * as metaA2a from './a2a.js';
+import * as metaAgentserverNode from './agentserver/node.js';
+import * as metaAgentserverObservability from './agentserver/observability.js';
+import * as metaAgentserver from './agentserver.js';
+import * as metaAnthropic from './anthropic.js';
+import * as metaFoundryHosting from './foundry/hosting.js';
+import * as metaFoundry from './foundry.js';
+import * as metaRoot from './index.js';
+import * as metaMcp from './mcp.js';
+import * as metaOpenai from './openai.js';
+import * as metaTesting from './testing.js';
+
+describe('every entry re-exports its package exactly', () => {
+  const entries: ReadonlyArray<[subpath: string, meta: object, source: object]> = [
+    ['.', metaRoot, sourceCore],
+    ['./testing', metaTesting, sourceTesting],
+    ['./openai', metaOpenai, sourceOpenai],
+    ['./anthropic', metaAnthropic, sourceAnthropic],
+    ['./mcp', metaMcp, sourceMcp],
+    ['./a2a', metaA2a, sourceA2a],
+    ['./foundry', metaFoundry, sourceFoundry],
+    ['./foundry/hosting', metaFoundryHosting, sourceFoundryHosting],
+    ['./agentserver', metaAgentserver, sourceAgentserver],
+    ['./agentserver/node', metaAgentserverNode, sourceAgentserverNode],
+    ['./agentserver/observability', metaAgentserverObservability, sourceAgentserverObservability],
+  ];
+
+  for (const [subpath, meta, source] of entries) {
+    it(subpath, () => {
+      expect(Object.keys(meta).sort()).toEqual(Object.keys(source).sort());
+    });
+  }
+});
+
+describe('the exports map mirrors every dependency subpath', () => {
+  type Manifest = { exports: Record<string, unknown> };
+
+  const readManifest = (relative: string): Manifest =>
+    JSON.parse(readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf8')) as Manifest;
+
+  // Package directory and the subpath prefix its entries are mirrored under; the core sits at
+  // the root, so its prefix is empty.
+  const dependencies: ReadonlyArray<[dir: string, prefix: string]> = [
+    ['core', ''],
+    ['openai', '/openai'],
+    ['anthropic', '/anthropic'],
+    ['mcp', '/mcp'],
+    ['a2a', '/a2a'],
+    ['foundry', '/foundry'],
+    ['agentserver', '/agentserver'],
+  ];
+
+  it('mirrors each subpath, with none missing and none dangling', () => {
+    const expected = new Set(['./package.json']);
+    for (const [dir, prefix] of dependencies) {
+      for (const subpath of Object.keys(readManifest(`../../${dir}/package.json`).exports)) {
+        if (subpath === './package.json') continue;
+        expected.add(`.${prefix}${subpath.slice(1)}`);
+      }
+    }
+
+    const actual = Object.keys(readManifest('../package.json').exports);
+    expect(actual.sort()).toEqual([...expected].sort());
+  });
+});

--- a/packages/meta/src/foundry.ts
+++ b/packages/meta/src/foundry.ts
@@ -1,0 +1,2 @@
+// `@polymind-inc/agent-framework/foundry` — re-export of `@polymind-inc/agent-framework-foundry`.
+export * from '@polymind-inc/agent-framework-foundry';

--- a/packages/meta/src/foundry/hosting.ts
+++ b/packages/meta/src/foundry/hosting.ts
@@ -1,0 +1,2 @@
+// `@polymind-inc/agent-framework/foundry/hosting` — re-export of `@polymind-inc/agent-framework-foundry/hosting`.
+export * from '@polymind-inc/agent-framework-foundry/hosting';

--- a/packages/meta/src/index.ts
+++ b/packages/meta/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * `@polymind-inc/agent-framework` — umbrella package for the Agent Framework.
+ *
+ * The root entry re-exports `@polymind-inc/agent-framework-core`; every other package in the
+ * family is re-exported under a subpath (`/openai`, `/anthropic`, `/mcp`, `/a2a`, `/foundry`,
+ * `/foundry/hosting`, `/agentserver`, `/agentserver/node`, `/agentserver/observability`,
+ * `/testing`). Installing this one package installs them all. ESM only.
+ */
+
+export * from '@polymind-inc/agent-framework-core';

--- a/packages/meta/src/mcp.ts
+++ b/packages/meta/src/mcp.ts
@@ -1,0 +1,2 @@
+// `@polymind-inc/agent-framework/mcp` — re-export of `@polymind-inc/agent-framework-mcp`.
+export * from '@polymind-inc/agent-framework-mcp';

--- a/packages/meta/src/openai.ts
+++ b/packages/meta/src/openai.ts
@@ -1,0 +1,2 @@
+// `@polymind-inc/agent-framework/openai` — re-export of `@polymind-inc/agent-framework-openai`.
+export * from '@polymind-inc/agent-framework-openai';

--- a/packages/meta/src/testing.ts
+++ b/packages/meta/src/testing.ts
@@ -1,0 +1,2 @@
+// `@polymind-inc/agent-framework/testing` — re-export of `@polymind-inc/agent-framework-core/testing`.
+export * from '@polymind-inc/agent-framework-core/testing';

--- a/packages/meta/tsconfig.config.json
+++ b/packages/meta/tsconfig.config.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "declaration": false,
+    "declarationMap": false,
+    "isolatedDeclarations": false
+  },
+  "include": ["tsdown.config.ts", "vitest.config.ts"]
+}

--- a/packages/meta/tsconfig.json
+++ b/packages/meta/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/meta/tsdown.config.ts
+++ b/packages/meta/tsdown.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: [
+    'src/index.ts',
+    'src/testing.ts',
+    'src/openai.ts',
+    'src/anthropic.ts',
+    'src/mcp.ts',
+    'src/a2a.ts',
+    'src/foundry.ts',
+    'src/foundry/hosting.ts',
+    'src/agentserver.ts',
+    'src/agentserver/node.ts',
+    'src/agentserver/observability.ts',
+  ],
+  format: ['esm'],
+  platform: 'node',
+  dts: { oxc: true, sourcemap: false },
+  clean: true,
+  treeshake: true,
+  target: 'es2024',
+  sourcemap: true,
+  outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+  deps: {
+    neverBundle: [
+      '@polymind-inc/agent-framework-a2a',
+      '@polymind-inc/agent-framework-agentserver',
+      '@polymind-inc/agent-framework-anthropic',
+      '@polymind-inc/agent-framework-core',
+      '@polymind-inc/agent-framework-foundry',
+      '@polymind-inc/agent-framework-mcp',
+      '@polymind-inc/agent-framework-openai',
+    ],
+  },
+});

--- a/packages/meta/vitest.config.ts
+++ b/packages/meta/vitest.config.ts
@@ -1,0 +1,30 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+/** Resolves a sibling package source file, so tests run without a prior build. */
+function src(path: string): string {
+  return fileURLToPath(new URL(path, import.meta.url));
+}
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      // Subpath aliases must come before their bare package name: a bare prefix match would
+      // otherwise rewrite the subpath into a path inside the package's index.ts.
+      '@polymind-inc/agent-framework-core/testing': src('../core/src/testing.ts'),
+      '@polymind-inc/agent-framework-core': src('../core/src/index.ts'),
+      '@polymind-inc/agent-framework-foundry/hosting': src('../foundry/src/hosting.ts'),
+      '@polymind-inc/agent-framework-foundry': src('../foundry/src/index.ts'),
+      '@polymind-inc/agent-framework-agentserver/node': src('../agentserver/src/node.ts'),
+      '@polymind-inc/agent-framework-agentserver/observability': src('../agentserver/src/observability.ts'),
+      '@polymind-inc/agent-framework-agentserver': src('../agentserver/src/index.ts'),
+      '@polymind-inc/agent-framework-openai': src('../openai/src/index.ts'),
+      '@polymind-inc/agent-framework-anthropic': src('../anthropic/src/index.ts'),
+      '@polymind-inc/agent-framework-mcp': src('../mcp/src/index.ts'),
+      '@polymind-inc/agent-framework-a2a': src('../a2a/src/index.ts'),
+    },
+  },
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,6 +316,43 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
 
+  packages/meta:
+    dependencies:
+      '@polymind-inc/agent-framework-a2a':
+        specifier: workspace:*
+        version: link:../a2a
+      '@polymind-inc/agent-framework-agentserver':
+        specifier: workspace:*
+        version: link:../agentserver
+      '@polymind-inc/agent-framework-anthropic':
+        specifier: workspace:*
+        version: link:../anthropic
+      '@polymind-inc/agent-framework-core':
+        specifier: workspace:*
+        version: link:../core
+      '@polymind-inc/agent-framework-foundry':
+        specifier: workspace:*
+        version: link:../foundry
+      '@polymind-inc/agent-framework-mcp':
+        specifier: workspace:*
+        version: link:../mcp
+      '@polymind-inc/agent-framework-openai':
+        specifier: workspace:*
+        version: link:../openai
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.3
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+
   packages/openai:
     dependencies:
       '@polymind-inc/agent-framework-core':

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 // Sets the version of every publishable package. All packages ship in lockstep, so they always
-// carry the same version; internal dependencies use `workspace:^` and are rewritten at publish
-// time by pnpm, so those need no edit.
+// carry the same version; internal dependencies use the `workspace:` protocol (`workspace:^`, or
+// `workspace:*` where a package pins its siblings exactly) and are rewritten to the real version
+// at publish time by pnpm, so those need no edit.
 //
 // Three packages also carry the version as a source constant, because they report it at runtime
 // (OpenTelemetry instrumentation scope, the hosting server identity, the MCP handshake) and the


### PR DESCRIPTION
## Summary

Adds `@polymind-inc/agent-framework` (workspace directory `packages/meta`) — one install for the whole family, mirroring what `pip install agent-framework` gives you in the Python implementation.

- Depends on every granular package and re-exports each under a subpath: the root entry is the core, and `/testing`, `/openai`, `/anthropic`, `/mcp`, `/a2a`, `/foundry`, `/foundry/hosting`, `/agentserver`, `/agentserver/node`, `/agentserver/observability` map one-to-one onto the packages they re-export.
- Subpaths are plain static re-exports — bundlers tree-shake whatever is not imported. The granular packages are unchanged and remain the smaller install.
- Sibling dependencies are pinned exactly (`workspace:*` → real version at publish time), so the umbrella can never resolve a sibling whose export surface it does not mirror. Same call Vue makes for its `@vue/*` constituents. The `set-version.mjs` header comment now describes both `workspace:` forms.
- Because the umbrella hard-depends on the agentserver package, the foundry package's optional peer on it is satisfied by a plain install and `/foundry/hosting` works out of the box.
- `packages/meta/src/exports.test.ts` guards the mirror in both directions: each entry's runtime exports must equal its source package's, and the exports map is checked against every sibling manifest — adding a subpath to a sibling without mirroring it here fails CI.
- Docs (README, CHANGELOG, CONTRIBUTING, SECURITY, CLAUDE.md) updated to cover the new package.

Note for the release that ships this: it is a new package, so the next version should be a minor bump (0.2.0), and its very first publish needs the `NPM_TOKEN` fallback — a trusted publisher cannot be configured before the package exists.

## Test plan

- [x] `pnpm check` (lint → build → typecheck → test → pack:check) passes; pack-check reports all packages, including the new one, packing cleanly
- [x] Packed manifest verified: `workspace:*` rewrites to the exact lockstep version, no range operators
- [x] Node smoke test against the built `dist/`: root, `/openai`, `/foundry/hosting` and `/testing` all resolve and expose the expected symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)