### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-All `@polymind-inc/agent-framework-*` packages are versioned in lockstep; one entry here covers the
-set. During 0.x, **minor releases may contain breaking changes**; patch releases are fixes only.
+The umbrella `@polymind-inc/agent-framework` package and all `@polymind-inc/agent-framework-*`
+packages are versioned in lockstep; one entry here covers the set. During 0.x, **minor releases may
+contain breaking changes**; patch releases are fixes only.
 
-## Unreleased
+## 0.2.0
 
 One new package; no change to any existing published API.
 

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymind-inc/agent-framework-a2a",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Agent2Agent (A2A) protocol client for the Agent Framework: use a remote A2A agent as an agent.",
   "keywords": [
     "agent",

--- a/packages/agentserver/package.json
+++ b/packages/agentserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymind-inc/agent-framework-agentserver",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Microsoft Foundry Responses container protocol v2.0.0 server. Independent of the Agent Framework.",
   "keywords": [
     "agent",

--- a/packages/agentserver/src/config.ts
+++ b/packages/agentserver/src/config.ts
@@ -120,7 +120,7 @@ export function stateRoot(): string {
 }
 
 /** This package's version. Keep in sync with `version` in package.json — a unit test enforces it. */
-export const PACKAGE_VERSION = '0.1.1';
+export const PACKAGE_VERSION = '0.2.0';
 
 /** The `x-platform-server` value: which SDK, which protocol, which runtime. */
 export function serverIdentity(): string {

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymind-inc/agent-framework-anthropic",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Anthropic Messages API chat client for the Agent Framework, built on the official @anthropic-ai/sdk.",
   "keywords": [
     "agent",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymind-inc/agent-framework-core",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Core abstractions for the Agent Framework (TypeScript): Agent, AgentSession, Message/Content, tools, and the ChatClient seam.",
   "keywords": [
     "agent",

--- a/packages/core/src/observability/version.ts
+++ b/packages/core/src/observability/version.ts
@@ -5,4 +5,4 @@
  * Kept in sync with the `version` field in package.json; a unit test enforces
  * the match.
  */
-export const INSTRUMENTATION_VERSION = '0.1.1';
+export const INSTRUMENTATION_VERSION = '0.2.0';

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymind-inc/agent-framework-foundry",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Microsoft Foundry chat client and Hosted Agent hosting adapter for the Agent Framework.",
   "keywords": [
     "agent",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymind-inc/agent-framework-mcp",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Model Context Protocol client integration for the Agent Framework: MCP server tools as framework tools.",
   "keywords": [
     "agent",

--- a/packages/mcp/src/connection.ts
+++ b/packages/mcp/src/connection.ts
@@ -7,7 +7,7 @@ import { GEN_AI, MCP, setMcpSpanError, withMcpClientSpan } from '@polymind-inc/a
  *
  * Kept in sync with `version` in this package's package.json; a unit test enforces the match.
  */
-export const MCP_CLIENT_VERSION = '0.1.1';
+export const MCP_CLIENT_VERSION = '0.2.0';
 
 /** The identity reported to servers when the consumer supplies no `clientInfo` of its own. */
 const DEFAULT_CLIENT_INFO = { name: 'agent-framework-js', version: MCP_CLIENT_VERSION };

--- a/packages/meta/package.json
+++ b/packages/meta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymind-inc/agent-framework",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Umbrella package for the Agent Framework (TypeScript): one install for the core, the OpenAI / Anthropic / Foundry providers, MCP, A2A and hosting, each re-exported under a subpath.",
   "keywords": [
     "agent",

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymind-inc/agent-framework-openai",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "OpenAI (and Azure OpenAI) chat client for the Agent Framework, built on the official openai SDK.",
   "keywords": [
     "agent",


### PR DESCRIPTION
## Summary

Version bump for the 0.2.0 release: every package moves to 0.2.0 in lockstep, the three source version constants (OpenTelemetry instrumentation scope, hosting server identity, MCP handshake) are updated by `set-version.mjs`, and the changelog's Unreleased section becomes the 0.2.0 entry.

0.2.0 ships the new `@polymind-inc/agent-framework` umbrella package (#4) plus the two fixes already on master: the agentserver routing regression (backtracking regex on trailing slashes) and the core id-generation hardening (`crypto.randomUUID` without a `Math.random` fallback).

After this merges, publishing is: create the `v0.2.0` GitHub Release (or push the tag), and the release workflow re-runs the full gate and publishes all packages to npm. The umbrella package's first publish uses the `NPM_TOKEN` fallback, which is confirmed present in the release environment.

## Test plan

- [x] `pnpm check` passes on the bump; pack-check reports all packages at 0.2.0 packing cleanly
- [x] The version-constant unit tests (which compare each constant against its package.json) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)