### PR TITLE
Approval durability, empty-response parity, server shutdown, and toolchain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,15 @@ updates:
       interval: weekly
     commit-message:
       prefix: 'ci'
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      production-dependencies:
+        dependency-type: production
+      development-dependencies:
+        dependency-type: development
+    commit-message:
+      prefix: 'deps'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,11 @@ jobs:
       # v6 is the first release that supports pnpm 11, which `packageManager` pins us to.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
-      # setup-node caches automatically only for npm, so pnpm needs `cache` set explicitly.
-      # It also has to run after pnpm is on PATH for the cache lookup to work.
+      # Release installs deliberately skip the package-manager cache, keeping the publish job's
+      # dependency inputs limited to the signed lockfile and registry responses for this run.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: pnpm
           registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ Deliberate divergences, and the reason for each:
 ## Requirements
 
 - **Node.js >= 24** (active LTS). ESM only — there is no CommonJS build.
-- **TypeScript**: type resolution is verified with TypeScript 7 under `moduleResolution: bundler`,
-  `node16` and `nodenext`. Declarations are emitted with `isolatedDeclarations`.
+- **TypeScript**: type resolution is verified with TypeScript 7 under `moduleResolution: bundler`
+  and `nodenext`. Declarations are emitted with `isolatedDeclarations`.
 
 ## Examples
 

--- a/examples/01-get-started/package.json
+++ b/examples/01-get-started/package.json
@@ -22,8 +22,8 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/node": "^24.0.0",
-    "tsx": "^4.23.1",
-    "typescript": "^7.0.2"
+    "@types/node": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/examples/02-foundry/package.json
+++ b/examples/02-foundry/package.json
@@ -21,9 +21,9 @@
     "@polymind-inc/agent-framework-foundry": "workspace:^"
   },
   "devDependencies": {
-    "@types/node": "^24.0.0",
-    "tsdown": "^0.22.14",
-    "tsx": "^4.23.1",
-    "typescript": "^7.0.2"
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/examples/03-extensibility/package.json
+++ b/examples/03-extensibility/package.json
@@ -22,8 +22,8 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/node": "^24.0.0",
-    "tsx": "^4.23.1",
-    "typescript": "^7.0.2"
+    "@types/node": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/examples/04-a2a/package.json
+++ b/examples/04-a2a/package.json
@@ -21,9 +21,9 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
-    "@types/node": "^24.0.0",
+    "@types/node": "catalog:",
     "express": "^5.1.0",
-    "tsx": "^4.23.1",
-    "typescript": "^7.0.2"
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "author": "shibayan <me@shibayan.jp>",
   "type": "module",
-  "packageManager": "pnpm@11.18.0",
+  "packageManager": "pnpm@11.20.0",
   "engines": {
     "node": ">=24"
   },
@@ -20,7 +20,8 @@
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "test:coverage": "vitest run --coverage --testTimeout=30000",
-    "typecheck": "pnpm -r typecheck",
+    "typecheck": "pnpm -r typecheck && pnpm run typecheck:resolution",
+    "typecheck:resolution": "tsc -p scripts/type-resolution/tsconfig.json --module nodenext --moduleResolution nodenext",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
@@ -32,10 +33,10 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.6",
-    "@types/node": "^24.0.0",
-    "@vitest/coverage-v8": "4.1.10",
-    "tsdown": "^0.22.14",
-    "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
+    "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -52,8 +52,8 @@
     "@polymind-inc/agent-framework-core": "workspace:^"
   },
   "devDependencies": {
-    "tsdown": "^0.22.14",
-    "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/a2a/tsconfig.config.json
+++ b/packages/a2a/tsconfig.config.json
@@ -1,10 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node"],
-    "declaration": false,
-    "declarationMap": false,
-    "isolatedDeclarations": false
-  },
+  "extends": "../../tsconfig.tools.json",
   "include": ["tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/agentserver/package.json
+++ b/packages/agentserver/package.json
@@ -81,9 +81,9 @@
   "devDependencies": {
     "@opentelemetry/exporter-metrics-otlp-grpc": "^0.221.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.221.0",
-    "@types/node": "^24.0.0",
-    "tsdown": "^0.22.14",
-    "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/agentserver/src/node.test.ts
+++ b/packages/agentserver/src/node.test.ts
@@ -104,6 +104,30 @@ describe('node adapter', () => {
     });
     expect(response.headers.get('x-platform-error-source')).toBe('user');
   });
+
+  it('removes its process signal handlers when closed', async () => {
+    const before = {
+      sigterm: process.listenerCount('SIGTERM'),
+      sigint: process.listenerCount('SIGINT'),
+    };
+    const signalled = await serve(new ResponsesServer({ handler: echo }), {
+      port: 0,
+      host: '127.0.0.1',
+      observability: false,
+    });
+    try {
+      expect(process.listenerCount('SIGTERM')).toBe(before.sigterm + 1);
+      expect(process.listenerCount('SIGINT')).toBe(before.sigint + 1);
+    } finally {
+      await signalled.close();
+    }
+    expect(process.listenerCount('SIGTERM')).toBe(before.sigterm);
+    expect(process.listenerCount('SIGINT')).toBe(before.sigint);
+    // Closing is idempotent and does not re-register anything.
+    await signalled.close();
+    expect(process.listenerCount('SIGTERM')).toBe(before.sigterm);
+    expect(process.listenerCount('SIGINT')).toBe(before.sigint);
+  });
 });
 
 describe('backpressure', () => {

--- a/packages/agentserver/src/node.ts
+++ b/packages/agentserver/src/node.ts
@@ -114,30 +114,43 @@ export async function serve(app: ResponsesServer, options: ServeOptions = {}): P
       const address = server.address();
       const boundPort = typeof address === 'object' && address !== null ? address.port : port;
 
-      const close = async (): Promise<void> => {
-        const deadline = Date.now() + gracefulShutdownSeconds() * 1000;
-        const drained = app.drain();
-        await new Promise<void>((done) => {
-          const timer = setTimeout(() => {
-            server.closeAllConnections?.();
-            done();
-          }, gracefulShutdownSeconds() * 1000);
-          timer.unref?.();
-          server.close(() => {
-            clearTimeout(timer);
-            done();
+      let stop: (() => void) | undefined;
+      let closePromise: Promise<void> | undefined;
+      const close = (): Promise<void> => {
+        if (closePromise !== undefined) {
+          return closePromise;
+        }
+        if (stop !== undefined) {
+          process.removeListener('SIGTERM', stop);
+          process.removeListener('SIGINT', stop);
+          stop = undefined;
+        }
+        closePromise = (async (): Promise<void> => {
+          const deadline = Date.now() + gracefulShutdownSeconds() * 1000;
+          const drained = app.drain();
+          await new Promise<void>((done) => {
+            const timer = setTimeout(() => {
+              server.closeAllConnections?.();
+              done();
+            }, gracefulShutdownSeconds() * 1000);
+            timer.unref?.();
+            server.close(() => {
+              clearTimeout(timer);
+              done();
+            });
           });
-        });
-        // Detached background runs are not connections, so `server.close` never waits for them.
-        // Give them what is left of the grace period to persist their terminal state — the
-        // Python shutdown handler holds the process for its background records the same way.
-        await raceTimeout(drained, Math.max(0, deadline - Date.now()));
-        // Whatever the drained turns recorded leaves with the process, not with the batch timer.
-        await flushTelemetry();
+          // Detached background runs are not connections, so `server.close` never waits for them.
+          // Give them what is left of the grace period to persist their terminal state — the
+          // Python shutdown handler holds the process for its background records the same way.
+          await raceTimeout(drained, Math.max(0, deadline - Date.now()));
+          // Whatever the drained turns recorded leaves with the process, not with the batch timer.
+          await flushTelemetry();
+        })();
+        return closePromise;
       };
 
       if (options.handleSignals !== false) {
-        const stop = (): void => {
+        stop = (): void => {
           void close().then(() => process.exit(0));
         };
         process.once('SIGTERM', stop);

--- a/packages/agentserver/src/server.ts
+++ b/packages/agentserver/src/server.ts
@@ -210,7 +210,7 @@ class BackgroundRun {
 
   readonly #maxEvents: number;
   #waiters: Array<() => void> = [];
-  #firstEventSeen!: () => void;
+  readonly #firstEventSeen: () => void;
   /** Resolves once the first event was folded (or the run ended): the non-stream 200 boundary. */
   readonly firstEvent: Promise<void>;
 
@@ -239,9 +239,9 @@ class BackgroundRun {
     this.abort = options.abort;
     this.persistSnapshot = options.persistSnapshot;
     this.#maxEvents = options.maxEvents;
-    this.firstEvent = new Promise<void>((resolve) => {
-      this.#firstEventSeen = resolve;
-    });
+    const { promise, resolve } = Promise.withResolvers<void>();
+    this.firstEvent = promise;
+    this.#firstEventSeen = resolve;
   }
 
   /**
@@ -397,12 +397,10 @@ interface IdClaim {
 
 /** A claim and its wait, in the one place both are created. */
 function newClaim(owner: ResponseOwner, generation: ResponseGeneration): IdClaim {
-  let settle!: (work?: Promise<void>) => void;
-  const done = new Promise<void>((resolve) => {
-    // A failure is still a completion as far as a shutdown is concerned: `drain()` waits for the
-    // turn to be *over*, not to have succeeded.
-    settle = (work) => resolve(work?.then(undefined, () => undefined));
-  });
+  const { promise: done, resolve } = Promise.withResolvers<void>();
+  // A failure is still a completion as far as a shutdown is concerned: `drain()` waits for the
+  // turn to be *over*, not to have succeeded.
+  const settle = (work?: Promise<void>): void => resolve(work?.then(undefined, () => undefined));
   return { owner, generation, run: undefined, done, settle };
 }
 

--- a/packages/agentserver/tsconfig.config.json
+++ b/packages/agentserver/tsconfig.config.json
@@ -1,10 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node"],
-    "declaration": false,
-    "declarationMap": false,
-    "isolatedDeclarations": false
-  },
+  "extends": "../../tsconfig.tools.json",
   "include": ["tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -52,8 +52,8 @@
     "@anthropic-ai/sdk": "^0.115.0"
   },
   "devDependencies": {
-    "tsdown": "^0.22.14",
-    "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/anthropic/tsconfig.config.json
+++ b/packages/anthropic/tsconfig.config.json
@@ -1,10 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node"],
-    "declaration": false,
-    "declarationMap": false,
-    "isolatedDeclarations": false
-  },
+  "extends": "../../tsconfig.tools.json",
   "include": ["tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,8 +61,8 @@
     "@opentelemetry/resources": "^2.10.0",
     "@opentelemetry/sdk-metrics": "^2.10.0",
     "@opentelemetry/sdk-trace-base": "^2.10.0",
-    "tsdown": "^0.22.14",
-    "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/core/src/client/function-invocation.test.ts
+++ b/packages/core/src/client/function-invocation.test.ts
@@ -4,6 +4,7 @@ import { functionMiddleware } from '../middleware/middleware.js';
 import { invocationCountOf, resetInvocationCount, tool } from '../tools/tool.js';
 import type {
   Content,
+  FunctionApprovalRequestContent,
   FunctionCallContent,
   FunctionResultContent,
   UserInputRequestContent,
@@ -300,6 +301,24 @@ describe('withFunctionInvocation', () => {
     expect(inner.calls[2]?.options?.tools).toBeUndefined();
     expect(inner.calls[2]?.options?.toolChoice).toBe('auto');
   });
+
+  it.each([0, -1, 0.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid maxIterations value %s',
+    (maxIterations) => {
+      expect(() => withFunctionInvocation(new MockChatClient([]), { maxIterations })).toThrow(
+        ConfigurationError,
+      );
+    },
+  );
+
+  it.each([-1, 0.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid maxConsecutiveErrors value %s',
+    (maxConsecutiveErrors) => {
+      expect(() => withFunctionInvocation(new MockChatClient([]), { maxConsecutiveErrors })).toThrow(
+        ConfigurationError,
+      );
+    },
+  );
 
   it('defaults to 40 iterations and 3 consecutive errors', async () => {
     const looping = tool({
@@ -833,6 +852,48 @@ describe('toolChoice across the approval boundary (Go parity)', () => {
     );
 
     expect(mock.calls[0]?.options?.toolChoice).toBe('auto');
+  });
+});
+
+describe('replayed unanswered approval requests', () => {
+  it('re-surfaces them and pauses instead of calling the model', async () => {
+    // A transcript-replaying caller can send a turn that still contains an approval request the
+    // human never answered. Silently stripping it and letting the model run would answer a
+    // conversation in which the gated call simply vanished.
+    const gated = tool({
+      name: 'gated',
+      description: 'Needs a human',
+      parameters: { type: 'object', properties: {} },
+      approvalMode: 'always_require',
+      execute: (() => 'ran') as never,
+    });
+    const mock = new MockChatClient([{ contents: [textContent('unreachable')], finishReason: 'stop' }]);
+    const client = withFunctionInvocation(mock);
+
+    const response = await client.getResponse(
+      [
+        { role: 'user', contents: [textContent('do it')] },
+        {
+          role: 'assistant',
+          contents: [
+            {
+              type: 'function_approval_request',
+              id: 'a1',
+              userInputRequest: true,
+              functionCall: call('c1', 'gated'),
+            },
+          ],
+        },
+      ],
+      { tools: [gated] } as ChatOptions,
+    );
+
+    expect(mock.callCount).toBe(0);
+    const requests = response.messages
+      .flatMap((msg) => msg.contents)
+      .filter((c): c is FunctionApprovalRequestContent => c.type === 'function_approval_request');
+    expect(requests.map((request) => request.id)).toEqual(['a1']);
+    expect(requests.map((request) => request.functionCall.callId)).toEqual(['c1']);
   });
 });
 

--- a/packages/core/src/client/function-invocation.ts
+++ b/packages/core/src/client/function-invocation.ts
@@ -1,5 +1,6 @@
 import type { AgentSession } from '../agent/session.js';
 import {
+  ConfigurationError,
   MiddlewareTerminated,
   ToolInvocationError,
   throwIfAborted,
@@ -39,7 +40,8 @@ export interface FunctionInvocationConfig {
   /** Set to `false` to pass calls straight through to the caller. Default `true`. */
   enabled?: boolean;
   /**
-   * Maximum number of tool rounds per run. Default `40`, matching .NET and Go.
+   * Maximum number of tool rounds per run. Must be a positive safe integer. Default `40`,
+   * matching .NET and Go.
    *
    * On hitting the limit the loop makes one final model call with the function tools removed, so
    * the run always ends with an assistant message rather than an unanswered tool call.
@@ -47,8 +49,9 @@ export interface FunctionInvocationConfig {
   maxIterations?: number;
   /**
    * Consecutive failing rounds tolerated before the aggregated error is thrown to the caller.
-   * Default `3`. A round without failures resets the counter; unknown-tool ("not found") results
-   * are reported to the model but do not count as failures.
+   * Must be a non-negative safe integer. Default `3`. A round without failures resets the
+   * counter; unknown-tool ("not found") results are reported to the model but do not count as
+   * failures.
    */
   maxConsecutiveErrors?: number;
   /** Stop the loop when the model calls an unknown tool instead of returning an error result. Default `false`. */
@@ -81,6 +84,14 @@ const REJECTED_RESULT_TEXT = 'Error: Tool call invocation was rejected by user.'
  * `Content.from_function_result(result=…, exception="UserInputRequiredException")`.
  */
 const USER_INPUT_UNAVAILABLE_RESULT_TEXT = 'Tool requires user input but no request details were provided.';
+
+/** Validates a numeric loop limit at the configuration boundary. */
+function loopLimit(name: 'maxIterations' | 'maxConsecutiveErrors', value: number, minimum: number): number {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new ConfigurationError(`${name} must be a safe integer greater than or equal to ${minimum}.`);
+  }
+  return value;
+}
 
 /** A `function_call` this layer is expected to act on, rather than one the provider already ran. */
 function isPendingCall(content: Content): content is FunctionCallContent {
@@ -697,8 +708,12 @@ export function withFunctionInvocation<TOptions extends ChatOptions>(
   config: FunctionInvocationConfig = {},
 ): ChatClient<TOptions> {
   const enabled = config.enabled ?? true;
-  const maxIterations = config.maxIterations ?? DEFAULT_MAX_ITERATIONS;
-  const maxConsecutiveErrors = config.maxConsecutiveErrors ?? DEFAULT_MAX_CONSECUTIVE_ERRORS;
+  const maxIterations = loopLimit('maxIterations', config.maxIterations ?? DEFAULT_MAX_ITERATIONS, 1);
+  const maxConsecutiveErrors = loopLimit(
+    'maxConsecutiveErrors',
+    config.maxConsecutiveErrors ?? DEFAULT_MAX_CONSECUTIVE_ERRORS,
+    0,
+  );
   const terminateOnUnknownCalls = config.terminateOnUnknownCalls ?? false;
   const includeDetailedErrors = config.includeDetailedErrors ?? false;
   const allowConcurrentInvocations = config.allowConcurrentInvocations ?? false;
@@ -812,6 +827,7 @@ export function withFunctionInvocation<TOptions extends ChatOptions>(
   > {
     const answered = new Set<string>();
     const respondedCallIds = new Set<string>();
+    const requested = new Map<string, FunctionApprovalRequestContent>();
     let hasApprovalContent = false;
     for (const msg of messages) {
       for (const content of msg.contents) {
@@ -822,7 +838,9 @@ export function withFunctionInvocation<TOptions extends ChatOptions>(
           !isHostedApproval(content)
         ) {
           hasApprovalContent = true;
-          if (isApprovalResponse(content)) {
+          if (isApprovalRequest(content)) {
+            requested.set(content.functionCall.callId, content);
+          } else {
             respondedCallIds.add(content.functionCall.callId);
           }
         }
@@ -832,8 +850,13 @@ export function withFunctionInvocation<TOptions extends ChatOptions>(
       return undefined;
     }
 
-    // Strip every local approval control item. Anything still pending is re-materialized below as
-    // a synthesized assistant tool-call message, which is where the model expects it.
+    const pending = [...requested.entries()]
+      .filter(([callId]) => !answered.has(callId) && !respondedCallIds.has(callId))
+      .map(([, request]) => request);
+
+    // Strip every local approval control item from provider-visible history. Answered calls are
+    // re-materialized below as assistant tool calls; unanswered requests are returned to the
+    // caller again and keep the loop paused.
     const history: Message[] = [];
     const decided = new Map<string, { approved: boolean; call: FunctionCallContent; reason?: string }>();
     for (const msg of messages) {
@@ -879,7 +902,19 @@ export function withFunctionInvocation<TOptions extends ChatOptions>(
     }
 
     if (decided.size === 0) {
-      return { history, emitted: [], terminated: false, errorCount: 0, invoked: false };
+      if (pending.length === 0) {
+        return { history, emitted: [], terminated: false, errorCount: 0, invoked: false };
+      }
+      // No decision arrived, but unanswered requests did (a replayed transcript). Running the
+      // model against a history the gated calls were stripped from would answer a conversation
+      // in which they never happened, so the requests go back to the caller instead.
+      return {
+        history,
+        emitted: [{ role: 'assistant', contents: pending, messageId: crypto.randomUUID() }],
+        terminated: true,
+        errorCount: 0,
+        invoked: false,
+      };
     }
 
     const decisions = [...decided.values()];
@@ -916,10 +951,13 @@ export function withFunctionInvocation<TOptions extends ChatOptions>(
     if (outcome !== undefined && outcome.approvals.length > 0) {
       emitted.push({ role: 'assistant', contents: outcome.approvals, messageId: crypto.randomUUID() });
     }
+    if (pending.length > 0) {
+      emitted.push({ role: 'assistant', contents: pending, messageId: crypto.randomUUID() });
+    }
     return {
       history: [...history, callMessage, resultMessage],
       emitted,
-      terminated: outcome?.terminated === true,
+      terminated: outcome?.terminated === true || pending.length > 0,
       invoked: outcome !== undefined,
       // The error budget is shared across the whole run, resumed calls included: restarting at
       // zero here would let a tool that fails on every turn be retried forever by re-approving it.

--- a/packages/core/src/client/tool-approval.test.ts
+++ b/packages/core/src/client/tool-approval.test.ts
@@ -12,6 +12,7 @@ import type {
   Content,
   FunctionApprovalRequestContent,
   FunctionApprovalResponseContent,
+  FunctionCallContent,
 } from '../types/content.js';
 import { textContent } from '../types/content.js';
 import type { Message } from '../types/message.js';
@@ -32,7 +33,7 @@ const readOnly = tool({
   execute: async () => 'read',
 });
 
-function call(callId: string, name: string): Content {
+function call(callId: string, name: string): FunctionCallContent {
   return { type: 'function_call', callId, name, arguments: '{}' };
 }
 
@@ -115,6 +116,46 @@ describe('tool approval', () => {
       ['c1', 'Error: Tool call invocation was rejected by user. too risky'],
     ]);
     expect(resumed.text).toBe('understood');
+  });
+
+  it('keeps unanswered requests pending when only part of an approval batch is answered', async () => {
+    const executed: string[] = [];
+    const gated = tool({
+      name: 'gated',
+      description: 'Needs a human',
+      parameters: { type: 'object', properties: { value: { type: 'string' } } },
+      approvalMode: 'always_require',
+      execute: async (input) => {
+        const value = String(input.value);
+        executed.push(value);
+        return value;
+      },
+    });
+    const mock = new MockChatClient([
+      {
+        contents: [
+          { ...call('c1', 'gated'), arguments: '{"value":"first"}' },
+          { ...call('c2', 'gated'), arguments: '{"value":"second"}' },
+        ],
+        finishReason: 'tool_calls',
+      },
+      { contents: [textContent('done')], finishReason: 'stop' },
+    ]);
+    const agent = new Agent({ client: mock, tools: [gated] });
+    const session = agent.createSession();
+
+    const first = await agent.run('do both', { session });
+    const [firstRequest, secondRequest] = approvals(first);
+    const partial = await agent.run(approvalResponse(must(firstRequest), true), { session });
+
+    expect(executed).toEqual(['first']);
+    expect(mock.callCount).toBe(1);
+    expect(approvals(partial).map((request) => request.functionCall.callId)).toEqual(['c2']);
+
+    const resumed = await agent.run(approvalResponse(must(secondRequest), true), { session });
+    expect(executed).toEqual(['first', 'second']);
+    expect(resumed.text).toBe('done');
+    expect(session.state._toolApproval).toBeUndefined();
   });
 
   it('treats malformed approval content as inert instead of crashing', async () => {

--- a/packages/core/src/client/tool-approval.ts
+++ b/packages/core/src/client/tool-approval.ts
@@ -150,6 +150,7 @@ function sameCall(a: FunctionCallContent, b: FunctionCallContent): boolean {
 function bindInboundDecisions(messages: readonly Message[], store: ApprovalStateStore): Message[] {
   const known = new Map<string, FunctionApprovalRequestContent>();
   const fromStore = new Set<string>();
+  const answeredCallIds = new Set<string>();
   for (const request of store.takePending()) {
     known.set(request.id, request);
     fromStore.add(request.id);
@@ -158,6 +159,9 @@ function bindInboundDecisions(messages: readonly Message[], store: ApprovalState
   let hasDecision = false;
   for (const msg of messages) {
     for (const content of msg.contents) {
+      if (content.type === 'function_result') {
+        answeredCallIds.add(content.callId);
+      }
       if (isHostedApproval(content)) {
         // Not ours to bind: the provider issued it and the provider checks it.
         continue;
@@ -171,7 +175,15 @@ function bindInboundDecisions(messages: readonly Message[], store: ApprovalState
       }
     }
   }
+  for (const [id, request] of known) {
+    if (answeredCallIds.has(request.functionCall.callId)) {
+      known.delete(id);
+    }
+  }
   if (!hasDecision) {
+    // `takePending` is destructive, but an unrelated turn must not consume approvals that the
+    // caller has not answered yet.
+    store.addPending([...known.values()]);
     return [...messages];
   }
 
@@ -204,6 +216,15 @@ function bindInboundDecisions(messages: readonly Message[], store: ApprovalState
     } else if (kept.length > 0) {
       out.push({ ...msg, contents: kept });
     }
+  }
+
+  // A caller may answer only part of a batch. Keep the remaining requests durable and inject
+  // them into this turn so the invocation loop can surface them again instead of silently
+  // consuming them when `takePending` cleared the store.
+  const pending = [...known.values()];
+  store.addPending(pending);
+  if (pending.length > 0) {
+    out.push({ role: 'assistant', contents: pending, messageId: crypto.randomUUID() });
   }
   return out;
 }

--- a/packages/core/src/types/response.test.ts
+++ b/packages/core/src/types/response.test.ts
@@ -183,12 +183,12 @@ describe('chatResponseToUpdates', () => {
     expect(restored.additionalProperties).toEqual({ metadata: { tenant: 'contoso' } });
   });
 
-  it('emits a metadata-only update for a response with no messages', () => {
+  it('emits no updates for an empty response', () => {
     const updates: ChatResponseUpdate[] = chatResponseToUpdates(
       chatResponse<undefined>({ messages: [], responseId: 'resp_2' }),
     );
-    expect(updates).toHaveLength(1);
-    expect(updates[0]?.responseId).toBe('resp_2');
+    expect(updates).toEqual([]);
+    expect(mergeChatUpdates(updates).messages).toEqual([]);
   });
 });
 

--- a/packages/core/src/types/response.ts
+++ b/packages/core/src/types/response.ts
@@ -372,12 +372,7 @@ function responseToUpdates(
 
   // Go gates the trailing update on a non-zero usage record (`!isZeroUsage`), not mere presence.
   const hasUsage = !isEmptyUsage(response.usageDetails);
-  if (
-    hasUsage ||
-    response.additionalProperties !== undefined ||
-    response.continuationToken !== undefined ||
-    inits.length === 0
-  ) {
+  if (hasUsage || response.additionalProperties !== undefined || response.continuationToken !== undefined) {
     const init: ResponseUpdateInitBase = {
       contents: hasUsage ? [{ type: 'usage', usageDetails: response.usageDetails as UsageDetails }] : [],
     };

--- a/packages/core/tsconfig.config.json
+++ b/packages/core/tsconfig.config.json
@@ -1,10 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node"],
-    "declaration": false,
-    "declarationMap": false,
-    "isolatedDeclarations": false
-  },
+  "extends": "../../tsconfig.tools.json",
   "include": ["tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -58,7 +58,7 @@
     "@polymind-inc/agent-framework-openai": "workspace:^",
     "@azure/identity": "^4.13.1",
     "@modelcontextprotocol/client": "^2.0.0",
-    "openai": "^7.2.0"
+    "openai": "catalog:"
   },
   "peerDependencies": {
     "@polymind-inc/agent-framework-agentserver": "workspace:^"
@@ -72,9 +72,9 @@
     "@polymind-inc/agent-framework-agentserver": "workspace:^",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/sdk-metrics": "^2.10.0",
-    "@types/node": "^24.0.0",
-    "tsdown": "^0.22.14",
-    "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/foundry/tsconfig.config.json
+++ b/packages/foundry/tsconfig.config.json
@@ -1,10 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node"],
-    "declaration": false,
-    "declarationMap": false,
-    "isolatedDeclarations": false
-  },
+  "extends": "../../tsconfig.tools.json",
   "include": ["tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -55,8 +55,8 @@
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/context-async-hooks": "^2.10.0",
     "@opentelemetry/sdk-trace-base": "^2.10.0",
-    "tsdown": "^0.22.14",
-    "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/mcp/tsconfig.config.json
+++ b/packages/mcp/tsconfig.config.json
@@ -1,10 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node"],
-    "declaration": false,
-    "declarationMap": false,
-    "isolatedDeclarations": false
-  },
+  "extends": "../../tsconfig.tools.json",
   "include": ["tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/meta/package.json
+++ b/packages/meta/package.json
@@ -101,9 +101,9 @@
     "@polymind-inc/agent-framework-openai": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^24.0.0",
-    "tsdown": "^0.22.14",
-    "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/meta/tsconfig.config.json
+++ b/packages/meta/tsconfig.config.json
@@ -1,10 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node"],
-    "declaration": false,
-    "declarationMap": false,
-    "isolatedDeclarations": false
-  },
+  "extends": "../../tsconfig.tools.json",
   "include": ["tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -50,11 +50,11 @@
   },
   "dependencies": {
     "@polymind-inc/agent-framework-core": "workspace:^",
-    "openai": "^7.2.0"
+    "openai": "catalog:"
   },
   "devDependencies": {
-    "tsdown": "^0.22.14",
-    "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/openai/tsconfig.config.json
+++ b/packages/openai/tsconfig.config.json
@@ -1,10 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node"],
-    "declaration": false,
-    "declarationMap": false,
-    "isolatedDeclarations": false
-  },
+  "extends": "../../tsconfig.tools.json",
   "include": ["tsdown.config.ts", "vitest.config.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,30 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@types/node':
+      specifier: ^24.0.0
+      version: 24.13.3
+    '@vitest/coverage-v8':
+      specifier: 4.1.10
+      version: 4.1.10
+    openai:
+      specifier: ^7.4.0
+      version: 7.4.0
+    tsdown:
+      specifier: ^0.22.14
+      version: 0.22.14
+    tsx:
+      specifier: ^4.23.5
+      version: 4.23.5
+    typescript:
+      specifier: ^7.0.2
+      version: 7.0.2
+    vitest:
+      specifier: ^4.1.10
+      version: 4.1.10
+
 importers:
 
   .:
@@ -12,20 +36,20 @@ importers:
         specifier: ^2.5.6
         version: 2.5.6
       '@types/node':
-        specifier: ^24.0.0
+        specifier: 'catalog:'
         version: 24.13.3
       '@vitest/coverage-v8':
-        specifier: 4.1.10
+        specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
       tsdown:
-        specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        specifier: 'catalog:'
+        version: 0.22.14(tsx@4.23.5)(typescript@7.0.2)
       typescript:
-        specifier: ^7.0.2
+        specifier: 'catalog:'
         version: 7.0.2
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5))
 
   examples/01-get-started:
     dependencies:
@@ -40,13 +64,13 @@ importers:
         version: 4.4.3
     devDependencies:
       '@types/node':
-        specifier: ^24.0.0
+        specifier: 'catalog:'
         version: 24.13.3
       tsx:
-        specifier: ^4.23.1
-        version: 4.23.1
+        specifier: 'catalog:'
+        version: 4.23.5
       typescript:
-        specifier: ^7.0.2
+        specifier: 'catalog:'
         version: 7.0.2
 
   examples/02-foundry:
@@ -62,16 +86,16 @@ importers:
         version: link:../../packages/foundry
     devDependencies:
       '@types/node':
-        specifier: ^24.0.0
+        specifier: 'catalog:'
         version: 24.13.3
       tsdown:
-        specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        specifier: 'catalog:'
+        version: 0.22.14(tsx@4.23.5)(typescript@7.0.2)
       tsx:
-        specifier: ^4.23.1
-        version: 4.23.1
+        specifier: 'catalog:'
+        version: 4.23.5
       typescript:
-        specifier: ^7.0.2
+        specifier: 'catalog:'
         version: 7.0.2
 
   examples/03-extensibility:
@@ -93,20 +117,20 @@ importers:
         version: 4.4.3
     devDependencies:
       '@types/node':
-        specifier: ^24.0.0
+        specifier: 'catalog:'
         version: 24.13.3
       tsx:
-        specifier: ^4.23.1
-        version: 4.23.1
+        specifier: 'catalog:'
+        version: 4.23.5
       typescript:
-        specifier: ^7.0.2
+        specifier: 'catalog:'
         version: 7.0.2
 
   examples/04-a2a:
     dependencies:
       '@a2a-js/sdk':
         specifier: ^1.0.1
-        version: 1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1(supports-color@7.2.0))
+        version: 1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1)
       '@polymind-inc/agent-framework-a2a':
         specifier: workspace:^
         version: link:../../packages/a2a
@@ -118,45 +142,45 @@ importers:
         specifier: ^5.0.3
         version: 5.0.6
       '@types/node':
-        specifier: ^24.0.0
+        specifier: 'catalog:'
         version: 24.13.3
       express:
         specifier: ^5.1.0
-        version: 5.2.1(supports-color@7.2.0)
+        version: 5.2.1
       tsx:
-        specifier: ^4.23.1
-        version: 4.23.1
+        specifier: 'catalog:'
+        version: 4.23.5
       typescript:
-        specifier: ^7.0.2
+        specifier: 'catalog:'
         version: 7.0.2
 
   packages/a2a:
     dependencies:
       '@a2a-js/sdk':
         specifier: ^1.0.1
-        version: 1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1(supports-color@7.2.0))
+        version: 1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1)
       '@polymind-inc/agent-framework-core':
         specifier: workspace:^
         version: link:../core
     devDependencies:
       tsdown:
-        specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        specifier: 'catalog:'
+        version: 0.22.14(tsx@4.23.5)(typescript@7.0.2)
       typescript:
-        specifier: ^7.0.2
+        specifier: 'catalog:'
         version: 7.0.2
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5))
 
   packages/agentserver:
     dependencies:
       '@azure/identity':
         specifier: ^4.13.1
-        version: 4.13.1(supports-color@7.2.0)
+        version: 4.13.1
       '@azure/monitor-opentelemetry-exporter':
         specifier: 1.0.0-beta.44
-        version: 1.0.0-beta.44(supports-color@7.2.0)
+        version: 1.0.0-beta.44
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -186,17 +210,17 @@ importers:
         specifier: ^0.221.0
         version: 0.221.0(@opentelemetry/api@1.9.1)
       '@types/node':
-        specifier: ^24.0.0
+        specifier: 'catalog:'
         version: 24.13.3
       tsdown:
-        specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        specifier: 'catalog:'
+        version: 0.22.14(tsx@4.23.5)(typescript@7.0.2)
       typescript:
-        specifier: ^7.0.2
+        specifier: 'catalog:'
         version: 7.0.2
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5))
 
   packages/anthropic:
     dependencies:
@@ -208,14 +232,14 @@ importers:
         version: link:../core
     devDependencies:
       tsdown:
-        specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        specifier: 'catalog:'
+        version: 0.22.14(tsx@4.23.5)(typescript@7.0.2)
       typescript:
-        specifier: ^7.0.2
+        specifier: 'catalog:'
         version: 7.0.2
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5))
 
   packages/core:
     dependencies:
@@ -236,20 +260,20 @@ importers:
         specifier: ^2.10.0
         version: 2.10.0(@opentelemetry/api@1.9.1)
       tsdown:
-        specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        specifier: 'catalog:'
+        version: 0.22.14(tsx@4.23.5)(typescript@7.0.2)
       typescript:
-        specifier: ^7.0.2
+        specifier: 'catalog:'
         version: 7.0.2
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5))
 
   packages/foundry:
     dependencies:
       '@azure/identity':
         specifier: ^4.13.1
-        version: 4.13.1(supports-color@7.2.0)
+        version: 4.13.1
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
@@ -263,8 +287,8 @@ importers:
         specifier: workspace:^
         version: link:../openai
       openai:
-        specifier: ^7.2.0
-        version: 7.2.0(zod@4.4.3)
+        specifier: 'catalog:'
+        version: 7.4.0(zod@4.4.3)
     devDependencies:
       '@opentelemetry/api':
         specifier: ^1.9.1
@@ -276,17 +300,17 @@ importers:
         specifier: workspace:^
         version: link:../agentserver
       '@types/node':
-        specifier: ^24.0.0
+        specifier: 'catalog:'
         version: 24.13.3
       tsdown:
-        specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        specifier: 'catalog:'
+        version: 0.22.14(tsx@4.23.5)(typescript@7.0.2)
       typescript:
-        specifier: ^7.0.2
+        specifier: 'catalog:'
         version: 7.0.2
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5))
 
   packages/mcp:
     dependencies:
@@ -307,14 +331,14 @@ importers:
         specifier: ^2.10.0
         version: 2.10.0(@opentelemetry/api@1.9.1)
       tsdown:
-        specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        specifier: 'catalog:'
+        version: 0.22.14(tsx@4.23.5)(typescript@7.0.2)
       typescript:
-        specifier: ^7.0.2
+        specifier: 'catalog:'
         version: 7.0.2
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5))
 
   packages/meta:
     dependencies:
@@ -341,17 +365,17 @@ importers:
         version: link:../openai
     devDependencies:
       '@types/node':
-        specifier: ^24.0.0
+        specifier: 'catalog:'
         version: 24.13.3
       tsdown:
-        specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        specifier: 'catalog:'
+        version: 0.22.14(tsx@4.23.5)(typescript@7.0.2)
       typescript:
-        specifier: ^7.0.2
+        specifier: 'catalog:'
         version: 7.0.2
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5))
 
   packages/openai:
     dependencies:
@@ -359,18 +383,49 @@ importers:
         specifier: workspace:^
         version: link:../core
       openai:
-        specifier: ^7.2.0
-        version: 7.2.0(zod@4.4.3)
+        specifier: 'catalog:'
+        version: 7.4.0(zod@4.4.3)
     devDependencies:
       tsdown:
-        specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        specifier: 'catalog:'
+        version: 0.22.14(tsx@4.23.5)(typescript@7.0.2)
       typescript:
-        specifier: ^7.0.2
+        specifier: 'catalog:'
         version: 7.0.2
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5))
+
+  scripts/type-resolution:
+    dependencies:
+      '@polymind-inc/agent-framework':
+        specifier: workspace:*
+        version: link:../../packages/meta
+      '@polymind-inc/agent-framework-a2a':
+        specifier: workspace:*
+        version: link:../../packages/a2a
+      '@polymind-inc/agent-framework-agentserver':
+        specifier: workspace:*
+        version: link:../../packages/agentserver
+      '@polymind-inc/agent-framework-anthropic':
+        specifier: workspace:*
+        version: link:../../packages/anthropic
+      '@polymind-inc/agent-framework-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@polymind-inc/agent-framework-foundry':
+        specifier: workspace:*
+        version: link:../../packages/foundry
+      '@polymind-inc/agent-framework-mcp':
+        specifier: workspace:*
+        version: link:../../packages/mcp
+      '@polymind-inc/agent-framework-openai':
+        specifier: workspace:*
+        version: link:../../packages/openai
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
 packages:
 
@@ -1953,8 +2008,8 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  openai@7.2.0:
-    resolution: {integrity: sha512-/P0jZP2WDSwSuiilTTcU4mkepzdSAiRrnTK2e9pk9KOzBoE3L9aHz2oIyIXqGbqnnMsGC0Izr223MOUhG2JuvQ==}
+  openai@7.4.0:
+    resolution: {integrity: sha512-+C9Muit5x8j9R8ej8ZzVgKcrVDtqFqTy9gxFdov0EItLgU68zrJtF9ZeT0cyqJQW9S3PCJkdFgADtRGquRBtew==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
@@ -2211,8 +2266,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.23.1:
-    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
+  tsx@4.23.5:
+    resolution: {integrity: sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2378,13 +2433,13 @@ packages:
 
 snapshots:
 
-  '@a2a-js/sdk@1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1(supports-color@7.2.0))':
+  '@a2a-js/sdk@1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1)':
     dependencies:
       jose: 6.2.5
       uuid: 11.1.1
     optionalDependencies:
       '@grpc/grpc-js': 1.14.4
-      express: 5.2.1(supports-color@7.2.0)
+      express: 5.2.1
 
   '@anthropic-ai/sdk@0.115.0(zod@4.4.3)':
     dependencies:
@@ -2393,13 +2448,13 @@ snapshots:
     optionalDependencies:
       zod: 4.4.3
 
-  '@azure-rest/core-client@2.8.0(supports-color@7.2.0)':
+  '@azure-rest/core-client@2.8.0':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
-      '@azure/core-rest-pipeline': 1.25.0(supports-color@7.2.0)
+      '@azure/core-auth': 1.11.0
+      '@azure/core-rest-pipeline': 1.25.0
       '@azure/core-tracing': 1.4.0
-      '@typespec/ts-http-runtime': 0.3.8(supports-color@7.2.0)
+      '@typespec/ts-http-runtime': 0.3.8
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -2408,34 +2463,34 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-auth@1.11.0(supports-color@7.2.0)':
+  '@azure/core-auth@1.11.0':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-util': 1.14.0(supports-color@7.2.0)
+      '@azure/core-util': 1.14.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-client@1.11.0(supports-color@7.2.0)':
+  '@azure/core-client@1.11.0':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
-      '@azure/core-rest-pipeline': 1.25.0(supports-color@7.2.0)
+      '@azure/core-auth': 1.11.0
+      '@azure/core-rest-pipeline': 1.25.0
       '@azure/core-tracing': 1.4.0
-      '@azure/core-util': 1.14.0(supports-color@7.2.0)
-      '@azure/logger': 1.4.0(supports-color@7.2.0)
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-rest-pipeline@1.25.0(supports-color@7.2.0)':
+  '@azure/core-rest-pipeline@1.25.0':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
+      '@azure/core-auth': 1.11.0
       '@azure/core-tracing': 1.4.0
-      '@azure/core-util': 1.14.0(supports-color@7.2.0)
-      '@azure/logger': 1.4.0(supports-color@7.2.0)
-      '@typespec/ts-http-runtime': 0.3.8(supports-color@7.2.0)
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
+      '@typespec/ts-http-runtime': 0.3.8
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -2444,23 +2499,23 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-util@1.14.0(supports-color@7.2.0)':
+  '@azure/core-util@1.14.0':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@typespec/ts-http-runtime': 0.3.8(supports-color@7.2.0)
+      '@typespec/ts-http-runtime': 0.3.8
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/identity@4.13.1(supports-color@7.2.0)':
+  '@azure/identity@4.13.1':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
-      '@azure/core-client': 1.11.0(supports-color@7.2.0)
-      '@azure/core-rest-pipeline': 1.25.0(supports-color@7.2.0)
+      '@azure/core-auth': 1.11.0
+      '@azure/core-client': 1.11.0
+      '@azure/core-rest-pipeline': 1.25.0
       '@azure/core-tracing': 1.4.0
-      '@azure/core-util': 1.14.0(supports-color@7.2.0)
-      '@azure/logger': 1.4.0(supports-color@7.2.0)
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
       '@azure/msal-browser': 5.17.3
       '@azure/msal-node': 5.4.3
       open: 10.2.0
@@ -2468,20 +2523,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/logger@1.4.0(supports-color@7.2.0)':
+  '@azure/logger@1.4.0':
     dependencies:
-      '@typespec/ts-http-runtime': 0.3.8(supports-color@7.2.0)
+      '@typespec/ts-http-runtime': 0.3.8
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.44(supports-color@7.2.0)':
+  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.44':
     dependencies:
-      '@azure-rest/core-client': 2.8.0(supports-color@7.2.0)
-      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
-      '@azure/core-client': 1.11.0(supports-color@7.2.0)
-      '@azure/core-rest-pipeline': 1.25.0(supports-color@7.2.0)
-      '@azure/core-util': 1.14.0(supports-color@7.2.0)
+      '@azure-rest/core-client': 2.8.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-client': 1.11.0
+      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-util': 1.14.0
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.220.0
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
@@ -3102,10 +3157,10 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@typespec/ts-http-runtime@0.3.8(supports-color@7.2.0)':
+  '@typespec/ts-http-runtime@0.3.8':
     dependencies:
-      http-proxy-agent: 7.0.2(supports-color@7.2.0)
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -3122,7 +3177,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -3133,13 +3188,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))':
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1)
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -3256,11 +3311,11 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
-  body-parser@2.3.0(supports-color@7.2.0):
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
@@ -3322,11 +3377,9 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  debug@4.4.3(supports-color@7.2.0):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 7.2.0
 
   default-browser-id@5.0.1: {}
 
@@ -3420,20 +3473,20 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  express@5.2.1(supports-color@7.2.0):
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0(supports-color@7.2.0)
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@7.2.0)
+      finalhandler: 2.1.1
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -3444,9 +3497,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.3.0
-      router: 2.2.0(supports-color@7.2.0)
-      send: 1.2.1(supports-color@7.2.0)
-      serve-static: 2.2.1(supports-color@7.2.0)
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -3459,9 +3512,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  finalhandler@2.1.1(supports-color@7.2.0):
+  finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -3525,17 +3578,17 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2(supports-color@7.2.0):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6(supports-color@7.2.0):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3729,7 +3782,7 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@7.2.0(zod@4.4.3):
+  openai@7.4.0(zod@4.4.3):
     optionalDependencies:
       zod: 4.4.3
 
@@ -3848,9 +3901,9 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.1
       '@rolldown/binding-win32-x64-msvc': 1.2.1
 
-  router@2.2.0(supports-color@7.2.0):
+  router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -3866,9 +3919,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1(supports-color@7.2.0):
+  send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -3882,12 +3935,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1(supports-color@7.2.0):
+  serve-static@2.2.1:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@7.2.0)
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -3973,7 +4026,7 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
-  tsdown@0.22.14(tsx@4.23.1)(typescript@7.0.2):
+  tsdown@0.22.14(tsx@4.23.5)(typescript@7.0.2):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -3991,7 +4044,7 @@ snapshots:
       unconfig-core: 7.5.0
       verkit: 0.3.1
     optionalDependencies:
-      tsx: 4.23.1
+      tsx: 4.23.5
       typescript: 7.0.2
     transitivePeerDependencies:
       - '@typescript/native-preview'
@@ -4001,7 +4054,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsx@4.23.1:
+  tsx@4.23.5:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
@@ -4051,7 +4104,7 @@ snapshots:
 
   verkit@0.3.1: {}
 
-  vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1):
+  vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -4062,12 +4115,12 @@ snapshots:
       '@types/node': 24.13.3
       esbuild: 0.28.1
       fsevents: 2.3.3
-      tsx: 4.23.1
+      tsx: 4.23.5
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1))
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -4084,7 +4137,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.1)
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.5)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,16 @@
 packages:
   - 'packages/*'
   - 'examples/*'
+  - 'scripts/type-resolution'
+minimumReleaseAge: 1440
+catalog:
+  '@types/node': ^24.0.0
+  '@vitest/coverage-v8': 4.1.10
+  openai: ^7.4.0
+  tsdown: ^0.22.14
+  tsx: ^4.23.5
+  typescript: ^7.0.2
+  vitest: ^4.1.10
 allowBuilds:
   esbuild: true
   # The optional OTLP/gRPC exporters pull protobufjs in; its postinstall only prints a banner

--- a/scripts/type-resolution/package.json
+++ b/scripts/type-resolution/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "agent-framework-type-resolution-smoke",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
+  "dependencies": {
+    "@polymind-inc/agent-framework": "workspace:*",
+    "@polymind-inc/agent-framework-a2a": "workspace:*",
+    "@polymind-inc/agent-framework-agentserver": "workspace:*",
+    "@polymind-inc/agent-framework-anthropic": "workspace:*",
+    "@polymind-inc/agent-framework-core": "workspace:*",
+    "@polymind-inc/agent-framework-foundry": "workspace:*",
+    "@polymind-inc/agent-framework-mcp": "workspace:*",
+    "@polymind-inc/agent-framework-openai": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  }
+}

--- a/scripts/type-resolution/smoke.ts
+++ b/scripts/type-resolution/smoke.ts
@@ -1,0 +1,23 @@
+import '@polymind-inc/agent-framework';
+import '@polymind-inc/agent-framework/testing';
+import '@polymind-inc/agent-framework/openai';
+import '@polymind-inc/agent-framework/anthropic';
+import '@polymind-inc/agent-framework/mcp';
+import '@polymind-inc/agent-framework/a2a';
+import '@polymind-inc/agent-framework/foundry';
+import '@polymind-inc/agent-framework/foundry/hosting';
+import '@polymind-inc/agent-framework/agentserver';
+import '@polymind-inc/agent-framework/agentserver/node';
+import '@polymind-inc/agent-framework/agentserver/observability';
+
+import '@polymind-inc/agent-framework-core';
+import '@polymind-inc/agent-framework-core/testing';
+import '@polymind-inc/agent-framework-openai';
+import '@polymind-inc/agent-framework-anthropic';
+import '@polymind-inc/agent-framework-mcp';
+import '@polymind-inc/agent-framework-a2a';
+import '@polymind-inc/agent-framework-foundry';
+import '@polymind-inc/agent-framework-foundry/hosting';
+import '@polymind-inc/agent-framework-agentserver';
+import '@polymind-inc/agent-framework-agentserver/node';
+import '@polymind-inc/agent-framework-agentserver/observability';

--- a/scripts/type-resolution/tsconfig.json
+++ b/scripts/type-resolution/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["smoke.ts"]
+}

--- a/tsconfig.tools.json
+++ b/tsconfig.tools.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "declaration": false,
+    "declarationMap": false,
+    "isolatedDeclarations": false
+  }
+}


### PR DESCRIPTION
## Summary

A quality-pass batch with no new features. Four independent areas:

### Tool approval durability (core)
- A partially answered approval batch no longer discards the unanswered requests: they are pruned of already-executed calls, written back to the session store, and re-surfaced to the caller while the loop stays paused.
- A replayed transcript carrying approval requests with no decision now re-surfaces them and pauses instead of stripping them and running the model against a history in which the gated calls never happened. Both reference implementations refuse to continue here: .NET returns queued requests without invoking the inner agent; Go rejects the transcript outright.
- `maxIterations` / `maxConsecutiveErrors` are validated as safe integers (positive / non-negative) at the configuration boundary, matching the .NET argument checks.

### Empty-response conversion parity (core)
- `chatResponseToUpdates` drops its local-only fallback and now matches Go's `Response.ToUpdates` exactly: a response with no messages, zero usage, no additional properties and no continuation token converts to zero updates.

### Server shutdown (agentserver)
- `RunningServer.close` is idempotent (concurrent and repeated calls share one drain) and removes the SIGTERM/SIGINT handlers it installed, covered by a listener-count regression test.

### Toolchain
- Shared dependency ranges move to the pnpm catalog; `minimumReleaseAge: 1440` adds a 24-hour cooldown on freshly published packages; Dependabot now covers npm; the release workflow drops the package-manager cache so publishes resolve only from the lockfile and registry.
- A private smoke package typechecks every public entry point of every package under `moduleResolution: nodenext` as part of `pnpm typecheck`, so a broken `exports` map fails CI instead of a consumer. The eight identical per-package tool tsconfigs collapse into one `tsconfig.tools.json`.

## Test plan

- [x] `pnpm check` (lint, build, typecheck incl. the new nodenext resolution smoke, all package tests, pack check) passes
- [x] Every behavioral fix landed reproduction-first: the new tests fail against the previous implementation (verified by temporarily reverting the fixes)
- [x] Approval semantics cross-checked against .NET (`ToolApprovalAgent`) and Go (`toolautocall`); empty-response conversion cross-checked against Go `Response.ToUpdates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)