### PR TITLE
Keep @types/node majors in step with the supported Node.js runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,12 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # @types/node tracks the minimum supported Node.js runtime, not the newest
+      # release, so its major version is only raised together with the runtime
+      # requirement — never through an automated bump.
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
     groups:
       production-dependencies:
         dependency-type: production


### PR DESCRIPTION
The package targets Node.js 24+, so `@types/node` stays on the matching major and is only raised together with the runtime requirement.

Dependabot's attempt to bump it to 26 (#7) also mishandled the pnpm catalog: it rewrote the root importer's lockfile specifier from `'catalog:'` to a literal version, so `pnpm install --frozen-lockfile` fails in CI with `ERR_PNPM_OUTDATED_LOCKFILE`. This adds an ignore rule for `version-update:semver-major` on `@types/node`; minor and patch updates within the supported major keep flowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)