### PR TITLE
Make @polymind-inc/agent-framework the single supported surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The umbrella `@polymind-inc/agent-framework` package and all `@polymind-inc/agen
 packages are versioned in lockstep; one entry here covers the set. During 0.x, **minor releases may
 contain breaking changes**; patch releases are fixes only.
 
+## Unreleased
+
+Documentation and positioning only — no change to any published API.
+
+- **`@polymind-inc/agent-framework` is now the single supported surface.** All examples, the
+  repository README and every code sample import through the main package
+  (`@polymind-inc/agent-framework`, `…/openai`, `…/foundry/hosting`, …). The
+  `@polymind-inc/agent-framework-*` constituent packages remain published — the main package
+  depends on them at exact versions, and importing one directly still resolves to the same
+  modules — but their READMEs now state that the main package is the documented way in. This
+  removes the awkwardness of two equivalent import styles for the same code.
+
 ## 0.2.0
 
 One new package; no change to any existing published API.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,12 @@ The points below are the ones most often gotten wrong.
 Node.js 24+ · TypeScript 7 · pnpm · ESM only · target ES2024 with `isolatedDeclarations` · Biome
 for lint and format · tsdown for builds · Vitest for tests.
 
-The packages under `packages/` are published as `@polymind-inc/agent-framework-*`, plus the
-umbrella `@polymind-inc/agent-framework`, which depends on all of them and re-exports each under a
-subpath. All are versioned in lockstep. `pnpm check` runs the same gate as CI.
+The public surface is the single package `@polymind-inc/agent-framework`: its root entry is the
+core and every other capability is a subpath (`/openai`, `/anthropic`, `/mcp`, `/a2a`, `/foundry`,
+`/agentserver`, `/testing`). It is built from `@polymind-inc/agent-framework-*` constituent
+packages under `packages/`, which stay published (the main package depends on them, pinned
+exactly) but are not the documented way in — examples and docs always import through the main
+package. All are versioned in lockstep. `pnpm check` runs the same gate as CI.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Agent Framework for TypeScript
 
 [![CI](https://github.com/polymind-inc/agent-framework-js/actions/workflows/ci.yml/badge.svg)](https://github.com/polymind-inc/agent-framework-js/actions/workflows/ci.yml)
-[![npm](https://img.shields.io/npm/v/@polymind-inc/agent-framework-core.svg)](https://www.npmjs.com/package/@polymind-inc/agent-framework-core)
-[![Node.js](https://img.shields.io/node/v/@polymind-inc/agent-framework-core.svg)](https://nodejs.org/)
+[![npm](https://img.shields.io/npm/v/@polymind-inc/agent-framework.svg)](https://www.npmjs.com/package/@polymind-inc/agent-framework)
+[![Node.js](https://img.shields.io/node/v/@polymind-inc/agent-framework.svg)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 A TypeScript implementation of the **Microsoft Agent Framework** programming model, designed for
@@ -38,12 +38,12 @@ cadence is chosen with that in mind.
 ## Quickstart
 
 ```bash
-npm install @polymind-inc/agent-framework-core @polymind-inc/agent-framework-openai zod
+npm install @polymind-inc/agent-framework zod
 ```
 
 ```ts
-import { Agent, tool } from '@polymind-inc/agent-framework-core';
-import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
+import { Agent, tool } from '@polymind-inc/agent-framework';
+import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
 import { z } from 'zod';
 
 const weather = tool({
@@ -78,23 +78,28 @@ the Go implementation uses.
 
 ## Packages
 
-All packages are published under the `@polymind-inc/` scope and released in lockstep.
+One package to install: **`@polymind-inc/agent-framework`**. The root entry is the agent core;
+every other capability lives under a subpath. The subpaths are plain static re-exports, so a
+bundler tree-shakes whatever you do not import.
 
-| Package                                     | Purpose                                                                                                                                               |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@polymind-inc/agent-framework`             | Umbrella package — installs every package below and re-exports each of their entry points under a subpath (the full mapping is in [its README](packages/meta/README.md)) |
-| `@polymind-inc/agent-framework-core`        | `Agent`, `AgentSession`, the `Message`/`Content` model, `tool()`, middleware, and the `ChatClient` seam. Sole runtime dependency: `@opentelemetry/api` |
-| `@polymind-inc/agent-framework-openai`      | OpenAI and Azure OpenAI chat client (Responses API)                                                                                                   |
-| `@polymind-inc/agent-framework-anthropic`   | Anthropic chat client (Messages API)                                                                                                                  |
-| `@polymind-inc/agent-framework-mcp`         | Model Context Protocol client integration — MCP server tools as framework tools                                                                       |
-| `@polymind-inc/agent-framework-a2a`         | Agent2Agent (A2A) protocol client — a remote A2A agent used as an agent                                                                               |
-| `@polymind-inc/agent-framework-foundry`     | Microsoft Foundry chat client and Hosted Agent hosting adapter                                                                                        |
-| `@polymind-inc/agent-framework-agentserver` | Foundry Responses container protocol v2.0.0 server, independent of the rest of the framework                                                          |
+| Import                                            | Provides                                                                                                                            |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `@polymind-inc/agent-framework`                   | `Agent`, `AgentSession`, the `Message`/`Content` model, `tool()`, middleware, and the `ChatClient` seam                              |
+| `@polymind-inc/agent-framework/openai`            | OpenAI and Azure OpenAI chat client (Responses API)                                                                                  |
+| `@polymind-inc/agent-framework/anthropic`         | Anthropic chat client (Messages API)                                                                                                 |
+| `@polymind-inc/agent-framework/mcp`               | Model Context Protocol client integration — MCP server tools as framework tools                                                      |
+| `@polymind-inc/agent-framework/a2a`               | Agent2Agent (A2A) protocol client — a remote A2A agent used as an agent                                                              |
+| `@polymind-inc/agent-framework/foundry`           | Microsoft Foundry chat client, with the Hosted Agent adapter under `/foundry/hosting`                                                |
+| `@polymind-inc/agent-framework/agentserver`       | Foundry Responses container protocol v2.0.0 server, with `/agentserver/node` and `/agentserver/observability` companions             |
+| `@polymind-inc/agent-framework/testing`           | `MockChatClient` and friends for testing agents without a live provider                                                              |
 
-The names mirror the Python distribution layout (`agent-framework` as the everything-included
-umbrella, `agent-framework-core`, `agent-framework-openai`, …) so that a move to a first-party
-scope is a mechanical rename. The granular packages remain the recommended install when size
-matters; the umbrella pulls in every provider SDK.
+Under the hood the framework is developed and published as a family of
+`@polymind-inc/agent-framework-*` constituent packages, released in lockstep and pinned to exact
+versions by the main package. They exist to keep the codebase modular and the upstream story
+flexible; importing them directly works — every subpath above is a static re-export of one of
+them — but the supported, documented surface is `@polymind-inc/agent-framework`. The names mirror
+the Python distribution layout (`agent-framework`, `agent-framework-core`, `agent-framework-openai`,
+…) so that a move to a first-party scope is a mechanical rename.
 
 ## Parity with the reference implementations
 

--- a/examples/01-get-started/01-basic.ts
+++ b/examples/01-get-started/01-basic.ts
@@ -6,8 +6,8 @@
  *
  * Run: `OPENAI_API_KEY=... pnpm --filter example-01-get-started basic`
  */
-import { Agent } from '@polymind-inc/agent-framework-core';
-import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
+import { Agent } from '@polymind-inc/agent-framework';
+import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
 
 const agent = new Agent({
   client: new OpenAIChatClient({ model: process.env.OPENAI_MODEL ?? 'gpt-4o-mini' }),

--- a/examples/01-get-started/02-tools.ts
+++ b/examples/01-get-started/02-tools.ts
@@ -6,8 +6,8 @@
  *
  * Run: `OPENAI_API_KEY=... pnpm --filter example-01-get-started tools`
  */
-import { Agent, tool } from '@polymind-inc/agent-framework-core';
-import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
+import { Agent, tool } from '@polymind-inc/agent-framework';
+import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
 import { z } from 'zod';
 
 const getWeather = tool({

--- a/examples/01-get-started/03-streaming.ts
+++ b/examples/01-get-started/03-streaming.ts
@@ -7,8 +7,8 @@
  *
  * Run: `OPENAI_API_KEY=... pnpm --filter example-01-get-started streaming`
  */
-import { Agent, tool } from '@polymind-inc/agent-framework-core';
-import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
+import { Agent, tool } from '@polymind-inc/agent-framework';
+import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
 import { z } from 'zod';
 
 const rollDice = tool({

--- a/examples/01-get-started/04-structured-output.ts
+++ b/examples/01-get-started/04-structured-output.ts
@@ -7,8 +7,8 @@
  *
  * Run: `OPENAI_API_KEY=... pnpm --filter example-01-get-started structured-output`
  */
-import { Agent } from '@polymind-inc/agent-framework-core';
-import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
+import { Agent } from '@polymind-inc/agent-framework';
+import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
 import { z } from 'zod';
 
 const Person = z.object({

--- a/examples/01-get-started/05-session.ts
+++ b/examples/01-get-started/05-session.ts
@@ -5,15 +5,15 @@
  * is `JSON.stringify(session)` and resuming it is `agent.deserializeSession(...)`.
  *
  * `node:fs` is used here on purpose: it belongs in the application, not in
- * `@polymind-inc/agent-framework-core`, which stays runtime-agnostic.
+ * `@polymind-inc/agent-framework`, which stays runtime-agnostic.
  *
  * Run: `OPENAI_API_KEY=... pnpm --filter example-01-get-started session`
  */
 import { readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { Agent } from '@polymind-inc/agent-framework-core';
-import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
+import { Agent } from '@polymind-inc/agent-framework';
+import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
 
 const agent = new Agent({
   client: new OpenAIChatClient({ model: process.env.OPENAI_MODEL ?? 'gpt-4o-mini' }),

--- a/examples/01-get-started/06-agent-as-tool.ts
+++ b/examples/01-get-started/06-agent-as-tool.ts
@@ -6,8 +6,8 @@
  *
  * Run: `OPENAI_API_KEY=... pnpm --filter example-01-get-started agent-as-tool`
  */
-import { Agent } from '@polymind-inc/agent-framework-core';
-import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
+import { Agent } from '@polymind-inc/agent-framework';
+import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
 
 const client = new OpenAIChatClient({ model: process.env.OPENAI_MODEL ?? 'gpt-4o-mini' });
 

--- a/examples/01-get-started/07-multimodal.ts
+++ b/examples/01-get-started/07-multimodal.ts
@@ -8,8 +8,8 @@
  */
 import { readFile } from 'node:fs/promises';
 import { extname } from 'node:path';
-import { Agent, dataContent } from '@polymind-inc/agent-framework-core';
-import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
+import { Agent, dataContent } from '@polymind-inc/agent-framework';
+import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
 
 const imagePath = process.argv[2];
 if (imagePath === undefined) {

--- a/examples/01-get-started/package.json
+++ b/examples/01-get-started/package.json
@@ -17,8 +17,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@polymind-inc/agent-framework-core": "workspace:^",
-    "@polymind-inc/agent-framework-openai": "workspace:^",
+    "@polymind-inc/agent-framework": "workspace:^",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/examples/02-foundry/01-foundry-chat.ts
+++ b/examples/02-foundry/01-foundry-chat.ts
@@ -11,8 +11,8 @@
  *   AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini \
  *   pnpm --filter example-02-foundry chat
  */
-import { Agent, tool } from '@polymind-inc/agent-framework-core';
-import { FoundryChatClient } from '@polymind-inc/agent-framework-foundry';
+import { Agent, tool } from '@polymind-inc/agent-framework';
+import { FoundryChatClient } from '@polymind-inc/agent-framework/foundry';
 
 const projectEndpoint = process.env.FOUNDRY_PROJECT_ENDPOINT;
 if (projectEndpoint === undefined) {

--- a/examples/02-foundry/02-hosted-agent/main.ts
+++ b/examples/02-foundry/02-hosted-agent/main.ts
@@ -11,10 +11,11 @@
  *
  * On Foundry: see README.md.
  */
-import { serve } from '@polymind-inc/agent-framework-agentserver/node';
-import { Agent, tool } from '@polymind-inc/agent-framework-core';
-import { FoundryChatClient } from '@polymind-inc/agent-framework-foundry';
-import { ResponsesHostServer } from '@polymind-inc/agent-framework-foundry/hosting';
+
+import { Agent, tool } from '@polymind-inc/agent-framework';
+import { serve } from '@polymind-inc/agent-framework/agentserver/node';
+import { FoundryChatClient } from '@polymind-inc/agent-framework/foundry';
+import { ResponsesHostServer } from '@polymind-inc/agent-framework/foundry/hosting';
 
 const getWeather = tool({
   name: 'get_weather',

--- a/examples/02-foundry/03-tool-approval.ts
+++ b/examples/02-foundry/03-tool-approval.ts
@@ -16,7 +16,7 @@ import type {
   ChatResponseStream,
   ChatResponseUpdate,
   Message,
-} from '@polymind-inc/agent-framework-core';
+} from '@polymind-inc/agent-framework';
 import {
   Agent,
   AgentSession,
@@ -26,7 +26,7 @@ import {
   mergeChatUpdates,
   textContent,
   tool,
-} from '@polymind-inc/agent-framework-core';
+} from '@polymind-inc/agent-framework';
 
 const deleteEverything = tool({
   name: 'delete_everything',

--- a/examples/02-foundry/04-toolbox.ts
+++ b/examples/02-foundry/04-toolbox.ts
@@ -15,9 +15,9 @@
  *   FOUNDRY_TOOLBOX_NAME=<toolbox> \
  *   pnpm --filter example-02-foundry toolbox
  */
-import { Agent } from '@polymind-inc/agent-framework-core';
-import { FoundryChatClient } from '@polymind-inc/agent-framework-foundry';
-import { FoundryToolbox } from '@polymind-inc/agent-framework-foundry/hosting';
+import { Agent } from '@polymind-inc/agent-framework';
+import { FoundryChatClient } from '@polymind-inc/agent-framework/foundry';
+import { FoundryToolbox } from '@polymind-inc/agent-framework/foundry/hosting';
 
 const projectEndpoint = process.env.FOUNDRY_PROJECT_ENDPOINT;
 const toolboxName = process.env.FOUNDRY_TOOLBOX_NAME;

--- a/examples/02-foundry/package.json
+++ b/examples/02-foundry/package.json
@@ -16,9 +16,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@polymind-inc/agent-framework-agentserver": "workspace:^",
-    "@polymind-inc/agent-framework-core": "workspace:^",
-    "@polymind-inc/agent-framework-foundry": "workspace:^"
+    "@polymind-inc/agent-framework": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/examples/03-extensibility/01-middleware.ts
+++ b/examples/03-extensibility/01-middleware.ts
@@ -18,8 +18,8 @@ import {
   textContent,
   tool,
   toolApprovalMiddleware,
-} from '@polymind-inc/agent-framework-core';
-import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
+} from '@polymind-inc/agent-framework';
+import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
 import { z } from 'zod';
 
 /** Observes a run from the outside: what went in, what came out, how long it took. */

--- a/examples/03-extensibility/02-context-provider.ts
+++ b/examples/03-extensibility/02-context-provider.ts
@@ -12,9 +12,9 @@ import type {
   ContextProvider,
   ProviderAfterRunContext,
   ProviderRunContext,
-} from '@polymind-inc/agent-framework-core';
-import { Agent, textContent, tool } from '@polymind-inc/agent-framework-core';
-import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
+} from '@polymind-inc/agent-framework';
+import { Agent, textContent, tool } from '@polymind-inc/agent-framework';
+import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
 import { z } from 'zod';
 
 /**

--- a/examples/03-extensibility/03-anthropic.ts
+++ b/examples/03-extensibility/03-anthropic.ts
@@ -8,9 +8,9 @@
  * Run: `ANTHROPIC_API_KEY=... pnpm --filter example-03-extensibility anthropic`
  */
 
-import type { AnthropicChatOptions } from '@polymind-inc/agent-framework-anthropic';
-import { AnthropicChatClient } from '@polymind-inc/agent-framework-anthropic';
-import { Agent, tool } from '@polymind-inc/agent-framework-core';
+import { Agent, tool } from '@polymind-inc/agent-framework';
+import type { AnthropicChatOptions } from '@polymind-inc/agent-framework/anthropic';
+import { AnthropicChatClient } from '@polymind-inc/agent-framework/anthropic';
 import { z } from 'zod';
 
 const getWeather = tool({

--- a/examples/03-extensibility/04-mcp.ts
+++ b/examples/03-extensibility/04-mcp.ts
@@ -7,9 +7,9 @@
  *
  * Run: `OPENAI_API_KEY=... MCP_SERVER_URL=https://… pnpm --filter example-03-extensibility mcp`
  */
-import { Agent, approvalResponse } from '@polymind-inc/agent-framework-core';
-import { MCPClient } from '@polymind-inc/agent-framework-mcp';
-import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
+import { Agent, approvalResponse } from '@polymind-inc/agent-framework';
+import { MCPClient } from '@polymind-inc/agent-framework/mcp';
+import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
 
 const url = process.env.MCP_SERVER_URL;
 if (url === undefined) {

--- a/examples/03-extensibility/05-openai-hosted-tools.ts
+++ b/examples/03-extensibility/05-openai-hosted-tools.ts
@@ -6,8 +6,8 @@
  *
  * Run: `OPENAI_API_KEY=... OPENAI_MODEL=... pnpm --filter example-03-extensibility hosted-tools`
  */
-import { Agent } from '@polymind-inc/agent-framework-core';
-import { codeInterpreterTool, OpenAIChatClient, webSearchTool } from '@polymind-inc/agent-framework-openai';
+import { Agent } from '@polymind-inc/agent-framework';
+import { codeInterpreterTool, OpenAIChatClient, webSearchTool } from '@polymind-inc/agent-framework/openai';
 
 const model = process.env.OPENAI_MODEL;
 if (model === undefined) {

--- a/examples/03-extensibility/package.json
+++ b/examples/03-extensibility/package.json
@@ -15,10 +15,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@polymind-inc/agent-framework-anthropic": "workspace:^",
-    "@polymind-inc/agent-framework-core": "workspace:^",
-    "@polymind-inc/agent-framework-mcp": "workspace:^",
-    "@polymind-inc/agent-framework-openai": "workspace:^",
+    "@polymind-inc/agent-framework": "workspace:^",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/examples/04-a2a/01-remote-agent.ts
+++ b/examples/04-a2a/01-remote-agent.ts
@@ -8,7 +8,7 @@
  * Start the local agent first (`pnpm --filter example-04-a2a server`), then run:
  * `pnpm --filter example-04-a2a remote-agent`
  */
-import { A2AAgent } from '@polymind-inc/agent-framework-a2a';
+import { A2AAgent } from '@polymind-inc/agent-framework/a2a';
 
 const url = process.env.A2A_AGENT_URL ?? 'http://localhost:4100';
 

--- a/examples/04-a2a/02-multi-turn.ts
+++ b/examples/04-a2a/02-multi-turn.ts
@@ -8,7 +8,7 @@
  * Start the local agent first, then run:
  * `pnpm --filter example-04-a2a multi-turn`
  */
-import { A2AAgent } from '@polymind-inc/agent-framework-a2a';
+import { A2AAgent } from '@polymind-inc/agent-framework/a2a';
 
 const agent = await A2AAgent.fromUrl(process.env.A2A_AGENT_URL ?? 'http://localhost:4100');
 const session = agent.createSession();

--- a/examples/04-a2a/03-background.ts
+++ b/examples/04-a2a/03-background.ts
@@ -9,7 +9,7 @@
  * Start the local agent first, then run:
  * `pnpm --filter example-04-a2a background`
  */
-import { A2AAgent } from '@polymind-inc/agent-framework-a2a';
+import { A2AAgent } from '@polymind-inc/agent-framework/a2a';
 
 const agent = await A2AAgent.fromUrl(process.env.A2A_AGENT_URL ?? 'http://localhost:4100');
 

--- a/examples/04-a2a/04-authentication.ts
+++ b/examples/04-a2a/04-authentication.ts
@@ -26,7 +26,7 @@ import {
   JsonRpcTransportFactory,
   RestTransportFactory,
 } from '@a2a-js/sdk/client';
-import { A2AAgent } from '@polymind-inc/agent-framework-a2a';
+import { A2AAgent } from '@polymind-inc/agent-framework/a2a';
 
 const url = process.env.A2A_AGENT_URL ?? 'http://localhost:4100';
 const token = process.env.A2A_TOKEN ?? 'invoice-secret';

--- a/examples/04-a2a/package.json
+++ b/examples/04-a2a/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "@a2a-js/sdk": "^1.0.1",
-    "@polymind-inc/agent-framework-a2a": "workspace:^",
-    "@polymind-inc/agent-framework-core": "workspace:^"
+    "@polymind-inc/agent-framework": "workspace:^"
   },
   "devDependencies": {
     "@types/express": "^5.0.3",

--- a/packages/a2a/README.md
+++ b/packages/a2a/README.md
@@ -1,5 +1,11 @@
 # @polymind-inc/agent-framework-a2a
 
+> **Constituent package.** The supported way to use the Agent Framework is the main
+> [`@polymind-inc/agent-framework`](https://www.npmjs.com/package/@polymind-inc/agent-framework)
+> package, which re-exports everything here under `@polymind-inc/agent-framework/a2a` and pins
+> this package to its exact version. Installing this package directly works and resolves to the
+> same modules, but examples and documentation import through the main package.
+
 Agent2Agent (A2A) protocol client for the Agent Framework: `A2AAgent` makes a remote A2A agent
 usable wherever the framework expects an agent — awaited or streamed, with sessions, as a tool of
 another agent. Built on the official [`@a2a-js/sdk`](https://github.com/a2aproject/a2a-js) client

--- a/packages/agentserver/README.md
+++ b/packages/agentserver/README.md
@@ -1,5 +1,12 @@
 # @polymind-inc/agent-framework-agentserver
 
+> **Constituent package.** The supported way to use the Agent Framework is the main
+> [`@polymind-inc/agent-framework`](https://www.npmjs.com/package/@polymind-inc/agent-framework)
+> package, which re-exports everything here under `@polymind-inc/agent-framework/agentserver`
+> (plus `/agentserver/node` and `/agentserver/observability`) and pins this package to its exact
+> version. Installing this package directly works and resolves to the same modules, but examples
+> and documentation import through the main package.
+
 The Microsoft Foundry Responses container protocol v2.0.0, as a server. Independent of the
 Agent Framework: routing, SSE framing and sequence numbers, the lifecycle contract, id
 generation, the header contract, storage abstractions, and error shapes, exposed as a

--- a/packages/anthropic/README.md
+++ b/packages/anthropic/README.md
@@ -1,5 +1,11 @@
 # @polymind-inc/agent-framework-anthropic
 
+> **Constituent package.** The supported way to use the Agent Framework is the main
+> [`@polymind-inc/agent-framework`](https://www.npmjs.com/package/@polymind-inc/agent-framework)
+> package, which re-exports everything here under `@polymind-inc/agent-framework/anthropic` and
+> pins this package to its exact version. Installing this package directly works and resolves to
+> the same modules, but examples and documentation import through the main package.
+
 Anthropic provider for the Agent Framework: `AnthropicChatClient` implements the `ChatClient`
 interface from `@polymind-inc/agent-framework-core` on top of the official `@anthropic-ai/sdk` Messages API,
 including streaming, extended thinking, structured output and remote MCP servers. Pass an

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,11 @@
 # @polymind-inc/agent-framework-core
 
+> **Constituent package.** The supported way to use the Agent Framework is the main
+> [`@polymind-inc/agent-framework`](https://www.npmjs.com/package/@polymind-inc/agent-framework)
+> package, whose root entry (and `/testing` subpath) re-exports everything here and pins this
+> package to its exact version. Installing this package directly works and resolves to the same
+> modules, but examples and documentation import through the main package.
+
 Runtime-agnostic core of the Agent Framework for TypeScript: `Agent`, `AgentSession`, the
 `Message` / `Content` model, `tool()` with Standard Schema support, the function-calling loop,
 and the `ChatClient` seam that providers implement. ESM only; the sole runtime dependency is

--- a/packages/foundry/README.md
+++ b/packages/foundry/README.md
@@ -1,5 +1,12 @@
 # @polymind-inc/agent-framework-foundry
 
+> **Constituent package.** The supported way to use the Agent Framework is the main
+> [`@polymind-inc/agent-framework`](https://www.npmjs.com/package/@polymind-inc/agent-framework)
+> package, which re-exports everything here under `@polymind-inc/agent-framework/foundry` (and
+> `/foundry/hosting`) and pins this package to its exact version. Installing this package directly
+> works and resolves to the same modules, but examples and documentation import through the main
+> package.
+
 Microsoft Foundry provider for the Agent Framework: `FoundryChatClient` talks to a Foundry
 project (model deployments or server agents) with Microsoft Entra authentication, and the
 `@polymind-inc/agent-framework-foundry/hosting` subpath publishes an `Agent` as a Foundry Hosted Agent over

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,5 +1,11 @@
 # @polymind-inc/agent-framework-mcp
 
+> **Constituent package.** The supported way to use the Agent Framework is the main
+> [`@polymind-inc/agent-framework`](https://www.npmjs.com/package/@polymind-inc/agent-framework)
+> package, which re-exports everything here under `@polymind-inc/agent-framework/mcp` and pins
+> this package to its exact version. Installing this package directly works and resolves to the
+> same modules, but examples and documentation import through the main package.
+
 Model Context Protocol client integration for the Agent Framework: `MCPClient` connects to an MCP
 server and exposes its tools as framework `FunctionTool`s, so an agent calls them like any other
 tool. Built on `@modelcontextprotocol/client` v2. Each `tools/call` is traced as an MCP client span

--- a/packages/meta/README.md
+++ b/packages/meta/README.md
@@ -1,9 +1,9 @@
 # @polymind-inc/agent-framework
 
-Umbrella package for the Agent Framework for TypeScript. One install brings in the whole family —
-the runtime-agnostic core, the OpenAI / Azure OpenAI, Anthropic and Microsoft Foundry providers,
-the MCP and A2A clients, and the Foundry hosting pieces — mirroring what `pip install
-agent-framework` gives you in the Python implementation. ESM only.
+The Agent Framework for TypeScript in a single package — the runtime-agnostic core, the OpenAI /
+Azure OpenAI, Anthropic and Microsoft Foundry providers, the MCP and A2A clients, and the Foundry
+hosting pieces — mirroring what `pip install agent-framework` gives you in the Python
+implementation. ESM only.
 
 ```sh
 npm install @polymind-inc/agent-framework
@@ -31,8 +31,9 @@ import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
 ```
 
 The subpaths are plain static re-exports, so a bundler tree-shakes whatever you do not import.
-If install size matters more than convenience — this package pulls in every provider SDK and the
-hosting server's OpenTelemetry dependencies — install the individual packages instead; they are
-the same code, and the two styles can be mixed freely.
+The constituent `@polymind-inc/agent-framework-*` packages are published as implementation detail
+— this package pins them to its own exact version — and importing one directly resolves to the
+same modules as the subpath above it. The supported, documented surface is this package; the
+examples and every code sample in the repository import through it.
 
 Requirements: Node.js >= 24, ESM only (no CommonJS build).

--- a/packages/openai/README.md
+++ b/packages/openai/README.md
@@ -1,5 +1,11 @@
 # @polymind-inc/agent-framework-openai
 
+> **Constituent package.** The supported way to use the Agent Framework is the main
+> [`@polymind-inc/agent-framework`](https://www.npmjs.com/package/@polymind-inc/agent-framework)
+> package, which re-exports everything here under `@polymind-inc/agent-framework/openai` and pins
+> this package to its exact version. Installing this package directly works and resolves to the
+> same modules, but examples and documentation import through the main package.
+
 OpenAI (and Azure OpenAI) provider for the Agent Framework: `OpenAIChatClient` implements the
 `ChatClient` interface from `@polymind-inc/agent-framework-core` on top of the official `openai` SDK's
 Responses API, including streaming, structured output, and the provider-hosted tools

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,12 +53,9 @@ importers:
 
   examples/01-get-started:
     dependencies:
-      '@polymind-inc/agent-framework-core':
+      '@polymind-inc/agent-framework':
         specifier: workspace:^
-        version: link:../../packages/core
-      '@polymind-inc/agent-framework-openai':
-        specifier: workspace:^
-        version: link:../../packages/openai
+        version: link:../../packages/meta
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -75,15 +72,9 @@ importers:
 
   examples/02-foundry:
     dependencies:
-      '@polymind-inc/agent-framework-agentserver':
+      '@polymind-inc/agent-framework':
         specifier: workspace:^
-        version: link:../../packages/agentserver
-      '@polymind-inc/agent-framework-core':
-        specifier: workspace:^
-        version: link:../../packages/core
-      '@polymind-inc/agent-framework-foundry':
-        specifier: workspace:^
-        version: link:../../packages/foundry
+        version: link:../../packages/meta
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -100,18 +91,9 @@ importers:
 
   examples/03-extensibility:
     dependencies:
-      '@polymind-inc/agent-framework-anthropic':
+      '@polymind-inc/agent-framework':
         specifier: workspace:^
-        version: link:../../packages/anthropic
-      '@polymind-inc/agent-framework-core':
-        specifier: workspace:^
-        version: link:../../packages/core
-      '@polymind-inc/agent-framework-mcp':
-        specifier: workspace:^
-        version: link:../../packages/mcp
-      '@polymind-inc/agent-framework-openai':
-        specifier: workspace:^
-        version: link:../../packages/openai
+        version: link:../../packages/meta
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -130,13 +112,10 @@ importers:
     dependencies:
       '@a2a-js/sdk':
         specifier: ^1.0.1
-        version: 1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1)
-      '@polymind-inc/agent-framework-a2a':
+        version: 1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1(supports-color@7.2.0))
+      '@polymind-inc/agent-framework':
         specifier: workspace:^
-        version: link:../../packages/a2a
-      '@polymind-inc/agent-framework-core':
-        specifier: workspace:^
-        version: link:../../packages/core
+        version: link:../../packages/meta
     devDependencies:
       '@types/express':
         specifier: ^5.0.3
@@ -146,7 +125,7 @@ importers:
         version: 24.13.3
       express:
         specifier: ^5.1.0
-        version: 5.2.1
+        version: 5.2.1(supports-color@7.2.0)
       tsx:
         specifier: 'catalog:'
         version: 4.23.5
@@ -158,7 +137,7 @@ importers:
     dependencies:
       '@a2a-js/sdk':
         specifier: ^1.0.1
-        version: 1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1)
+        version: 1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1(supports-color@7.2.0))
       '@polymind-inc/agent-framework-core':
         specifier: workspace:^
         version: link:../core
@@ -177,10 +156,10 @@ importers:
     dependencies:
       '@azure/identity':
         specifier: ^4.13.1
-        version: 4.13.1
+        version: 4.13.1(supports-color@7.2.0)
       '@azure/monitor-opentelemetry-exporter':
         specifier: 1.0.0-beta.44
-        version: 1.0.0-beta.44
+        version: 1.0.0-beta.44(supports-color@7.2.0)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -273,7 +252,7 @@ importers:
     dependencies:
       '@azure/identity':
         specifier: ^4.13.1
-        version: 4.13.1
+        version: 4.13.1(supports-color@7.2.0)
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
@@ -2433,13 +2412,13 @@ packages:
 
 snapshots:
 
-  '@a2a-js/sdk@1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1)':
+  '@a2a-js/sdk@1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1(supports-color@7.2.0))':
     dependencies:
       jose: 6.2.5
       uuid: 11.1.1
     optionalDependencies:
       '@grpc/grpc-js': 1.14.4
-      express: 5.2.1
+      express: 5.2.1(supports-color@7.2.0)
 
   '@anthropic-ai/sdk@0.115.0(zod@4.4.3)':
     dependencies:
@@ -2448,13 +2427,13 @@ snapshots:
     optionalDependencies:
       zod: 4.4.3
 
-  '@azure-rest/core-client@2.8.0':
+  '@azure-rest/core-client@2.8.0(supports-color@7.2.0)':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-auth': 1.11.0
-      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
+      '@azure/core-rest-pipeline': 1.25.0(supports-color@7.2.0)
       '@azure/core-tracing': 1.4.0
-      '@typespec/ts-http-runtime': 0.3.8
+      '@typespec/ts-http-runtime': 0.3.8(supports-color@7.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -2463,34 +2442,34 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-auth@1.11.0':
+  '@azure/core-auth@1.11.0(supports-color@7.2.0)':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-util': 1.14.0
+      '@azure/core-util': 1.14.0(supports-color@7.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-client@1.11.0':
+  '@azure/core-client@1.11.0(supports-color@7.2.0)':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-auth': 1.11.0
-      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
+      '@azure/core-rest-pipeline': 1.25.0(supports-color@7.2.0)
       '@azure/core-tracing': 1.4.0
-      '@azure/core-util': 1.14.0
-      '@azure/logger': 1.4.0
+      '@azure/core-util': 1.14.0(supports-color@7.2.0)
+      '@azure/logger': 1.4.0(supports-color@7.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-rest-pipeline@1.25.0':
+  '@azure/core-rest-pipeline@1.25.0(supports-color@7.2.0)':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-auth': 1.11.0
+      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
       '@azure/core-tracing': 1.4.0
-      '@azure/core-util': 1.14.0
-      '@azure/logger': 1.4.0
-      '@typespec/ts-http-runtime': 0.3.8
+      '@azure/core-util': 1.14.0(supports-color@7.2.0)
+      '@azure/logger': 1.4.0(supports-color@7.2.0)
+      '@typespec/ts-http-runtime': 0.3.8(supports-color@7.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -2499,23 +2478,23 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-util@1.14.0':
+  '@azure/core-util@1.14.0(supports-color@7.2.0)':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@typespec/ts-http-runtime': 0.3.8
+      '@typespec/ts-http-runtime': 0.3.8(supports-color@7.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/identity@4.13.1':
+  '@azure/identity@4.13.1(supports-color@7.2.0)':
     dependencies:
       '@azure/abort-controller': 2.2.0
-      '@azure/core-auth': 1.11.0
-      '@azure/core-client': 1.11.0
-      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
+      '@azure/core-client': 1.11.0(supports-color@7.2.0)
+      '@azure/core-rest-pipeline': 1.25.0(supports-color@7.2.0)
       '@azure/core-tracing': 1.4.0
-      '@azure/core-util': 1.14.0
-      '@azure/logger': 1.4.0
+      '@azure/core-util': 1.14.0(supports-color@7.2.0)
+      '@azure/logger': 1.4.0(supports-color@7.2.0)
       '@azure/msal-browser': 5.17.3
       '@azure/msal-node': 5.4.3
       open: 10.2.0
@@ -2523,20 +2502,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/logger@1.4.0':
+  '@azure/logger@1.4.0(supports-color@7.2.0)':
     dependencies:
-      '@typespec/ts-http-runtime': 0.3.8
+      '@typespec/ts-http-runtime': 0.3.8(supports-color@7.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.44':
+  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.44(supports-color@7.2.0)':
     dependencies:
-      '@azure-rest/core-client': 2.8.0
-      '@azure/core-auth': 1.11.0
-      '@azure/core-client': 1.11.0
-      '@azure/core-rest-pipeline': 1.25.0
-      '@azure/core-util': 1.14.0
+      '@azure-rest/core-client': 2.8.0(supports-color@7.2.0)
+      '@azure/core-auth': 1.11.0(supports-color@7.2.0)
+      '@azure/core-client': 1.11.0(supports-color@7.2.0)
+      '@azure/core-rest-pipeline': 1.25.0(supports-color@7.2.0)
+      '@azure/core-util': 1.14.0(supports-color@7.2.0)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.220.0
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
@@ -3157,10 +3136,10 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@typespec/ts-http-runtime@0.3.8':
+  '@typespec/ts-http-runtime@0.3.8(supports-color@7.2.0)':
     dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@7.2.0)
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -3311,11 +3290,11 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@7.2.0):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
@@ -3377,9 +3356,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   default-browser-id@5.0.1: {}
 
@@ -3473,20 +3454,20 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  express@5.2.1:
+  express@5.2.1(supports-color@7.2.0):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@7.2.0)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@7.2.0)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -3497,9 +3478,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.3.0
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@7.2.0)
+      send: 1.2.1(supports-color@7.2.0)
+      serve-static: 2.2.1(supports-color@7.2.0)
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -3512,9 +3493,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -3578,17 +3559,17 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3901,9 +3882,9 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.1
       '@rolldown/binding-win32-x64-msvc': 1.2.1
 
-  router@2.2.0:
+  router@2.2.0(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -3919,9 +3900,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -3935,12 +3916,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@7.2.0):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

Follow-up to #4. Having two equivalent import styles — `@polymind-inc/agent-framework-openai` vs `@polymind-inc/agent-framework/openai` — made example code non-portable between install styles, even though both resolve to the same modules at runtime. This adopts the firebase/vue model: **the main package is the single supported surface**, and the constituent packages are published implementation detail. It also matches the Python implementation, whose documented surface is the unified `agent_framework.*` namespace, never the per-distribution module names.

- README quickstart and package table now present `@polymind-inc/agent-framework` and its subpaths as the way in; the npm badge points at the main package
- All examples import through the main package and depend only on it
- Each constituent package README opens with a note pointing at the main package; direct installs keep working (exact-version pins guarantee they resolve to the same modules) but are no longer the documented path
- CHANGELOG gains an Unreleased entry (documentation/positioning only — no API change)

## Test plan

- [x] `pnpm check` passes — examples build and typecheck against the main package's subpaths
- [x] pack-check reports all packages packing cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)