### PR TITLE
Report cancelled to GET while a cancel is still winding down

### DIFF
--- a/packages/agentserver/src/background.test.ts
+++ b/packages/agentserver/src/background.test.ts
@@ -888,6 +888,44 @@ describe('cancellation always wins over the handler', () => {
     expect(terminal.output).toEqual([]);
   });
 
+  it('reports cancelled to GET while the winddown is still inside its grace', async () => {
+    // Long enough that every GET below happens while the cancel route is still waiting.
+    vi.stubEnv('AGENTSERVER_CANCEL_GRACE_MS', '60000');
+    const gate = deferred();
+    const server = makeServer(stubbornHandler(gate.promise));
+    const id = newResponseId();
+
+    const created = await server.handle(post({ input: 'hi', background: true, response_id: id }));
+    expect(created.status).toBe(200);
+    // The handler has produced its output and is now held on the gate: the winddown view below
+    // is judged against a snapshot that is known to carry something.
+    await pollUntil(server, id, (r) => (r.output?.length ?? 0) > 0);
+
+    let cancelSettled = false;
+    const cancelling = server.handle(cancelRequest(id)).then((res) => {
+      cancelSettled = true;
+      return res;
+    });
+
+    // The reference refreshes the record's status from the cancel signal on every GET, so the
+    // flip to `cancelled` is visible as soon as the cancel was accepted — not only once the
+    // route's grace has run out.
+    const during = await pollUntil(server, id, (r) => r.status === 'cancelled');
+    expect(cancelSettled).toBe(false);
+    // Only the status is refreshed. The rest of the snapshot is still the handler's — clearing
+    // the accumulated output is the cancelled *terminal*'s job, and that is the cancel route's
+    // to apply once the winddown ends.
+    expect(during.output).toHaveLength(1);
+
+    gate.resolve();
+    const cancelled = await cancelling;
+    expect(cancelled.status).toBe(200);
+    expect(((await cancelled.json()) as ResponseObject).status).toBe('cancelled');
+    const final = (await (await server.handle(get(`/responses/${id}`))).json()) as ResponseObject;
+    expect(final.status).toBe('cancelled');
+    expect(final.output).toEqual([]);
+  });
+
   it('does not write its terminal into the turn that reused its id', async () => {
     shortGrace();
     const gate = deferred();

--- a/packages/agentserver/src/server.ts
+++ b/packages/agentserver/src/server.ts
@@ -1395,7 +1395,16 @@ export class ResponsesServer {
     const run = this.#runFor(id, owner);
     if (run !== undefined) {
       if (!streamReplay) {
-        return jsonResponse(run.tracker.response, 200);
+        // A cancel that is still inside its winddown grace has already promised `cancelled`, and
+        // the reference refreshes the record's status from the cancel signal before answering any
+        // GET (`_refresh_background_status`). Only the status is refreshed — the rest of the
+        // snapshot, accumulated output included, stays the handler's until the cancel route
+        // applies the actual cancelled terminal.
+        const snapshot = run.tracker.response;
+        if (run.cancelRequested && !TERMINAL_STATUSES.has(String(snapshot.status))) {
+          return jsonResponse({ ...snapshot, status: 'cancelled' }, 200);
+        }
+        return jsonResponse(snapshot, 200);
       }
       if (!run.streamed) {
         throw invalidMode('This response cannot be streamed because it was not created with stream=true.');


### PR DESCRIPTION
The reference server refreshes an in-flight record's status from the cancel signal before answering any GET, so the flip to `cancelled` is visible as soon as the cancel was accepted. Our GET route returned the tracker snapshot untouched, so a poller kept reading `in_progress` for as long as the cancel route waited out its grace — seconds, with a handler that ignores the signal.

The equivalent check already existed as `runStatus()` and was applied on the cancel and DELETE routes; GET now answers a status-only view of the snapshot when a cancel is pending. Only the status is overridden — clearing the accumulated output is the cancelled terminal's job, which the cancel route applies once the winddown ends. This matches the reference's refresh, which also rewrites nothing but the status. The tracker itself is not touched: it belongs to the runner, and the view is derived per request.

## Test plan

- New case: with a 60s cancel grace and a handler that ignores its signal, a concurrent GET reports `cancelled` while the cancel route is still pending (asserted), with the accumulated output still present; after the winddown, the terminal has `output: []` as before.
- Negative control: with the GET change reverted, the new case fails (measured).
- `pnpm check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)