### PR TITLE
Automate issue and pull request labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Something behaves differently from what the API documents or from the reference implementations.
-labels: [bug]
+type: bug
 
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Propose new functionality or an improvement to an existing API.
-labels: [enhancement]
+type: feature
 
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Propose new functionality or an improvement to an existing API.
+labels: [enhancement]
+
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the user problem or missing capability, not only the proposed API.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior and API shape you would like to see.
+    validations:
+      required: true
+
+  - type: input
+    id: packages
+    attributes:
+      label: Affected packages
+      placeholder: "@polymind-inc/agent-framework-core, @polymind-inc/agent-framework-foundry"
+    validations:
+      required: false
+
+  - type: textarea
+    id: parity
+    attributes:
+      label: Reference behavior
+      description: If .NET, Python, or Go already supports this, link the implementation or sample.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,8 @@ reference implementation you checked and where. If it deliberately diverges, say
 
 - Reference checked:
 - Wire format affected: yes / no
+- Public API affected: yes / no
+- Breaking change: yes / no
 
 ## Checklist
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,100 @@
+# Package labels are based on implementation and package documentation files. Package manifests
+# and build configuration are intentionally excluded so lockstep release PRs do not receive every
+# package label.
+core:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/core/src/**"
+          - "packages/core/README.md"
+
+agentserver:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/agentserver/src/**"
+          - "packages/agentserver/README.md"
+
+anthropic:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/anthropic/src/**"
+          - "packages/anthropic/README.md"
+
+openai:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/openai/src/**"
+          - "packages/openai/README.md"
+
+meta:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/meta/src/**"
+          - "packages/meta/README.md"
+
+# Feature labels follow the terminology used by the official .NET/Python repository.
+agents:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/core/src/agent/**"
+
+workflows:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/**/workflow*/**"
+          - "examples/**/workflow*/**"
+
+hosting:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/agentserver/src/**"
+          - "packages/agentserver/README.md"
+          - "packages/foundry/src/hosting/**"
+          - "examples/02-foundry/02-hosted-agent/**"
+
+foundry:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/foundry/src/**"
+          - "packages/foundry/README.md"
+          - "examples/02-foundry/**"
+
+memory:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/**/memory/**"
+          - "packages/**/*memory*.ts"
+          - "examples/**/*memory*.ts"
+
+skills:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/**/skills/**"
+          - "packages/**/*skill*.ts"
+          - "examples/**/*skill*.ts"
+
+mcp:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/mcp/src/**"
+          - "packages/mcp/README.md"
+          - "examples/**/*mcp*.ts"
+          - "examples/02-foundry/04-toolbox.ts"
+
+a2a:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/a2a/src/**"
+          - "packages/a2a/README.md"
+          - "examples/04-a2a/**"
+
+observability:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/core/src/observability/**"
+          - "packages/agentserver/src/**/*observability*.ts"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "**/*.md"

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -1,0 +1,27 @@
+name: Label issues
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    name: Mark external issues for triage
+    if: ${{ !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const labels = new Set((context.payload.issue.labels ?? []).map((label) => label.name));
+            if (!labels.has("triage")) {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: context.issue.number,
+                labels: ["triage"],
+              });
+            }

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -53,19 +53,17 @@ jobs:
             const body = pullRequest.body ?? "";
             const breakingTitle = /^(?:\[BREAKING\]|BREAKING(?: CHANGE)?[: ])\s*/i.test(title);
             const breakingYes = /^\s*-\s*Breaking change:\s*yes\s*$/im.test(body);
-            const breakingNo = /^\s*-\s*Breaking change:\s*no\s*$/im.test(body);
             const publicApiYes = /^\s*-\s*Public API affected:\s*yes\s*$/im.test(body);
-            const publicApiNo = /^\s*-\s*Public API affected:\s*no\s*$/im.test(body);
 
             if (breakingTitle || breakingYes) {
               await addLabel("breaking change");
-            } else if (breakingNo) {
+            } else {
               await removeLabel("breaking change");
             }
 
             if (publicApiYes) {
               await addLabel("public-api-change");
-            } else if (publicApiNo) {
+            } else {
               await removeLabel("public-api-change");
             }
 

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,75 @@
+name: Label pull request
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  paths:
+    name: Add path labels
+    runs-on: ubuntu-latest
+    steps:
+      # This action reads the changed-file list through the API and never checks out PR code.
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  metadata:
+    name: Synchronize review labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const pullRequest = context.payload.pull_request;
+            const current = new Set((pullRequest.labels ?? []).map((label) => label.name));
+
+            async function addLabel(name) {
+              if (current.has(name)) return;
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: pullRequest.number,
+                labels: [name],
+              });
+              current.add(name);
+            }
+
+            async function removeLabel(name) {
+              if (!current.has(name)) return;
+              await github.rest.issues.removeLabel({
+                ...context.repo,
+                issue_number: pullRequest.number,
+                name,
+              });
+              current.delete(name);
+            }
+
+            const title = pullRequest.title ?? "";
+            const body = pullRequest.body ?? "";
+            const breakingTitle = /^(?:\[BREAKING\]|BREAKING(?: CHANGE)?[: ])\s*/i.test(title);
+            const breakingYes = /^\s*-\s*Breaking change:\s*yes\s*$/im.test(body);
+            const breakingNo = /^\s*-\s*Breaking change:\s*no\s*$/im.test(body);
+            const publicApiYes = /^\s*-\s*Public API affected:\s*yes\s*$/im.test(body);
+            const publicApiNo = /^\s*-\s*Public API affected:\s*no\s*$/im.test(body);
+
+            if (breakingTitle || breakingYes) {
+              await addLabel("breaking change");
+            } else if (breakingNo) {
+              await removeLabel("breaking change");
+            }
+
+            if (publicApiYes) {
+              await addLabel("public-api-change");
+            } else if (publicApiNo) {
+              await removeLabel("public-api-change");
+            }
+
+            // A parity review is tied to the reviewed commit. New commits always invalidate it.
+            if (context.payload.action === "synchronize") {
+              await removeLabel("parity-approved");
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,10 @@ also carries an explicit **"Security considerations"** note, as the .NET impleme
 - Say which reference implementation you checked against, and whether the wire format is affected.
   The pull request template asks for both.
 
+Issues use the organization-level `Bug`, `Feature` and `Task` issue types for classification;
+labels describe feature areas and triage state. Pull requests do not have an issue type, so use
+`bug`, `enhancement`, `maintenance` or `release` to describe their change kind.
+
 Changed package and feature paths are labeled automatically. Maintainers add `parity-approved`
 only after comparing the current pull request commit with the relevant .NET, Python or Go
 implementation; pushing another commit removes that approval. `public-api-change` flags exported

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,12 +80,19 @@ also carries an explicit **"Security considerations"** note, as the .NET impleme
   `type:` prefix — "Add the umbrella package", not "feat: add umbrella package". Pull requests
   are squash-merged, so the title becomes the commit subject on the default branch. The
   conventional-commit prefixes configured in `dependabot.yml` apply only to Dependabot's own
-  commits.
+  commits. Prefix a backward-incompatible change with `[BREAKING]`; automation keeps the
+  `breaking change` label synchronized with the title and pull request template.
 - `pnpm check` passes.
 - Behaviour changes come with a test that fails without the change.
 - Public API changes update the package README and `CHANGELOG.md`.
 - Say which reference implementation you checked against, and whether the wire format is affected.
   The pull request template asks for both.
+
+Changed package and feature paths are labeled automatically. Maintainers add `parity-approved`
+only after comparing the current pull request commit with the relevant .NET, Python or Go
+implementation; pushing another commit removes that approval. `public-api-change` flags exported
+API changes for additional review, while `dependencies`, `javascript` and `github_actions` are
+reserved for Dependabot.
 
 ## Releasing
 


### PR DESCRIPTION
## What this changes

- classify issues with the organization-level `Bug`, `Feature`, and `Task` issue types and migrate the existing Hosted Agent issues
- add path-based labels for packages, hosting, Foundry, workflows, memory, skills, MCP, A2A, observability, and documentation
- mark externally reported issues for maintainer triage
- synchronize `public-api-change` and `breaking change` from explicit PR metadata
- invalidate `parity-approved` whenever a new commit is pushed
- add issue forms and document the Issue Type and label workflow

## Why

Issue kinds were previously represented by `bug` and `enhancement` labels alongside feature-area labels. Using GitHub Issue Types for Bug, Feature, and Task keeps classification separate from labels and aligns the TypeScript repository with the official .NET/Python label vocabulary and the Go parity-review model while preserving Dependabot-only labels.

## Impact

Issue and PR triage becomes searchable and repeatable. Issue Types classify issues, labels describe feature areas and triage state, and PR labels describe change kinds. Path labels and safe review-state transitions are automated; semantic approval labels still require maintainer review.

## Parity

- Reference checked: microsoft/agent-framework issue types and label workflows, and microsoft/agent-framework-go API consistency review
- Wire format affected: no
- Public API affected: no
- Breaking change: no

## Validation

- `git diff --check`
- parsed both Issue forms and all label workflow YAML files with the `yaml` CLI
- verified PR metadata parsing does not treat the template default `yes / no` as an affirmative answer
- verified all 19 Hosted Agent issues have the intended Issue Type and no duplicate `bug` or `enhancement` label
- verified the resulting historical PR labels through GitHub CLI
- `pnpm check` could not run locally because the Windows ARM64 optional binaries for Biome and TypeScript are absent; GitHub CI runs on its configured runners