### PR TITLE
Surface failed response errors and join message texts with a newline

### DIFF
--- a/packages/core/src/middleware/middleware.test.ts
+++ b/packages/core/src/middleware/middleware.test.ts
@@ -261,7 +261,9 @@ describe('agent middleware', () => {
       // drain
     }
 
-    expect((await stream.finalResponse()).text).toBe('hey!');
+    // The middleware appended a separate assistant message, so the joined text keeps the
+    // message boundary visible as a newline.
+    expect((await stream.finalResponse()).text).toBe('hey\n!');
   });
 
   it('streams the updates of a response a middleware supplied', async () => {

--- a/packages/core/src/types/message.test.ts
+++ b/packages/core/src/types/message.test.ts
@@ -62,21 +62,38 @@ describe('textOf', () => {
   it('accepts an AgentResponse too', () => {
     const response = agentResponse({
       messages: [
-        { role: 'assistant', contents: [textContent('hello ')] },
+        { role: 'assistant', contents: [textContent('hello')] },
         { role: 'assistant', contents: [textContent('world')] },
       ],
     });
-    expect(textOf(response)).toBe('hello world');
+    expect(textOf(response)).toBe('hello\nworld');
   });
 });
 
 describe('textOfMessages', () => {
-  it('concatenates across messages', () => {
+  it('joins message texts with a newline', () => {
     expect(
       textOfMessages([
         { role: 'user', contents: [textContent('a')] },
         { role: 'assistant', contents: [textContent('b')] },
       ]),
-    ).toBe('ab');
+    ).toBe('a\nb');
+  });
+
+  it('skips empty messages instead of separating them', () => {
+    expect(
+      textOfMessages([
+        { role: 'assistant', contents: [textContent('foo')] },
+        { role: 'assistant', contents: [] },
+        { role: 'assistant', contents: [{ type: 'function_call', callId: 'c1', name: 'f', arguments: '{}' }] },
+        { role: 'assistant', contents: [textContent('Bar')] },
+      ]),
+    ).toBe('foo\nBar');
+  });
+
+  it('concatenates contents inside one message without a separator', () => {
+    expect(
+      textOfMessages([{ role: 'assistant', contents: [textContent('foo'), textContent('Bar')] }]),
+    ).toBe('fooBar');
   });
 });

--- a/packages/core/src/types/message.test.ts
+++ b/packages/core/src/types/message.test.ts
@@ -85,15 +85,18 @@ describe('textOfMessages', () => {
       textOfMessages([
         { role: 'assistant', contents: [textContent('foo')] },
         { role: 'assistant', contents: [] },
-        { role: 'assistant', contents: [{ type: 'function_call', callId: 'c1', name: 'f', arguments: '{}' }] },
+        {
+          role: 'assistant',
+          contents: [{ type: 'function_call', callId: 'c1', name: 'f', arguments: '{}' }],
+        },
         { role: 'assistant', contents: [textContent('Bar')] },
       ]),
     ).toBe('foo\nBar');
   });
 
   it('concatenates contents inside one message without a separator', () => {
-    expect(
-      textOfMessages([{ role: 'assistant', contents: [textContent('foo'), textContent('Bar')] }]),
-    ).toBe('fooBar');
+    expect(textOfMessages([{ role: 'assistant', contents: [textContent('foo'), textContent('Bar')] }])).toBe(
+      'fooBar',
+    );
   });
 });

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -77,16 +77,30 @@ export function normalizeInput(input?: AgentRunInput): Message[] {
   return result;
 }
 
-/** Concatenates the text of every message. */
+/**
+ * Joins the text of every message, separating non-empty messages with a newline.
+ *
+ * Message boundaries stay visible in the combined text, so two assistant messages `foo` and `Bar`
+ * read as `foo\nBar`, not `fooBar` (.NET `AgentResponse.Text` joins with a newline the same way,
+ * as does Go `Response.String()`). A message with no text contributes nothing — not a separator —
+ * and the contents *inside* one message still concatenate without a separator.
+ */
 export function textOfMessages(messages: readonly Message[]): string {
   let out = '';
   for (const msg of messages) {
-    out += textOfContents(msg.contents);
+    const text = textOfContents(msg.contents);
+    if (text === '') {
+      continue;
+    }
+    if (out !== '') {
+      out += '\n';
+    }
+    out += text;
   }
   return out;
 }
 
-/** Concatenates the text of a single message, or of every message in an agent response. */
+/** Concatenates the text of a single message, or joins every message's text in an agent response. */
 export function textOf(value: Message | AgentResponse<unknown>): string {
   return 'messages' in value ? value.text : textOfContents(value.contents);
 }

--- a/packages/openai/src/from-openai.test.ts
+++ b/packages/openai/src/from-openai.test.ts
@@ -238,7 +238,9 @@ describe('failed responses surface their error', () => {
     const updates = fold([
       { type: 'response.completed', response: { id: 'resp_1', status: 'completed', output: [] } },
     ]);
-    expect(updates.flatMap((update) => update.contents).some((content) => content.type === 'error')).toBe(false);
+    expect(updates.flatMap((update) => update.contents).some((content) => content.type === 'error')).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/openai/src/from-openai.test.ts
+++ b/packages/openai/src/from-openai.test.ts
@@ -179,6 +179,69 @@ describe('logprobs', () => {
   });
 });
 
+// A failed response reports why: the API's `response.error` becomes an `error` content on the
+// parsed response, so the failure diagnostic reaches the caller instead of being dropped. This
+// mirrors .NET (MEAI `OpenAIResponsesChatClient`) and Go `responsesFailureContent`, which also
+// substitute a generic message/code when the wire carries none.
+describe('failed responses surface their error', () => {
+  it('adds an error content to an awaited failed response', () => {
+    const response = parseResponse({
+      id: 'resp_1',
+      status: 'failed',
+      error: { code: 'server_error', message: 'The model blew up.' },
+      output: [],
+    });
+    expect(contentsOf(response)).toContainEqual(
+      expect.objectContaining({ type: 'error', message: 'The model blew up.', errorCode: 'server_error' }),
+    );
+  });
+
+  it('falls back to a generic message and code when the failure carries none', () => {
+    const response = parseResponse({ id: 'resp_1', status: 'failed', error: { message: '  ' }, output: [] });
+    expect(contentsOf(response)).toContainEqual(
+      expect.objectContaining({ type: 'error', message: 'The agent run failed.', errorCode: 'failed' }),
+    );
+  });
+
+  it('surfaces a reported error even without the failed status', () => {
+    const response = parseResponse({
+      id: 'resp_1',
+      status: 'completed',
+      error: { code: 'rate_limit_exceeded', message: 'Rate limited.' },
+      output: [],
+    });
+    expect(contentsOf(response)).toContainEqual(
+      expect.objectContaining({ type: 'error', message: 'Rate limited.', errorCode: 'rate_limit_exceeded' }),
+    );
+  });
+
+  it('adds the error to the response.failed stream event', () => {
+    const updates = fold([
+      {
+        type: 'response.failed',
+        response: {
+          id: 'resp_1',
+          status: 'failed',
+          error: { code: 'server_error', message: 'The model blew up.' },
+          output: [],
+        },
+      },
+    ]);
+    expect(updates.flatMap((update) => update.contents)).toContainEqual(
+      expect.objectContaining({ type: 'error', message: 'The model blew up.', errorCode: 'server_error' }),
+    );
+  });
+
+  it('adds nothing to a successful response', () => {
+    const awaited = parseResponse({ id: 'resp_1', status: 'completed', output: [] });
+    expect(contentsOf(awaited).some((content) => content.type === 'error')).toBe(false);
+    const updates = fold([
+      { type: 'response.completed', response: { id: 'resp_1', status: 'completed', output: [] } },
+    ]);
+    expect(updates.flatMap((update) => update.contents).some((content) => content.type === 'error')).toBe(false);
+  });
+});
+
 // Python maps `response.image_generation_call.partial_image` to the same
 // call/result pair the finished item produces, with the preview marked so a consumer can tell the
 // two apart (`_chat_client.py:3196-3222`). The event only exists when the caller asked for it via

--- a/packages/openai/src/from-openai.ts
+++ b/packages/openai/src/from-openai.ts
@@ -140,7 +140,10 @@ const DEFAULT_FAILURE_CODE = 'failed';
  * MEAI Responses client and Go `responsesFailureContent` report the same content). When the wire
  * carries no usable message or code, generic substitutes keep the failure from being silent.
  */
-function failureContent(response: Partial<Response> | null | undefined, rawEvent: unknown): ErrorContent | undefined {
+function failureContent(
+  response: Partial<Response> | null | undefined,
+  rawEvent: unknown,
+): ErrorContent | undefined {
   const error = response?.error;
   const message = typeof error?.message === 'string' ? error.message : '';
   const code = typeof error?.code === 'string' ? error.code : '';

--- a/packages/openai/src/from-openai.ts
+++ b/packages/openai/src/from-openai.ts
@@ -4,6 +4,7 @@ import type {
   ChatResponseUpdate,
   ChatResponseUpdateInit,
   Content,
+  ErrorContent,
   FinishReason,
   UsageDetails,
 } from '@polymind-inc/agent-framework-core';
@@ -125,6 +126,33 @@ export function parseFinishReason(response: unknown): FinishReason | undefined {
   if (raw?.status !== 'completed') return undefined;
   const output = raw.output ?? [];
   return output.some((item) => item?.type === 'function_call') ? 'tool_calls' : 'stop';
+}
+
+/** The substitute diagnostic for a failure the wire does not describe. */
+const DEFAULT_FAILURE_MESSAGE = 'The agent run failed.';
+const DEFAULT_FAILURE_CODE = 'failed';
+
+/**
+ * The `error` content a failed response reports, or `undefined` when the response did not fail.
+ *
+ * The Responses API marks failure with `status: "failed"` and describes it in `response.error`;
+ * either signal alone counts, so a failure is surfaced to the caller rather than dropped (.NET's
+ * MEAI Responses client and Go `responsesFailureContent` report the same content). When the wire
+ * carries no usable message or code, generic substitutes keep the failure from being silent.
+ */
+function failureContent(response: Partial<Response> | null | undefined, rawEvent: unknown): ErrorContent | undefined {
+  const error = response?.error;
+  const message = typeof error?.message === 'string' ? error.message : '';
+  const code = typeof error?.code === 'string' ? error.code : '';
+  if (response?.status !== 'failed' && message === '' && code === '') {
+    return undefined;
+  }
+  return {
+    type: 'error',
+    message: message.trim() === '' ? DEFAULT_FAILURE_MESSAGE : message,
+    errorCode: code === '' ? DEFAULT_FAILURE_CODE : code,
+    rawRepresentation: rawEvent,
+  };
 }
 
 /**
@@ -544,6 +572,10 @@ export function parseResponse(response: unknown, ctx: ParseContext = {}): ChatRe
       }
     }
   }
+  const failure = failureContent(raw, response);
+  if (failure !== undefined) {
+    contents.push(failure);
+  }
 
   const init: Parameters<typeof chatResponse<undefined>>[0] = {
     messages: [{ role: 'assistant', contents }],
@@ -812,6 +844,12 @@ export function parseStreamEvent(
       const usage = parseUsage(response?.usage);
       if (usage !== undefined) {
         contents.push({ type: 'usage', usageDetails: usage, rawRepresentation: event });
+      }
+      if (raw.type === 'response.failed') {
+        const failure = failureContent(response, event);
+        if (failure !== undefined) {
+          contents.push(failure);
+        }
       }
       break;
     }


### PR DESCRIPTION
Two behavioural fixes aligning with the .NET reference implementation (both also adopted by Go in microsoft/agent-framework-go#804 and #742).

## Surface the error of a failed Responses API response

A failed response carried its diagnostic only in `rawRepresentation`: the parsed response and the `response.failed` stream event reported usage and finish reason but dropped `response.error`, so the caller never saw why the run failed.

`parseResponse` and the `response.failed` stream event now report an `error` content when the response has `status: 'failed'` or a non-empty error message/code. When the wire carries no usable message or code, generic substitutes (`The agent run failed.` / `failed`) keep the failure from being silent. Successful responses are unchanged, and nothing about the request input changes.

## Join response message texts with a newline

`AgentResponse.text` / `ChatResponse.text` flattened every message's text with no separator, so a multi-message assistant turn read as `fooBar` where .NET `AgentResponse.Text` (ChatMessage list `ConcatText`) returns `foo\nBar`. Non-empty message texts are now joined with a newline; empty messages contribute nothing, not a separator. Contents *inside* one message still concatenate without a separator, and update `text` is unchanged.

The separator is a fixed `\n` rather than .NET's `Environment.NewLine`, so the same transcript reads the same on every platform. This also affects the string an agent-as-tool (`asTool`) returns.

## Verification

- Reproduction tests were added first and observed failing (4 + 3), then re-observed failing with each fix temporarily reverted.
- Full suite: 1256 passed, plus the complete `pnpm check` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)