### PR TITLE
Preserve Responses v2 item types and add cross-SDK parity tests

### DIFF
--- a/packages/foundry/src/hosting/converters.parity.test.ts
+++ b/packages/foundry/src/hosting/converters.parity.test.ts
@@ -1,0 +1,464 @@
+import type { OutputItem } from '@polymind-inc/agent-framework-agentserver';
+import type { Content, Message } from '@polymind-inc/agent-framework-core';
+import { describe, expect, it } from 'vitest';
+import { itemToMessage } from './converters.js';
+import { OutputBuilder } from './output.js';
+
+// Fixtures mirror the wire shapes of the official SDK models (`azure-ai-agentserver-responses`
+// item types, the same set the .NET `Azure.AI.AgentServer` union declares), so these tests pin
+// the converter against payloads a .NET- or Python-hosted container actually produces. Every
+// recognized item type must survive replay with its semantic data — a stored-response transcript
+// is replayed through `itemToMessage`, and an item that comes back `undefined` is deleted from
+// what the model sees.
+
+const WEB_SEARCH_CALL: OutputItem = {
+  type: 'web_search_call',
+  id: 'ws_0123456789abcdef0123456789abcdef0123456789abcdef01',
+  status: 'completed',
+  action: { type: 'search', query: 'best pizza in tokyo' },
+};
+
+const FILE_SEARCH_CALL: OutputItem = {
+  type: 'file_search_call',
+  id: 'fs_0123456789abcdef0123456789abcdef0123456789abcdef01',
+  status: 'completed',
+  queries: ['quarterly revenue'],
+  results: [{ file_id: 'file-1', filename: 'q3.pdf', score: 0.92, text: 'Revenue was up.' }],
+};
+
+const CODE_INTERPRETER_CALL: OutputItem = {
+  type: 'code_interpreter_call',
+  id: 'ci_0123456789abcdef0123456789abcdef0123456789abcdef01',
+  status: 'completed',
+  container_id: 'cntr_1',
+  code: 'print(1 + 1)',
+  outputs: [
+    { type: 'logs', logs: '2\n' },
+    { type: 'image', url: 'https://example.com/plot.png' },
+  ],
+};
+
+const LOCAL_SHELL_CALL: OutputItem = {
+  type: 'local_shell_call',
+  id: 'lsh_1',
+  call_id: 'call_ls1',
+  status: 'completed',
+  action: { type: 'exec', command: ['ls', '-la'], env: {} },
+};
+
+const LOCAL_SHELL_CALL_OUTPUT: OutputItem = {
+  type: 'local_shell_call_output',
+  id: 'lsho_1',
+  status: 'completed',
+  output: 'total 0\n',
+};
+
+const COMPUTER_CALL: OutputItem = {
+  type: 'computer_call',
+  id: 'cu_1',
+  call_id: 'call_cu1',
+  status: 'completed',
+  action: { type: 'click', button: 'left', x: 100, y: 200 },
+  pending_safety_checks: [],
+};
+
+const COMPUTER_CALL_OUTPUT: OutputItem = {
+  type: 'computer_call_output',
+  id: 'cuo_1',
+  call_id: 'call_cu1',
+  output: { type: 'computer_screenshot', image_url: 'data:image/png;base64,AAAA' },
+};
+
+const CUSTOM_TOOL_CALL: OutputItem = {
+  type: 'custom_tool_call',
+  id: 'ctc_1',
+  call_id: 'call_ct1',
+  name: 'run_query',
+  input: 'SELECT 1',
+};
+
+const APPLY_PATCH_CALL: OutputItem = {
+  type: 'apply_patch_call',
+  id: 'apc_1',
+  call_id: 'call_ap1',
+  status: 'completed',
+  operation: { type: 'update_file', path: 'src/index.ts', diff: '@@ -1 +1 @@' },
+};
+
+const APPLY_PATCH_CALL_OUTPUT: OutputItem = {
+  type: 'apply_patch_call_output',
+  id: 'apco_1',
+  call_id: 'call_ap1',
+  status: 'completed',
+  output: 'Updated src/index.ts',
+};
+
+const STRUCTURED_OUTPUTS: OutputItem = {
+  type: 'structured_outputs',
+  id: 'so_1',
+  output: { answer: 42 },
+};
+
+const OUTPUT_MESSAGE: OutputItem = {
+  type: 'output_message',
+  id: 'om_1',
+  role: 'assistant',
+  status: 'completed',
+  content: [{ type: 'output_text', text: 'Done.', annotations: [] }],
+};
+
+/** Converts, then narrows away the undefined case with a clear failure. */
+function messageOf(item: OutputItem): Message {
+  const message = itemToMessage(item);
+  if (message === undefined) throw new Error(`expected a message for item type '${item.type}'`);
+  return message;
+}
+
+function contentsOf(item: OutputItem): Content[] {
+  return messageOf(item).contents;
+}
+
+describe('search item replay', () => {
+  it('replays a web search call as the call and its result', () => {
+    const message = messageOf(WEB_SEARCH_CALL);
+    expect(message.role).toBe('assistant');
+    expect(message.contents[0]).toMatchObject({
+      type: 'search_tool_call',
+      callId: WEB_SEARCH_CALL.id,
+      toolName: 'web_search',
+      arguments: { type: 'search', query: 'best pizza in tokyo' },
+      additionalProperties: { status: 'completed' },
+    });
+    expect(message.contents[1]).toMatchObject({
+      type: 'search_tool_result',
+      callId: WEB_SEARCH_CALL.id,
+      toolName: 'web_search',
+      result: { action: { type: 'search', query: 'best pizza in tokyo' } },
+    });
+  });
+
+  it('replays a file search call with its queries and results', () => {
+    const [call, result] = contentsOf(FILE_SEARCH_CALL);
+    expect(call).toMatchObject({
+      type: 'search_tool_call',
+      callId: FILE_SEARCH_CALL.id,
+      toolName: 'file_search',
+      arguments: { queries: ['quarterly revenue'] },
+    });
+    expect(result).toMatchObject({
+      type: 'search_tool_result',
+      callId: FILE_SEARCH_CALL.id,
+      toolName: 'file_search',
+      result: { results: [expect.objectContaining({ file_id: 'file-1' })] },
+    });
+  });
+});
+
+describe('code interpreter item replay', () => {
+  it('replays the executed code and its outputs', () => {
+    const [call, result] = contentsOf(CODE_INTERPRETER_CALL);
+    expect(call).toMatchObject({
+      type: 'code_interpreter_tool_call',
+      callId: CODE_INTERPRETER_CALL.id,
+      inputs: [{ type: 'text', text: 'print(1 + 1)' }],
+    });
+    expect(result).toMatchObject({
+      type: 'code_interpreter_tool_result',
+      callId: CODE_INTERPRETER_CALL.id,
+    });
+    const outputs = (result as { outputs: Content[] }).outputs;
+    expect(outputs[0]).toMatchObject({ type: 'text', text: '2\n' });
+    expect(outputs[1]).toMatchObject({ type: 'uri', uri: 'https://example.com/plot.png' });
+  });
+
+  it('replays a call with no code as the result only', () => {
+    const contents = contentsOf({ ...CODE_INTERPRETER_CALL, code: null });
+    expect(contents).toHaveLength(1);
+    expect(contents[0]).toMatchObject({ type: 'code_interpreter_tool_result' });
+  });
+});
+
+describe('local shell item replay', () => {
+  it('replays a local shell call as a shell tool call', () => {
+    const message = messageOf(LOCAL_SHELL_CALL);
+    expect(message.role).toBe('assistant');
+    expect(message.contents[0]).toMatchObject({
+      type: 'shell_tool_call',
+      callId: 'call_ls1',
+      commands: ['ls', '-la'],
+      status: 'completed',
+    });
+  });
+
+  it('replays a local shell output keyed by the item id', () => {
+    const message = messageOf(LOCAL_SHELL_CALL_OUTPUT);
+    expect(message.role).toBe('tool');
+    // The wire item carries no `call_id`; its own id is the correlation key (Python parity).
+    expect(message.contents[0]).toMatchObject({ type: 'shell_tool_result', callId: 'lsho_1' });
+    expect((message.contents[0] as { outputs: Content[] }).outputs[0]).toMatchObject({
+      type: 'shell_command_output',
+      stdout: 'total 0\n',
+    });
+  });
+});
+
+describe('computer, patch and custom tool item replay', () => {
+  it('replays a computer call as an informational function call with JSON arguments', () => {
+    const message = messageOf(COMPUTER_CALL);
+    expect(message.role).toBe('assistant');
+    // The action stays a structured object — stringifying it as a repr would make the
+    // arguments unparseable on the next hop.
+    expect(message.contents[0]).toMatchObject({
+      type: 'function_call',
+      callId: 'call_cu1',
+      name: 'computer_use',
+      arguments: { type: 'click', button: 'left', x: 100, y: 200 },
+      informationalOnly: true,
+    });
+  });
+
+  it('replays a computer call output with its structured screenshot payload', () => {
+    const message = messageOf(COMPUTER_CALL_OUTPUT);
+    expect(message.role).toBe('tool');
+    expect(message.contents[0]).toMatchObject({
+      type: 'function_result',
+      callId: 'call_cu1',
+      result: { type: 'computer_screenshot', image_url: 'data:image/png;base64,AAAA' },
+    });
+  });
+
+  it('replays a custom tool call under its own name', () => {
+    expect(contentsOf(CUSTOM_TOOL_CALL)[0]).toMatchObject({
+      type: 'function_call',
+      callId: 'call_ct1',
+      name: 'run_query',
+      arguments: 'SELECT 1',
+      informationalOnly: true,
+    });
+  });
+
+  it('replays an apply patch call with its structured operation', () => {
+    expect(contentsOf(APPLY_PATCH_CALL)[0]).toMatchObject({
+      type: 'function_call',
+      callId: 'call_ap1',
+      name: 'apply_patch',
+      arguments: { type: 'update_file', path: 'src/index.ts', diff: '@@ -1 +1 @@' },
+      informationalOnly: true,
+    });
+  });
+
+  it('replays an apply patch output as the tool result', () => {
+    const message = messageOf(APPLY_PATCH_CALL_OUTPUT);
+    expect(message.role).toBe('tool');
+    expect(message.contents[0]).toMatchObject({
+      type: 'function_result',
+      callId: 'call_ap1',
+      result: 'Updated src/index.ts',
+    });
+  });
+});
+
+describe('remaining recognized item replay', () => {
+  it('replays structured outputs as their JSON text', () => {
+    const message = messageOf(STRUCTURED_OUTPUTS);
+    expect(message.role).toBe('assistant');
+    expect(message.contents[0]).toMatchObject({ type: 'text', text: '{"answer":42}' });
+  });
+
+  it('passes a string structured output through unchanged', () => {
+    expect(contentsOf({ ...STRUCTURED_OUTPUTS, output: 'plain' })[0]).toMatchObject({
+      type: 'text',
+      text: 'plain',
+    });
+  });
+
+  it('replays an output_message like a message', () => {
+    const message = messageOf(OUTPUT_MESSAGE);
+    expect(message.role).toBe('assistant');
+    expect(message.contents[0]).toMatchObject({ type: 'text', text: 'Done.' });
+    expect(message.messageId).toBe('om_1');
+  });
+});
+
+describe('items with no framework representation', () => {
+  it('preserves an unrecognized item as unknown content instead of dropping it', () => {
+    const item: OutputItem = {
+      type: 'memory_search_call',
+      id: 'msc_1',
+      status: 'completed',
+      query: 'what did we decide',
+    };
+    const message = messageOf(item);
+    expect(message.role).toBe('assistant');
+    expect(message.contents[0]).toMatchObject({
+      type: 'unknown',
+      unknownType: 'memory_search_call',
+      id: 'msc_1',
+      query: 'what did we decide',
+    });
+  });
+
+  it('does not double-handle an approval decision', () => {
+    // `mcp_approval_response` is consumed out of band (`approvalResponseTarget` binds the
+    // decision to the stored request); replaying it as content too would answer twice.
+    expect(
+      itemToMessage({ type: 'mcp_approval_response', approval_request_id: 'mcpr_1', approve: true }),
+    ).toBeUndefined();
+  });
+
+  it('does not replay an item reference', () => {
+    // A reference points at a service-held item this container cannot dereference.
+    expect(itemToMessage({ type: 'item_reference', id: 'msg_1' })).toBeUndefined();
+  });
+});
+
+describe('search and code interpreter output round trip', () => {
+  it('emits a web search call item and replays it', () => {
+    const builder = new OutputBuilder('caresp_hint');
+    const events = [
+      ...builder.push({
+        type: 'search_tool_call',
+        callId: WEB_SEARCH_CALL.id,
+        toolName: 'web_search',
+        arguments: { type: 'search', query: 'best pizza in tokyo' },
+      } as Content),
+      ...builder.push({
+        type: 'search_tool_result',
+        callId: WEB_SEARCH_CALL.id,
+        toolName: 'web_search',
+        result: { action: { type: 'search', query: 'best pizza in tokyo' } },
+      } as Content),
+      ...builder.close(),
+    ];
+
+    const done = events.filter((event) => event.type === 'response.output_item.done');
+    expect(done).toHaveLength(1);
+    const item = (done[0] as unknown as { item: OutputItem }).item;
+    expect(item).toMatchObject({
+      type: 'web_search_call',
+      id: WEB_SEARCH_CALL.id,
+      status: 'completed',
+      action: { type: 'search', query: 'best pizza in tokyo' },
+    });
+
+    const replayed = messageOf(item);
+    expect(replayed.contents[0]).toMatchObject({
+      type: 'search_tool_call',
+      callId: WEB_SEARCH_CALL.id,
+      toolName: 'web_search',
+      arguments: { type: 'search', query: 'best pizza in tokyo' },
+    });
+  });
+
+  it('emits a file search call item carrying the results and replays it', () => {
+    const builder = new OutputBuilder('caresp_hint');
+    const events = [
+      ...builder.push({
+        type: 'search_tool_call',
+        callId: FILE_SEARCH_CALL.id,
+        toolName: 'file_search',
+        arguments: { queries: ['quarterly revenue'] },
+      } as Content),
+      ...builder.push({
+        type: 'search_tool_result',
+        callId: FILE_SEARCH_CALL.id,
+        toolName: 'file_search',
+        result: {
+          results: [{ file_id: 'file-1', filename: 'q3.pdf', score: 0.92, text: 'Revenue was up.' }],
+        },
+      } as Content),
+      ...builder.close(),
+    ];
+
+    const done = events.filter((event) => event.type === 'response.output_item.done');
+    expect(done).toHaveLength(1);
+    const item = (done[0] as unknown as { item: OutputItem }).item;
+    expect(item).toMatchObject({
+      type: 'file_search_call',
+      id: FILE_SEARCH_CALL.id,
+      status: 'completed',
+      queries: ['quarterly revenue'],
+      results: [expect.objectContaining({ file_id: 'file-1' })],
+    });
+
+    const [call, result] = messageOf(item).contents;
+    expect(call).toMatchObject({ type: 'search_tool_call', toolName: 'file_search' });
+    expect(result).toMatchObject({
+      type: 'search_tool_result',
+      result: { results: [expect.objectContaining({ file_id: 'file-1' })] },
+    });
+  });
+
+  it('re-mints a search item id that does not fit the protocol format', () => {
+    const builder = new OutputBuilder('caresp_hint');
+    const events = [
+      ...builder.push({
+        type: 'search_tool_call',
+        callId: 'provider-namespace-id',
+        toolName: 'web_search',
+        arguments: {},
+      } as Content),
+      ...builder.close(),
+    ];
+    const done = events.at(-1) as unknown as { item: OutputItem };
+    expect(String(done.item.id)).toMatch(/^ws_/);
+  });
+
+  it('emits a code interpreter call item with code and outputs and replays it', () => {
+    const builder = new OutputBuilder('caresp_hint');
+    const events = [
+      ...builder.push({
+        type: 'code_interpreter_tool_call',
+        callId: CODE_INTERPRETER_CALL.id,
+        inputs: [{ type: 'text', text: 'print(1 + 1)' }],
+      } as Content),
+      ...builder.push({
+        type: 'code_interpreter_tool_result',
+        callId: CODE_INTERPRETER_CALL.id,
+        outputs: [
+          { type: 'text', text: '2\n' },
+          { type: 'uri', uri: 'https://example.com/plot.png', mediaType: 'image' },
+        ],
+      } as Content),
+      ...builder.close(),
+    ];
+
+    const done = events.filter((event) => event.type === 'response.output_item.done');
+    expect(done).toHaveLength(1);
+    const item = (done[0] as unknown as { item: OutputItem }).item;
+    expect(item).toMatchObject({
+      type: 'code_interpreter_call',
+      id: CODE_INTERPRETER_CALL.id,
+      status: 'completed',
+      code: 'print(1 + 1)',
+      outputs: [
+        { type: 'logs', logs: '2\n' },
+        { type: 'image', url: 'https://example.com/plot.png' },
+      ],
+    });
+
+    const [call, result] = messageOf(item).contents;
+    expect(call).toMatchObject({
+      type: 'code_interpreter_tool_call',
+      inputs: [{ type: 'text', text: 'print(1 + 1)' }],
+    });
+    expect((result as { outputs: Content[] }).outputs).toHaveLength(2);
+  });
+
+  it('reports a search result with no open call instead of emitting an orphan', () => {
+    const dropped: Content[] = [];
+    const builder = new OutputBuilder('caresp_hint', {
+      onUnsupportedContent: (content) => dropped.push(content),
+    });
+    const events = [
+      ...builder.push({
+        type: 'search_tool_result',
+        callId: 'ws_orphan',
+        toolName: 'web_search',
+        result: {},
+      } as Content),
+    ];
+    expect(events).toHaveLength(0);
+    expect(dropped).toHaveLength(1);
+  });
+});

--- a/packages/foundry/src/hosting/converters.parity.test.ts
+++ b/packages/foundry/src/hosting/converters.parity.test.ts
@@ -404,6 +404,63 @@ describe('search and code interpreter output round trip', () => {
     expect(String(done.item.id)).toMatch(/^ws_/);
   });
 
+  it('parses arguments streamed as a JSON string instead of dropping them', () => {
+    // While streaming, tool-call arguments commonly arrive as the concatenated JSON string
+    // rather than a parsed object; the emitted item must carry the same action either way.
+    const builder = new OutputBuilder('caresp_hint');
+    const events = [
+      ...builder.push({
+        type: 'search_tool_call',
+        callId: WEB_SEARCH_CALL.id,
+        toolName: 'web_search',
+        arguments: '{"type":"search","query":"best pizza in tokyo"}',
+      } as Content),
+      ...builder.close(),
+    ];
+    const done = events.at(-1) as unknown as { item: OutputItem };
+    expect(done.item).toMatchObject({
+      type: 'web_search_call',
+      action: { type: 'search', query: 'best pizza in tokyo' },
+    });
+
+    const fileBuilder = new OutputBuilder('caresp_hint');
+    const fileEvents = [
+      ...fileBuilder.push({
+        type: 'search_tool_call',
+        callId: FILE_SEARCH_CALL.id,
+        toolName: 'file_search',
+        arguments: '{"queries":["quarterly revenue"]}',
+      } as Content),
+      ...fileBuilder.close(),
+    ];
+    const fileDone = fileEvents.at(-1) as unknown as { item: OutputItem };
+    expect(fileDone.item).toMatchObject({
+      type: 'file_search_call',
+      queries: ['quarterly revenue'],
+    });
+  });
+
+  it('reports a search call whose tool it does not recognize instead of guessing a wire type', () => {
+    // A `search_tool_call` carrying an unknown `toolName` (or none) has no defined wire item;
+    // emitting it as `web_search_call` would invent semantics the content never had.
+    const dropped: Content[] = [];
+    const builder = new OutputBuilder('caresp_hint', {
+      onUnsupportedContent: (content) => dropped.push(content),
+    });
+    const events = [
+      ...builder.push({
+        type: 'search_tool_call',
+        callId: 'ms_1',
+        toolName: 'memory_search',
+        arguments: {},
+      } as Content),
+      ...builder.push({ type: 'search_tool_call', callId: 'anon_1', arguments: {} } as Content),
+      ...builder.close(),
+    ];
+    expect(events).toHaveLength(0);
+    expect(dropped).toHaveLength(2);
+  });
+
   it('emits a code interpreter call item with code and outputs and replays it', () => {
     const builder = new OutputBuilder('caresp_hint');
     const events = [

--- a/packages/foundry/src/hosting/converters.ts
+++ b/packages/foundry/src/hosting/converters.ts
@@ -5,7 +5,7 @@ import type {
   ResponseUsage,
 } from '@polymind-inc/agent-framework-agentserver';
 import type { ChatOptions, Content, Message, UsageDetails } from '@polymind-inc/agent-framework-core';
-import { uriContent } from '@polymind-inc/agent-framework-core';
+import { unknownContent, uriContent } from '@polymind-inc/agent-framework-core';
 
 /**
  * The label the framework declares itself under when it surfaces an approval as MCP's.
@@ -171,8 +171,12 @@ function parseArguments(raw: unknown): Record<string, unknown> | string {
 /**
  * Converts one Responses input or output item into a framework message.
  *
- * Returns `undefined` for items with no framework representation (item references, hosted-tool
- * bookkeeping), which are simply not replayed.
+ * Returns `undefined` only for items that are deliberately not replayed because another mechanism
+ * already carries their meaning: this container's own approval requests (`ApprovalStorage`),
+ * approval decisions (`approvalResponseTarget`), and item references (which point at service-held
+ * items this container cannot dereference). Every other item is converted — an item type this
+ * build does not model is preserved as unknown content rather than deleted from the transcript,
+ * so replaying a stored response never silently loses what the model said or did.
  */
 export function itemToMessage(item: OutputItem): Message | undefined {
   switch (item.type) {
@@ -180,6 +184,16 @@ export function itemToMessage(item: OutputItem): Message | undefined {
       const role = typeof item.role === 'string' ? item.role : 'user';
       const contents = contentsOfMessage(item.content, item);
       return { role, contents, ...(typeof item.id === 'string' ? { messageId: item.id } : {}) };
+    }
+
+    case 'output_message': {
+      // An assistant turn under its dedicated wire type; the parts are the same message shapes.
+      const contents = contentsOfMessage(item.content, item);
+      return {
+        role: typeof item.role === 'string' ? item.role : 'assistant',
+        contents,
+        ...(typeof item.id === 'string' ? { messageId: item.id } : {}),
+      };
     }
 
     case 'function_call':
@@ -387,8 +401,210 @@ export function itemToMessage(item: OutputItem): Message | undefined {
       };
     }
 
-    default:
+    case 'web_search_call':
+    case 'file_search_call': {
+      // Both halves of a provider-run search live on one item; the shapes mirror the openai
+      // package's conversion of the same item types, so the provider-bound re-send path treats
+      // a replayed search and a live one identically.
+      const callId =
+        typeof item.id === 'string' ? item.id : typeof item.call_id === 'string' ? item.call_id : '';
+      const isWeb = item.type === 'web_search_call';
+      const toolName = isWeb ? 'web_search' : 'file_search';
+      const action =
+        typeof item.action === 'object' && item.action !== null
+          ? (item.action as Record<string, unknown>)
+          : {};
+      const status = typeof item.status === 'string' ? { additionalProperties: { status: item.status } } : {};
+      return {
+        role: 'assistant',
+        contents: [
+          {
+            type: 'search_tool_call',
+            callId,
+            toolName,
+            arguments: isWeb ? action : { queries: Array.isArray(item.queries) ? item.queries : [] },
+            ...status,
+            rawRepresentation: item,
+          },
+          {
+            type: 'search_tool_result',
+            callId,
+            toolName,
+            result: isWeb ? { action: item.action } : { results: item.results },
+            ...status,
+            rawRepresentation: item,
+          },
+        ],
+      };
+    }
+
+    case 'code_interpreter_call': {
+      const callId =
+        typeof item.id === 'string' ? item.id : typeof item.call_id === 'string' ? item.call_id : '';
+      const contents: Content[] = [];
+      if (typeof item.code === 'string' && item.code !== '') {
+        contents.push({
+          type: 'code_interpreter_tool_call',
+          callId,
+          inputs: [{ type: 'text', text: item.code, rawRepresentation: item }],
+          rawRepresentation: item,
+        });
+      }
+      const outputs: Content[] = [];
+      for (const output of Array.isArray(item.outputs) ? (item.outputs as JsonObject[]) : []) {
+        if (output?.type === 'logs') {
+          outputs.push({
+            type: 'text',
+            text: typeof output.logs === 'string' ? output.logs : '',
+            rawRepresentation: output,
+          });
+        } else if (output?.type === 'image' && typeof output.url === 'string') {
+          outputs.push({ type: 'uri', uri: output.url, mediaType: 'image', rawRepresentation: output });
+        }
+      }
+      contents.push({ type: 'code_interpreter_tool_result', callId, outputs, rawRepresentation: item });
+      return { role: 'assistant', contents };
+    }
+
+    case 'local_shell_call': {
+      // The exec action's field is `command` (a list), unlike `shell_call`'s `commands`.
+      const action = item.action as { command?: unknown } | undefined;
+      const commands = Array.isArray(action?.command)
+        ? action.command.filter((command): command is string => typeof command === 'string')
+        : [];
+      return {
+        role: 'assistant',
+        contents: [
+          {
+            type: 'shell_tool_call',
+            callId: typeof item.call_id === 'string' ? item.call_id : (item.id ?? ''),
+            commands,
+            ...(typeof item.status === 'string' ? { status: item.status } : {}),
+            rawRepresentation: item,
+          },
+        ],
+      };
+    }
+
+    case 'local_shell_call_output':
+      // The wire item carries no `call_id`; its own id is the correlation key (Python replays
+      // `call_id=lsco.id` the same way).
+      return {
+        role: 'tool',
+        contents: [
+          {
+            type: 'shell_tool_result',
+            callId: typeof item.id === 'string' ? item.id : '',
+            outputs: [
+              {
+                type: 'shell_command_output',
+                stdout: typeof item.output === 'string' ? item.output : '',
+                stderr: '',
+                rawRepresentation: item,
+              },
+            ],
+            rawRepresentation: item,
+          },
+        ],
+      };
+
+    case 'computer_call':
+      // Reported for information only, under a well-known name — this container cannot re-drive
+      // a computer-use session, but the model must keep seeing what it did. The action stays a
+      // structured object: stringifying it would make the arguments unparseable on the next hop.
+      return {
+        role: 'assistant',
+        contents: [
+          {
+            type: 'function_call',
+            callId: typeof item.call_id === 'string' ? item.call_id : (item.id ?? ''),
+            name: 'computer_use',
+            arguments: parseArguments(item.action),
+            informationalOnly: true,
+            rawRepresentation: item,
+          },
+        ],
+      };
+
+    case 'computer_call_output':
+      return {
+        role: 'tool',
+        contents: [
+          {
+            type: 'function_result',
+            callId: typeof item.call_id === 'string' ? item.call_id : '',
+            // The screenshot payload stays structured for the same reason the call's action does.
+            result: item.output ?? '',
+            rawRepresentation: item,
+          },
+        ],
+      };
+
+    case 'custom_tool_call':
+      return {
+        role: 'assistant',
+        contents: [
+          {
+            type: 'function_call',
+            callId: typeof item.call_id === 'string' ? item.call_id : (item.id ?? ''),
+            name: typeof item.name === 'string' ? item.name : '',
+            arguments: parseArguments(item.input),
+            informationalOnly: true,
+            rawRepresentation: item,
+          },
+        ],
+      };
+
+    case 'apply_patch_call':
+      return {
+        role: 'assistant',
+        contents: [
+          {
+            type: 'function_call',
+            callId: typeof item.call_id === 'string' ? item.call_id : (item.id ?? ''),
+            name: 'apply_patch',
+            arguments: parseArguments(item.operation),
+            informationalOnly: true,
+            rawRepresentation: item,
+          },
+        ],
+      };
+
+    case 'apply_patch_call_output':
+      return {
+        role: 'tool',
+        contents: [
+          {
+            type: 'function_result',
+            callId: typeof item.call_id === 'string' ? item.call_id : '',
+            result: typeof item.output === 'string' ? item.output : '',
+            rawRepresentation: item,
+          },
+        ],
+      };
+
+    case 'structured_outputs': {
+      // Replayed as its JSON text, which is exactly what the model produced.
+      const output = item.output;
+      const text = typeof output === 'string' ? output : (JSON.stringify(output) ?? '');
+      return { role: 'assistant', contents: [{ type: 'text', text, rawRepresentation: item }] };
+    }
+
+    case 'mcp_approval_response':
+      // Consumed out of band: `approvalResponseTarget` binds the decision to the stored request.
+      // Replaying it as content too would answer the same approval twice.
       return undefined;
+
+    case 'item_reference':
+      // A pointer to a service-held item this container cannot dereference (.NET drops it the
+      // same way).
+      return undefined;
+
+    default:
+      // An item type this build does not model is preserved verbatim rather than dropped — the
+      // transcript survives a round trip through a newer producer, and the model keeps whatever
+      // the framework can represent of it.
+      return { role: 'assistant', contents: [unknownContent(item)] };
   }
 }
 

--- a/packages/foundry/src/hosting/hosting.test.ts
+++ b/packages/foundry/src/hosting/hosting.test.ts
@@ -1404,6 +1404,66 @@ describe('hosted tool content mappings', () => {
   });
 });
 
+describe('stored-history replay', () => {
+  it('replays every prefetched history item to the model, including ones this build does not model', async () => {
+    // The platform prefetches the transcript and the handler replays it as this turn's input.
+    // A hosted-tool record or an item from a newer producer must survive that hop: dropping it
+    // would have the model answer as though its own earlier actions never happened.
+    const client = new MockChatClient([say('done')]);
+    const handler = createFoundryHandler({
+      agent: new Agent({ client }),
+      sessionStore: new InMemoryAgentSessionStore(),
+      approvalStorage: new InMemoryApprovalStorage(),
+      hosted: false,
+    });
+    const responseId = newId(ID_PREFIX.response);
+    const context: HandlerContext = {
+      responseId,
+      conversationId: undefined,
+      request: createRequestContext(new Headers()),
+      history: [
+        {
+          type: 'web_search_call',
+          id: 'ws_1',
+          status: 'completed',
+          action: { type: 'search', query: 'weather in tokyo' },
+        },
+        {
+          type: 'computer_call',
+          id: 'cu_1',
+          call_id: 'call_cu1',
+          status: 'completed',
+          action: { type: 'screenshot' },
+          pending_safety_checks: [],
+        },
+        { type: 'memory_search_call', id: 'msc_1', query: 'past decisions' },
+      ],
+      signal: new AbortController().signal,
+      response: { id: responseId, object: 'response', created_at: 0, status: 'queued', output: [] },
+    };
+
+    for await (const event of handler({ input: 'hi' }, context)) {
+      void event;
+    }
+
+    const contents = must(client.calls[0]).messages.flatMap((message) => message.contents);
+    expect(contents).toContainEqual(
+      expect.objectContaining({ type: 'search_tool_call', callId: 'ws_1', toolName: 'web_search' }),
+    );
+    expect(contents).toContainEqual(
+      expect.objectContaining({
+        type: 'function_call',
+        callId: 'call_cu1',
+        name: 'computer_use',
+        informationalOnly: true,
+      }),
+    );
+    expect(contents).toContainEqual(
+      expect.objectContaining({ type: 'unknown', unknownType: 'memory_search_call', id: 'msc_1' }),
+    );
+  });
+});
+
 describe('usage on the terminal event', () => {
   it('converts framework usage to the wire shape (.NET ConvertUsage)', () => {
     expect(

--- a/packages/foundry/src/hosting/output.ts
+++ b/packages/foundry/src/hosting/output.ts
@@ -27,7 +27,14 @@ export interface SurfacedApproval {
 }
 
 /** Which kind of output item a content maps to. */
-type ItemKind = 'message' | 'function_call' | 'reasoning' | 'mcp_call' | 'mcp_approval_request';
+type ItemKind =
+  | 'message'
+  | 'function_call'
+  | 'reasoning'
+  | 'mcp_call'
+  | 'mcp_approval_request'
+  | 'search_call'
+  | 'code_interpreter_call';
 
 function kindOf(content: Content): ItemKind | undefined {
   switch (content.type) {
@@ -41,6 +48,10 @@ function kindOf(content: Content): ItemKind | undefined {
       return 'mcp_call';
     case 'function_approval_request':
       return 'mcp_approval_request';
+    case 'search_tool_call':
+      return 'search_call';
+    case 'code_interpreter_tool_call':
+      return 'code_interpreter_call';
     default:
       return undefined;
   }
@@ -119,6 +130,38 @@ function shellOutputEntry(content: {
     stderr: content.stderr ?? '',
     outcome: { type: 'exit', exit_code: content.exitCode ?? 0 },
   };
+}
+
+/** The code a `code_interpreter_tool_call` ran: the concatenated text of its inputs. */
+function codeOfInputs(inputs: unknown): string {
+  if (!Array.isArray(inputs)) {
+    return '';
+  }
+  let code = '';
+  for (const input of inputs) {
+    const text = (input as { text?: unknown } | null)?.text;
+    if (typeof text === 'string') {
+      code += text;
+    }
+  }
+  return code;
+}
+
+/** Wire `code_interpreter_call.outputs` entries from a result's content outputs. */
+function codeInterpreterWireOutputs(outputs: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(outputs)) {
+    return [];
+  }
+  const entries: Array<Record<string, unknown>> = [];
+  for (const output of outputs) {
+    const record = output as { type?: unknown; text?: unknown; uri?: unknown } | null;
+    if (record?.type === 'text' && typeof record.text === 'string') {
+      entries.push({ type: 'logs', logs: record.text });
+    } else if ((record?.type === 'uri' || record?.type === 'data') && typeof record.uri === 'string') {
+      entries.push({ type: 'image', url: record.uri });
+    }
+  }
+  return entries;
 }
 
 /** The wire text for an MCP tool result's `output` payload (Python `_stringify_mcp_output`). */
@@ -209,6 +252,45 @@ export class OutputBuilder {
         call_id: callId ?? '',
         output: mcpOutputText(content),
       });
+      return;
+    }
+    if (content.type === 'search_tool_result') {
+      // A search result belongs *on* its call item: the wire carries a web search's outcome
+      // inside `action` (already on the item) and a file search's retrieved documents in
+      // `results`. There is no standalone wire item for an orphan search result, so one with no
+      // matching open call is reported rather than emitted.
+      const open = this.#open;
+      const callId = content.callId;
+      if (
+        open !== undefined &&
+        open.kind === 'search_call' &&
+        (callId === undefined || callId === open.callId || callId === open.id)
+      ) {
+        const results = (content.result as { results?: unknown } | null | undefined)?.results;
+        if (open.item.type === 'file_search_call' && Array.isArray(results)) {
+          open.item.results = results;
+        }
+        yield* this.close();
+        return;
+      }
+      this.#onUnsupportedContent?.(content);
+      return;
+    }
+    if (content.type === 'code_interpreter_tool_result') {
+      // Same shape as a search result: the sandbox's outputs live on the `code_interpreter_call`
+      // item itself, and an orphan result has no wire item of its own.
+      const open = this.#open;
+      const callId = content.callId;
+      if (
+        open !== undefined &&
+        open.kind === 'code_interpreter_call' &&
+        (callId === undefined || callId === open.callId || callId === open.id)
+      ) {
+        open.item.outputs = codeInterpreterWireOutputs(content.outputs);
+        yield* this.close();
+        return;
+      }
+      this.#onUnsupportedContent?.(content);
       return;
     }
     if (content.type === 'image_generation_tool_result') {
@@ -306,8 +388,9 @@ export class OutputBuilder {
       const id = (content as { id?: string }).id;
       return id === undefined || id === this.#open.id;
     }
-    // A single approval request is one item; a second one needs its own.
-    return kind !== 'mcp_approval_request';
+    // One item per approval request, per search call and per code interpreter run; only message
+    // text and MCP-call argument fragments coalesce.
+    return kind !== 'mcp_approval_request' && kind !== 'search_call' && kind !== 'code_interpreter_call';
   }
 
   *#open_(kind: ItemKind, content: Content): Generator<ResponseEvent> {
@@ -378,6 +461,45 @@ export class OutputBuilder {
         this.surfacedApprovals.push({ wireId: id, request });
         break;
       }
+      case 'search_call': {
+        const call = content as {
+          callId?: string;
+          toolName?: string;
+          arguments?: Record<string, unknown> | string;
+        };
+        const isWeb = call.toolName !== 'file_search';
+        // The provider's own call id is reused only when it fits this protocol's id format,
+        // like `mcp_call`; the replayed item then carries the id the provider actually issued.
+        id = isValidId(call.callId)
+          ? (call.callId as string)
+          : newId(isWeb ? ID_PREFIX.webSearchCall : ID_PREFIX.fileSearchCall, this.#partitionHint);
+        const args = typeof call.arguments === 'object' && call.arguments !== null ? call.arguments : {};
+        item = isWeb
+          ? { type: 'web_search_call', id, status: 'in_progress', action: args }
+          : {
+              type: 'file_search_call',
+              id,
+              status: 'in_progress',
+              queries: Array.isArray((args as { queries?: unknown }).queries)
+                ? ((args as { queries: unknown[] }).queries as unknown[])
+                : [],
+            };
+        break;
+      }
+      case 'code_interpreter_call': {
+        const call = content as { callId?: string; inputs?: unknown };
+        id = isValidId(call.callId)
+          ? (call.callId as string)
+          : newId(ID_PREFIX.codeInterpreterCall, this.#partitionHint);
+        item = {
+          type: 'code_interpreter_call',
+          id,
+          status: 'in_progress',
+          code: codeOfInputs(call.inputs),
+          outputs: [],
+        };
+        break;
+      }
     }
 
     this.#open = {
@@ -386,7 +508,8 @@ export class OutputBuilder {
       index,
       item,
       buffer: '',
-      ...(kind === 'mcp_call' && typeof (content as { callId?: string }).callId === 'string'
+      ...((kind === 'mcp_call' || kind === 'search_call' || kind === 'code_interpreter_call') &&
+      typeof (content as { callId?: string }).callId === 'string'
         ? { callId: (content as { callId?: string }).callId }
         : {}),
     };
@@ -486,7 +609,10 @@ export class OutputBuilder {
         return;
       }
       case 'mcp_approval_request':
-        // Approval requests carry no incremental payload.
+      case 'search_call':
+      case 'code_interpreter_call':
+        // These carry no incremental payload: an approval request is complete when surfaced, and
+        // provider-executed calls arrive whole.
         return;
     }
   }
@@ -572,6 +698,12 @@ export class OutputBuilder {
         break;
       }
       case 'mcp_approval_request':
+        break;
+      case 'search_call':
+      case 'code_interpreter_call':
+        // The result (file search documents, sandbox outputs) was attached by `push` before the
+        // close; a call whose result never arrived still finishes its item, like `mcp_call`.
+        open.item.status = 'completed';
         break;
     }
 

--- a/packages/foundry/src/hosting/output.ts
+++ b/packages/foundry/src/hosting/output.ts
@@ -49,7 +49,11 @@ function kindOf(content: Content): ItemKind | undefined {
     case 'function_approval_request':
       return 'mcp_approval_request';
     case 'search_tool_call':
-      return 'search_call';
+      // Only the two searches with a wire item; an unknown search tool must not be guessed
+      // into `web_search_call` semantics it never had.
+      return content.toolName === 'web_search' || content.toolName === 'file_search'
+        ? 'search_call'
+        : undefined;
     case 'code_interpreter_tool_call':
       return 'code_interpreter_call';
     default:
@@ -130,6 +134,30 @@ function shellOutputEntry(content: {
     stderr: content.stderr ?? '',
     outcome: { type: 'exit', exit_code: content.exitCode ?? 0 },
   };
+}
+
+/**
+ * A tool call's arguments as a structured object.
+ *
+ * While streaming, arguments commonly arrive as the concatenated JSON string rather than a parsed
+ * object; both forms must produce the same wire item. A string that is not a JSON object (still
+ * partial, or not JSON at all) yields an empty object rather than a crash or a dropped field.
+ */
+function argumentsRecord(args: Record<string, unknown> | string | undefined): Record<string, unknown> {
+  if (typeof args === 'object' && args !== null) {
+    return args;
+  }
+  if (typeof args === 'string' && args !== '') {
+    try {
+      const parsed: unknown = JSON.parse(args);
+      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Fall through to the empty object.
+    }
+  }
+  return {};
 }
 
 /** The code a `code_interpreter_tool_call` ran: the concatenated text of its inputs. */
@@ -473,7 +501,7 @@ export class OutputBuilder {
         id = isValidId(call.callId)
           ? (call.callId as string)
           : newId(isWeb ? ID_PREFIX.webSearchCall : ID_PREFIX.fileSearchCall, this.#partitionHint);
-        const args = typeof call.arguments === 'object' && call.arguments !== null ? call.arguments : {};
+        const args = argumentsRecord(call.arguments);
         item = isWeb
           ? { type: 'web_search_call', id, status: 'in_progress', action: args }
           : {


### PR DESCRIPTION
Closes #22

## Problem

The hosting converter handled only 11 Responses v2 item types. Everything else returned `undefined` from `itemToMessage` and was silently deleted from the transcript during stored-response replay, so the model answered as though its own earlier actions never happened. The output builder had the matching gap: provider-run searches and code interpreter executions had no wire representation, so they vanished from the stored response and never reached the next turn's history.

## Changes

**Inbound (`itemToMessage`)** — 12 item types added, semantics cross-checked against both the .NET (`InputConverter`) and Python (`_item_to_message` / `_output_item_to_message`) hosted converters:

- `web_search_call` / `file_search_call` → `search_tool_call` + `search_tool_result`, mirroring the openai package's conversion of the same items so the re-send path treats a replayed search and a live one identically
- `code_interpreter_call` → `code_interpreter_tool_call` + `code_interpreter_tool_result`, keeping the executed code and the sandbox outputs
- `local_shell_call` / `local_shell_call_output` → shell tool contents (the output item's own id is the correlation key, matching the reference behavior)
- `computer_call` / `apply_patch_call` / `custom_tool_call` → informational `function_call` under well-known names; the action/operation stays a structured object rather than a stringified repr, so it remains parseable on the next hop
- `computer_call_output` / `apply_patch_call_output` → `function_result` with the structured payload preserved
- `output_message`, `structured_outputs` → message / JSON text

**Unrecognized items are preserved as unknown content** instead of dropped, so a transcript survives a round trip through a newer producer. Only two types stay unreplayed, each explicitly documented: `mcp_approval_response` (consumed out of band by the approval layer) and `item_reference` (points at a service-held item this container cannot dereference).

**Outbound (`OutputBuilder`)** — emits `web_search_call`, `file_search_call` and `code_interpreter_call` items from their hosted-tool contents, folding the result (file search documents, sandbox outputs) onto the call item before close, the same way `mcp_call` folds its output. Provider ids are reused only when they fit the protocol id format. An orphan result with no matching open call is reported through `onUnsupportedContent` rather than emitted, since the wire has no standalone item for it.

## Tests

- 22 fixture-based parity tests pin the mappings against representative payloads shaped like the official SDK models, and round-trip the emitted items back through the replay path
- A handler-level test verifies prefetched history — including an item type this build does not model — reaches the model intact
- Reproduction-first: 19 of the new tests fail without the fix (verified by temporarily reverting it)
- `pnpm check` passes end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)