### PR TITLE
Make FoundryResponseStore production-ready and the hosted default

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,9 @@ environment variables each one needs.
 - The MCP integration covers **tools only** — no sampling, elicitation or prompts.
 - The A2A package is a **client**. Serving a framework agent over A2A, push notifications, task
   listing and cancellation are not covered; use [`@a2a-js/sdk`][a2a-sdk] directly for those.
-- Hosted background responses backed by Foundry storage are fail-closed (HTTP 501) until event
-  persistence lands.
+- A hosted container persists responses in the Foundry storage service by default (matching the
+  reference implementations); the background replay log lives beside the sandbox state, so stream
+  replay after a sandbox recycle fails closed rather than resuming.
 - The core runs in browsers, but calling a model provider directly from a browser exposes your API
   key — **run agents server-side**.
 - Because `agent.run()` returns a hybrid thenable, type-aware lint rules such as

--- a/examples/02-foundry/02-hosted-agent/README.md
+++ b/examples/02-foundry/02-hosted-agent/README.md
@@ -127,15 +127,21 @@ Notes from doing this against a live project (extension `azure.ai.agents` 1.0.0-
 
 ### Where the transcript is stored
 
-A deployed container stores responses on its **sandbox filesystem** (`FileResponseProvider`), not
-in the Foundry storage service. `POST /storage/responses` answers an opaque `500` even from inside
-a deployed container (verified against the live service), so making it the default would fail every turn.
-The sandbox is keyed by `x-agent-session-id`, which is derived to be stable for a conversation, so
-a follow-up turn lands on the same filesystem. To opt back in once the service side is resolved:
+A deployed container persists responses in the **Foundry storage service**
+(`FoundryResponseStore`) by default, the same activation the reference implementations make —
+responses then survive sandbox recycling and a conversation can continue from any sandbox. To
+keep a deployment on its sandbox filesystem instead, pass the store explicitly:
 
 ```ts
-new ResponsesHostServer({ agent, store: new FoundryResponseStore() });
+new ResponsesHostServer({ agent, store: new FileResponseProvider() });
 ```
+
+Two service behaviours worth knowing, both measured against a live project: storage writes are
+gated on the **hosted-agent credential**, so `FoundryResponseStore` works from inside a deployed
+container and answers an opaque `500` from a workstation login; and every write must carry an
+`agent_reference` with a non-empty name, which the server stamps onto each response
+automatically. The storage service has no events API, so a background response's replay log stays
+beside the sandbox state.
 
 Afterwards the agent answers at
 `{projectEndpoint}/agents/weather-agent/endpoint/protocols/openai`, which is exactly what

--- a/examples/02-foundry/02-hosted-agent/main.ts
+++ b/examples/02-foundry/02-hosted-agent/main.ts
@@ -49,8 +49,8 @@ const agent = new Agent({
   defaultOptions: { store: false },
 });
 
-// The store defaults to the sandbox filesystem in a container. `new FoundryResponseStore()`
-// switches to the platform's storage service — see README.md for why that is not the default.
+// In a container the store defaults to the Foundry storage service, so responses survive sandbox
+// recycling; pass `store: new FileResponseProvider()` to keep a deployment off it — see README.md.
 const server = new ResponsesHostServer({ agent });
 
 const { port } = await serve(server);

--- a/packages/agentserver/src/index.ts
+++ b/packages/agentserver/src/index.ts
@@ -10,7 +10,7 @@
  * The Node adapter is in the `./node` subpath, so the protocol itself stays on Web standards.
  */
 
-export { isHosted, projectEndpoint } from './config.js';
+export { isHosted, projectEndpoint, stateRoot } from './config.js';
 export type { RequestContext } from './context.js';
 export {
   createRequestContext,
@@ -69,7 +69,7 @@ export type {
 } from './server.js';
 export { ResponsesServer } from './server.js';
 export type { AgentSessionIdOptions } from './session-id.js';
-export { resolveAgentSessionId } from './session-id.js';
+export { resolveAgentReference, resolveAgentSessionId } from './session-id.js';
 export { FileResponseProvider } from './store/file.js';
 export type { InMemoryResponseProviderConfig } from './store/memory.js';
 export { InMemoryResponseProvider } from './store/memory.js';

--- a/packages/agentserver/src/observability/trace-context.ts
+++ b/packages/agentserver/src/observability/trace-context.ts
@@ -12,7 +12,7 @@
  */
 
 import type { Context, TextMapGetter } from '@opentelemetry/api';
-import { context as contextApi, propagation, ROOT_CONTEXT } from '@opentelemetry/api';
+import { propagation, ROOT_CONTEXT } from '@opentelemetry/api';
 
 const HEADERS_GETTER: TextMapGetter<Headers> = {
   get(carrier: Headers, key: string): string | undefined {
@@ -100,28 +100,30 @@ export function withResponseBaggage(context: Context, turn: ResponseBaggage): Co
 }
 
 /**
- * Pins `context` to every pull of `iterable`.
+ * Runs every pull of `iterable` through `run`, which re-enters whatever ambient scopes the turn
+ * needs — the OTel context, the request's `AsyncLocalStorage`, or both composed.
  *
  * An async generator resumes in whatever context its consumer holds when it calls `next()` — and
  * an SSE body is consumed by the socket writer, long after the request scope closed. Without
  * this, the handler's spans would parent correctly up to the first event (pulled inside the
- * request scope) and then fall out of the trace.
+ * request scope) and then fall out of the trace, and work the turn still does while the stream
+ * drains would lose the request's platform headers.
  */
-export function bindIterable<T>(iterable: AsyncIterable<T>, context: Context): AsyncIterable<T> {
+export function bindIterable<T>(iterable: AsyncIterable<T>, run: <R>(fn: () => R) => R): AsyncIterable<T> {
   return {
     [Symbol.asyncIterator](): AsyncIterator<T> {
       const iterator = iterable[Symbol.asyncIterator]();
       const { return: returnFn, throw: throwFn } = iterator;
       const bound: AsyncIterator<T> = {
-        next: (): Promise<IteratorResult<T>> => contextApi.with(context, () => iterator.next()),
+        next: (): Promise<IteratorResult<T>> => run(() => iterator.next()),
       };
       if (returnFn !== undefined) {
         bound.return = (value?: unknown): Promise<IteratorResult<T>> =>
-          contextApi.with(context, () => returnFn.call(iterator, value));
+          run(() => returnFn.call(iterator, value));
       }
       if (throwFn !== undefined) {
         bound.throw = (error?: unknown): Promise<IteratorResult<T>> =>
-          contextApi.with(context, () => throwFn.call(iterator, error));
+          run(() => throwFn.call(iterator, error));
       }
       return bound;
     },

--- a/packages/agentserver/src/server.test.ts
+++ b/packages/agentserver/src/server.test.ts
@@ -100,6 +100,60 @@ describe('routes', () => {
     expect(JSON.stringify(body.output[0])).toContain('Echo: Hi');
   });
 
+  it('stamps the agent identity onto every response resource', async () => {
+    // A service-side store validates that every persisted response names its agent — without the
+    // stamp, the write dies as an opaque 500. Resolved once at resource construction so every
+    // store sees it: the request's own reference first, else the environment, else the default.
+    const saved = { name: process.env.FOUNDRY_AGENT_NAME, version: process.env.FOUNDRY_AGENT_VERSION };
+    try {
+      process.env.FOUNDRY_AGENT_NAME = 'weather-agent';
+      process.env.FOUNDRY_AGENT_VERSION = '2';
+      const server = makeServer();
+
+      const fromEnv = (await (await server.handle(post({ input: 'Hi' }))).json()) as ResponseObject;
+      expect(fromEnv.agent_reference).toEqual({
+        type: 'agent_reference',
+        name: 'weather-agent',
+        version: '2',
+      });
+
+      const requested = (await (
+        await server.handle(
+          post({ input: 'Hi', agent_reference: { type: 'agent_reference', name: 'router', version: '9' } }),
+        )
+      ).json()) as ResponseObject;
+      expect(requested.agent_reference).toEqual({
+        type: 'agent_reference',
+        name: 'router',
+        version: '9',
+      });
+
+      delete process.env.FOUNDRY_AGENT_NAME;
+      delete process.env.FOUNDRY_AGENT_VERSION;
+      const fallback = (await (await server.handle(post({ input: 'Hi' }))).json()) as ResponseObject;
+      expect(fallback.agent_reference).toEqual({ type: 'agent_reference', name: 'server-default-agent' });
+
+      // Validation only checks name and version, so a caller can omit the discriminator or send
+      // a wrong one — the resolved reference normalizes it to the literal the wire type declares.
+      const untyped = (await (
+        await server.handle(post({ input: 'Hi', agent_reference: { name: 'router' } }))
+      ).json()) as ResponseObject;
+      expect(untyped.agent_reference).toEqual({ type: 'agent_reference', name: 'router' });
+
+      const mistyped = (await (
+        await server.handle(
+          post({ input: 'Hi', agent_reference: { type: 'other', name: 'router', version: '3' } }),
+        )
+      ).json()) as ResponseObject;
+      expect(mistyped.agent_reference).toEqual({ type: 'agent_reference', name: 'router', version: '3' });
+    } finally {
+      if (saved.name !== undefined) process.env.FOUNDRY_AGENT_NAME = saved.name;
+      else delete process.env.FOUNDRY_AGENT_NAME;
+      if (saved.version !== undefined) process.env.FOUNDRY_AGENT_VERSION = saved.version;
+      else delete process.env.FOUNDRY_AGENT_VERSION;
+    }
+  });
+
   it('gets, lists input items for, and deletes a response', async () => {
     const server = makeServer();
     const created = (await (

--- a/packages/agentserver/src/server.ts
+++ b/packages/agentserver/src/server.ts
@@ -30,7 +30,7 @@ import type { LifecycleViolation } from './lifecycle.js';
 import { applyCancelledTerminal, enforceLifecycle, ResponseTracker } from './lifecycle.js';
 import { flushTelemetry } from './observability/flush.js';
 import { bindIterable, extractTraceContext, withResponseBaggage } from './observability/trace-context.js';
-import { resolveAgentSessionId } from './session-id.js';
+import { resolveAgentReference, resolveAgentSessionId } from './session-id.js';
 import { SequenceNumberWriter, SSE_HEADERS, toSseStream } from './sse.js';
 import { InMemoryResponseProvider } from './store/memory.js';
 import type { ResponseGeneration, ResponseOwner, ResponseProvider } from './store/provider.js';
@@ -913,6 +913,9 @@ export class ResponsesServer {
       created_at: Math.floor(Date.now() / 1000),
       status: 'queued',
       output: [],
+      // Which agent produced this response. Always resolved to a non-empty name: a service-side
+      // store validates its presence on every write, and rejects one without it opaquely.
+      agent_reference: resolveAgentReference(created.agent_reference),
       // Persisted on the resource because the replay and cancel routes decide their answers by
       // it long after the run itself is gone.
       ...(background ? { background: true } : {}),
@@ -991,9 +994,13 @@ export class ResponsesServer {
       }
       // An SSE body (and a background run's tail) is pulled after this request scope has closed,
       // and an async generator resumes in its *consumer's* context — which would drop the
-      // handler's later spans out of the caller's trace, and the baggage stamped just above with
-      // them. Pinning this context to every pull keeps the whole turn under one trace.
-      events = bindIterable(events, otelContext.active());
+      // handler's later spans out of the caller's trace (and the baggage stamped just above with
+      // them), and lose the platform headers a service-side store requires. Pinning both ambient
+      // scopes to every pull keeps the whole turn under one trace and one request context.
+      const turnContext = otelContext.active();
+      events = bindIterable(events, (fn) =>
+        otelContext.with(turnContext, () => runWithRequestContext(context, fn)),
+      );
 
       // A string `input` is shorthand for one user message. Normalizing it here is what keeps it
       // in the stored transcript: left as-is it would simply vanish, and the next turn would
@@ -1014,28 +1021,47 @@ export class ResponsesServer {
             ? (created.input as OutputItem[])
             : [];
       const storedInputItems = [...history, ...inputItems];
-      const persistSnapshot = async (response: ResponseObject): Promise<void> => {
-        if (!this.#holds(responseId, claim)) {
-          // The id this turn was claiming now belongs to somebody else — `DELETE` frees a terminal
-          // run's id while it is still winding down, and the next create takes it. A detached run
-          // (or the cancel route's post-grace write) must not land its snapshot on that turn.
-          return;
-        }
-        const stored = {
-          response,
-          inputItems: storedInputItems,
-          // The turn's stamp travels with the record, so a later write addressed by this id can be
-          // told apart from one made by whoever holds the id now.
-          generation,
-          ...(context.userId === undefined ? {} : { userId: context.userId }),
-        };
-        await this.#store.put(stored);
-        if (conversationId !== undefined && conversationId !== response.id) {
-          // A conversation-addressed turn is also reachable by the conversation id, so the next
-          // request can resolve it without knowing the response id.
-          await this.#store.put({ ...stored, response: { ...response, id: conversationId } });
-        }
-      };
+      // The replayed history is already held by a service-side store under these very ids, so it
+      // travels as references; only this turn's own items are new. A local store ignores the
+      // split and keeps the merged list.
+      const historyItemIds = history
+        .map((item) => item.id)
+        .filter((id): id is string => typeof id === 'string' && id !== '');
+      // Bound to this turn's request context however it is reached: a foreground stream persists
+      // from the SSE consumer's pull and a detached run from its winddown — both outside the
+      // request's AsyncLocalStorage scope — and a service-side store needs the turn's platform
+      // headers on every one of those writes.
+      const persistSnapshot = (response: ResponseObject): Promise<void> =>
+        runWithRequestContext(context, async (): Promise<void> => {
+          if (!this.#holds(responseId, claim)) {
+            // The id this turn was claiming now belongs to somebody else — `DELETE` frees a
+            // terminal run's id while it is still winding down, and the next create takes it. A
+            // detached run (or the cancel route's post-grace write) must not land its snapshot on
+            // that turn.
+            return;
+          }
+          const stored = {
+            response,
+            inputItems: storedInputItems,
+            historyItemIds,
+            // The turn's stamp travels with the record, so a later write addressed by this id
+            // can be told apart from one made by whoever holds the id now.
+            generation,
+            ...(context.userId === undefined ? {} : { userId: context.userId }),
+          };
+          await this.#store.put(stored);
+          if (
+            conversationId !== undefined &&
+            conversationId !== response.id &&
+            this.#store.linksConversationsServiceSide !== true
+          ) {
+            // A conversation-addressed turn is also reachable by the conversation id, so the next
+            // request can resolve it without knowing the response id. Local stores get that from
+            // this alias record; a service-linked store resolves the conversation itself (and its
+            // alias create would collide with the item ids the service already holds).
+            await this.#store.put({ ...stored, response: { ...response, id: conversationId } });
+          }
+        });
       const persist = async (): Promise<void> => {
         if (created.store === false) {
           return;

--- a/packages/agentserver/src/session-id.ts
+++ b/packages/agentserver/src/session-id.ts
@@ -1,7 +1,7 @@
 import { agentName, agentSessionId, agentVersion } from './config.js';
 import { partitionKeyOf, toHex } from './ids.js';
 import { conversationIdOf } from './validation.js';
-import type { CreateResponseRequest } from './wire.js';
+import type { AgentReference, CreateResponseRequest } from './wire.js';
 
 /** Session ids are 63 lowercase hex characters, whether derived or random, matching the Python reference. */
 const SESSION_ID_LENGTH = 63;
@@ -36,6 +36,28 @@ function randomHex(length: number): string {
   const bytes = new Uint8Array(Math.ceil(length / 2));
   crypto.getRandomValues(bytes);
   return toHex(bytes).slice(0, length);
+}
+
+/**
+ * Resolves the agent identity a response resource is stamped with.
+ *
+ * The Foundry storage service validates that every persisted response carries an
+ * `agent_reference` with a non-empty name and rejects a write without one — as an opaque `500`,
+ * measured against a live project from inside a hosted container. The reference is therefore
+ * resolved once, here, from the same chain the session id uses: the request's own reference when
+ * it names an agent, else the platform-injected `FOUNDRY_AGENT_NAME` / `FOUNDRY_AGENT_VERSION`,
+ * else the default name (the service accepts any non-empty name without checking it exists).
+ */
+export function resolveAgentReference(requested?: AgentReference): AgentReference {
+  // Rebuilt rather than passed through: validation only checks `name` and `version`, so the
+  // caller's object may omit the discriminator or carry a wrong one, and whatever is returned
+  // here goes onto the resource and into storage payloads verbatim.
+  const requestedName = trimmed(requested?.name);
+  const [name, version] =
+    requestedName !== undefined
+      ? [requestedName, trimmed(requested?.version)]
+      : [trimmed(agentName()) ?? DEFAULT_AGENT_NAME, trimmed(agentVersion())];
+  return { type: 'agent_reference', name, ...(version === undefined ? {} : { version }) };
 }
 
 /**

--- a/packages/agentserver/src/store/provider.ts
+++ b/packages/agentserver/src/store/provider.ts
@@ -25,6 +25,17 @@ export interface StoredResponse {
    * it, exactly like {@link userId}.
    */
   generation?: ResponseGeneration;
+  /**
+   * The ids within {@link inputItems} that a service-side store is already holding — replayed
+   * history, as opposed to what this turn newly said.
+   *
+   * A service-side store must send these as **references** and only the remaining items as new:
+   * re-sending an already-stored item under its own id makes the create fail (measured against
+   * the live Foundry service, which resolves references back into the transcript on read — the
+   * same split the reference implementations' `history_item_ids` field carries). A local store
+   * holds the whole list itself and may ignore this.
+   */
+  historyItemIds?: string[];
 }
 
 /**
@@ -55,6 +66,14 @@ export type ResponseOwner = string | undefined;
  * id exists, which is itself the other user's business.
  */
 export interface ResponseProvider {
+  /**
+   * `true` when the backing service links a response to its conversation itself (from the
+   * `conversation` field on the resource), so the server must NOT write the conversation-id
+   * alias record it writes for local stores. The alias create would re-send the turn's items
+   * under ids the service already holds, which it rejects. Implies {@link history} can resolve
+   * a conversation id.
+   */
+  readonly linksConversationsServiceSide?: boolean;
   get(id: string, owner: ResponseOwner): Promise<StoredResponse | undefined>;
   /**
    * Stores a response under `stored.response.id`, owned by `stored.userId`.

--- a/packages/foundry/README.md
+++ b/packages/foundry/README.md
@@ -24,11 +24,9 @@ needs it, so consumers using just `FoundryChatClient` can leave it uninstalled.
 
 Known limitations:
 
-- **Hosted background responses against Foundry storage are fail-closed (501)** until
-  `FoundryResponseStore` implements event persistence; foreground turns and the file-backed
-  store are unaffected.
-- The default hosted response store is file-backed: writes to the Foundry storage service were
-  observed to fail server-side, so `FoundryResponseStore` is opt-in.
+- `FoundryResponseStore` (the hosted default) keeps the response resource in the Foundry storage
+  service and the background replay log beside the sandbox state — the storage service has no
+  events API — so stream replay after a sandbox recycle fails closed rather than resuming.
 
 ---
 

--- a/packages/foundry/src/hosting/hosting.test.ts
+++ b/packages/foundry/src/hosting/hosting.test.ts
@@ -39,6 +39,7 @@ import {
 } from './converters.js';
 import { createFoundryHandler, defaultApprovalStorage, defaultSessionStore } from './handler.js';
 import { OutputBuilder } from './output.js';
+import { FoundryResponseStore } from './response-store.js';
 import { FileSystemAgentSessionStore, InMemoryAgentSessionStore } from './session-store.js';
 
 function say(text: string): MockTurn {
@@ -61,6 +62,21 @@ function textOf(response: ResponseObject): string {
 function must<T>(value: T | null | undefined): T {
   if (value == null) throw new Error('expected a value');
   return value;
+}
+
+/** Polls `GET /responses/{id}` until the response completes, failing the test after ~4s. */
+async function waitUntilCompleted(app: ResponsesServer, id: string): Promise<ResponseObject> {
+  for (let attempt = 0; attempt < 400; attempt += 1) {
+    const response = await app.handle(new Request(`http://localhost:8088/responses/${id}`));
+    if (response.status === 200) {
+      const body = (await response.json()) as ResponseObject;
+      if (body.status === 'completed') {
+        return body;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`response ${id} never completed`);
 }
 
 describe('function_call_output encoding', () => {
@@ -1461,6 +1477,306 @@ describe('stored-history replay', () => {
     expect(contents).toContainEqual(
       expect.objectContaining({ type: 'unknown', unknownType: 'memory_search_call', id: 'msc_1' }),
     );
+  });
+});
+
+describe('background execution with the Foundry store', () => {
+  /**
+   * An in-memory double of the Foundry storage service, faithful to the behaviours measured
+   * against the live one: a write whose response carries no `agent_reference.name` dies as an
+   * opaque 500; a create that re-sends an already-stored item id fails with an "already exists"
+   * body (the shape that masquerades as a duplicate create); `history_item_ids` resolve back
+   * into the transcript on read; and a conversation is linked from the resource itself.
+   */
+  function storageServiceDouble(options: { requireCallId?: boolean } = {}): {
+    fetch: typeof globalThis.fetch;
+    writes: ResponseObject[];
+  } {
+    const records = new Map<string, { response: ResponseObject; itemIds: string[] }>();
+    const items = new Map<string, OutputItem>();
+    const conversations = new Map<string, string[]>();
+    const writes: ResponseObject[] = [];
+    const respond = (status: number, body?: unknown): Response =>
+      new Response(body === undefined ? null : JSON.stringify(body), { status });
+    const outputOf = (response: ResponseObject): OutputItem[] =>
+      Array.isArray(response.output) ? response.output : [];
+    const idsOf = (list: OutputItem[]): string[] =>
+      list.map((item) => item.id).filter((id): id is string => typeof id === 'string');
+    // One statement of the live service's write validation, used by create and update alike.
+    const namesAgent = (response: ResponseObject): boolean =>
+      typeof response.agent_reference?.name === 'string' && response.agent_reference.name !== '';
+    /** Registers output items and extends the conversation's transcript, like the service does. */
+    const index = (response: ResponseObject): void => {
+      for (const item of outputOf(response)) {
+        if (typeof item.id === 'string') items.set(item.id, item);
+      }
+      const conversation = (response as { conversation?: { id?: string } }).conversation;
+      if (typeof conversation?.id === 'string') {
+        const ids = conversations.get(conversation.id) ?? [];
+        const stored = records.get(response.id);
+        for (const itemId of [...(stored?.itemIds ?? []), ...idsOf(outputOf(response))]) {
+          if (!ids.includes(itemId)) ids.push(itemId);
+        }
+        conversations.set(conversation.id, ids);
+      }
+    };
+
+    const handle = async (url: URL, init?: RequestInit): Promise<Response> => {
+      const method = init?.method ?? 'GET';
+      const segments = url.pathname.split('/storage/')[1]?.split('/') ?? [];
+      const payload = typeof init?.body === 'string' ? (JSON.parse(init.body) as never) : undefined;
+
+      if (
+        options.requireCallId === true &&
+        method !== 'GET' &&
+        new Headers(init?.headers).get('x-agent-foundry-call-id') === null
+      ) {
+        // The live service's behaviour: a write without the platform call id fails opaquely.
+        return respond(500, { error: { code: 'server_error', message: 'An error occurred.' } });
+      }
+
+      if (method === 'POST' && segments.length === 1 && segments[0] === 'responses') {
+        const create = payload as unknown as {
+          response: ResponseObject;
+          input_items: OutputItem[];
+          history_item_ids: string[];
+        };
+        writes.push(create.response);
+        if (!namesAgent(create.response)) {
+          return respond(500, { error: { code: 'server_error', message: 'An error occurred.' } });
+        }
+        if (records.has(create.response.id)) {
+          return respond(409, { error: { code: 'conflict', message: 'already exists' } });
+        }
+        for (const item of [...create.input_items, ...outputOf(create.response)]) {
+          if (typeof item.id === 'string' && items.has(item.id)) {
+            return respond(400, {
+              error: { code: 'invalid_request', message: `Item '${item.id}' already exists.` },
+            });
+          }
+        }
+        for (const item of create.input_items) {
+          if (typeof item.id === 'string') items.set(item.id, item);
+        }
+        records.set(create.response.id, {
+          response: create.response,
+          itemIds: [...create.history_item_ids, ...idsOf(create.input_items)],
+        });
+        index(create.response);
+        return respond(201, create.response);
+      }
+      const id = segments[1] ?? '';
+      const record = records.get(id);
+      if (method === 'POST' && segments.length === 2 && segments[0] === 'responses') {
+        const update = payload as unknown as ResponseObject;
+        writes.push(update);
+        if (!namesAgent(update)) {
+          return respond(500, { error: { code: 'server_error', message: 'An error occurred.' } });
+        }
+        if (record === undefined) {
+          return respond(404, { error: { code: 'not_found', message: 'not found' } });
+        }
+        record.response = update;
+        index(update);
+        return respond(200, update);
+      }
+      if (method === 'GET' && segments.length === 2 && segments[0] === 'responses') {
+        return record === undefined ? respond(404) : respond(200, record.response);
+      }
+      if (method === 'GET' && segments.length === 3 && segments[2] === 'input_items') {
+        return record === undefined
+          ? respond(404)
+          : respond(200, {
+              object: 'list',
+              data: record.itemIds.map((itemId) => items.get(itemId)).filter((item) => item !== undefined),
+              has_more: false,
+            });
+      }
+      if (method === 'DELETE' && segments.length === 2 && segments[0] === 'responses') {
+        return records.delete(id) ? respond(204) : respond(404);
+      }
+      if (method === 'GET' && segments[0] === 'history' && segments[1] === 'item_ids') {
+        const ids = conversations.get(url.searchParams.get('conversation_id') ?? '');
+        return ids === undefined ? respond(404) : respond(200, ids);
+      }
+      if (
+        method === 'POST' &&
+        segments[0] === 'items' &&
+        segments[1] === 'batch' &&
+        segments[2] === 'retrieve'
+      ) {
+        const request = payload as unknown as { item_ids: string[] };
+        return respond(
+          200,
+          request.item_ids.map((itemId) => items.get(itemId) ?? null),
+        );
+      }
+      return respond(500, {
+        error: { code: 'server_error', message: `unhandled ${method} ${url.pathname}` },
+      });
+    };
+
+    return {
+      fetch: (async (url: string | URL | Request, init?: RequestInit) =>
+        handle(new URL(String(url)), init)) as typeof globalThis.fetch,
+      writes,
+    };
+  }
+
+  async function foundryBackedServer(
+    turns: MockTurn[],
+    options: { requireCallId?: boolean } = {},
+  ): Promise<{
+    app: ResponsesServer;
+    writes: ResponseObject[];
+    client: MockChatClient;
+  }> {
+    const service = storageServiceDouble(options);
+    const client = new MockChatClient(turns);
+    const store = new FoundryResponseStore({
+      projectEndpoint: 'https://my-resource.services.ai.azure.com/api/projects/my-project',
+      credential: {
+        getToken: async () => ({ token: 'mi-token', expiresOnTimestamp: Date.now() + 3_600_000 }),
+      },
+      fetch: service.fetch,
+      replayRoot: await mkdtemp(join(tmpdir(), 'afjs-fdry-')),
+      retry: { baseDelayMs: 0 },
+    });
+    const app = new ResponsesServer({
+      handler: createFoundryHandler({
+        agent: new Agent({ client }),
+        sessionStore: new InMemoryAgentSessionStore(),
+        approvalStorage: new InMemoryApprovalStorage(),
+        hosted: false,
+      }),
+      store,
+    });
+    return { app, writes: service.writes, client };
+  }
+
+  it('accepts a background create instead of the documented 501, and finishes durably', async () => {
+    const { app, writes } = await foundryBackedServer([say('bg answer')]);
+
+    const created = await app.handle(post({ input: 'hi', background: true }));
+    expect(created.status).toBe(200);
+    const snapshot = (await created.json()) as ResponseObject;
+    expect(snapshot.background).toBe(true);
+
+    const finished = await waitUntilCompleted(app, snapshot.id);
+    expect(JSON.stringify(finished.output)).toContain('bg answer');
+
+    // Every service write carried the agent reference the service validates — the resource was
+    // stamped at construction, not patched up by the store's fallback.
+    expect(writes.length).toBeGreaterThan(0);
+    for (const write of writes) {
+      expect(write.agent_reference?.name).toBe('server-default-agent');
+    }
+  });
+
+  it('replays the finished background stream from the persisted event log', async () => {
+    const { app } = await foundryBackedServer([say('replayed')]);
+
+    const created = await app.handle(post({ input: 'hi', background: true, stream: true }));
+    expect(created.status).toBe(200);
+    // Drain the live stream so the run finishes and persists its replay log.
+    const live = await created.text();
+    const id = /"id":\s*"(caresp_[A-Za-z0-9]+)"/.exec(live)?.[1];
+    expect(id).toBeDefined();
+    await waitUntilCompleted(app, must(id));
+
+    // A second subscriber replays the same events from the persisted log — the run is gone.
+    const replay = await app.handle(
+      new Request(`http://localhost:8088/responses/${id}?stream=true`, { method: 'GET' }),
+    );
+    expect(replay.status).toBe(200);
+    const replayed = await replay.text();
+    expect(replayed).toContain('response.completed');
+    expect(replayed).toContain('replayed');
+  });
+
+  it('keeps the platform call id on writes made while a foreground stream drains', async () => {
+    // The terminal persist of a `stream: true` foreground turn runs from the SSE consumer, after
+    // `handle()` returned — outside the request's AsyncLocalStorage scope unless the stream is
+    // re-bound to it. Without the call id the live service refuses the write, and a perfectly
+    // good stream ends in `storage_error`.
+    const { app, writes } = await foundryBackedServer([say('streamed answer')], {
+      requireCallId: true,
+    });
+
+    const created = await app.handle(
+      post({ input: 'hi', stream: true }, { [HEADERS.foundryCallId]: 'call-fg-1' }),
+    );
+    expect(created.status).toBe(200);
+    const stream = await created.text();
+
+    expect(stream).toContain('response.completed');
+    expect(stream).not.toContain('storage_error');
+    expect(writes.length).toBeGreaterThan(0);
+  });
+
+  it('continues a conversation with previous_response_id without re-sending stored items', async () => {
+    // The continuation turn's write embeds the previous turn's items; sent under their own ids
+    // the service rejects the create and the whole turn dies as `storage_error` (measured live).
+    // They must travel as history references instead.
+    const { app, client } = await foundryBackedServer([say('first answer'), say('second answer')]);
+
+    const first = (await (
+      await app.handle(post({ input: 'remember the word apple' }))
+    ).json()) as ResponseObject;
+    expect(first.status).toBe('completed');
+
+    const second = (await (
+      await app.handle(post({ input: 'what word?', previous_response_id: first.id }))
+    ).json()) as ResponseObject;
+    expect(second.status).toBe('completed');
+    expect(second.error ?? null).toBeNull();
+
+    // The model saw the first turn's transcript, replayed from the service store.
+    const replayedTexts = JSON.stringify(must(client.calls[1]).messages);
+    expect(replayedTexts).toContain('remember the word apple');
+    expect(replayedTexts).toContain('first answer');
+  });
+
+  it('continues a conversation-addressed turn through the service linkage, with no alias record', async () => {
+    const { app, writes, client } = await foundryBackedServer([say('one'), say('two')]);
+
+    const first = (await (
+      await app.handle(post({ input: 'the color is teal', conversation: 'caconv_test1' }))
+    ).json()) as ResponseObject;
+    expect(first.status).toBe('completed');
+
+    const second = (await (
+      await app.handle(post({ input: 'which color?', conversation: 'caconv_test1' }))
+    ).json()) as ResponseObject;
+    expect(second.status).toBe('completed');
+    expect(second.error ?? null).toBeNull();
+    expect(JSON.stringify(must(client.calls[1]).messages)).toContain('the color is teal');
+
+    // No alias record was written under the conversation id: every stored response keeps its own
+    // id, and the linkage lives in the service (the alias create would have collided anyway).
+    for (const write of writes) {
+      expect(write.id).not.toBe('caconv_test1');
+    }
+  });
+
+  it('resumes the replay after the cursor, not from the top', async () => {
+    const { app } = await foundryBackedServer([say('cursor test')]);
+
+    const created = await app.handle(post({ input: 'hi', background: true, stream: true }));
+    const live = await created.text();
+    const id = must(/"id":\s*"(caresp_[A-Za-z0-9]+)"/.exec(live)?.[1]);
+    await waitUntilCompleted(app, id);
+
+    const tail = await app.handle(
+      new Request(`http://localhost:8088/responses/${id}?stream=true&starting_after=0`, {
+        method: 'GET',
+      }),
+    );
+    expect(tail.status).toBe(200);
+    const replayed = await tail.text();
+    // Event 0 (`response.created`) is behind the cursor; the terminal is ahead of it.
+    expect(replayed).not.toContain('response.created');
+    expect(replayed).toContain('response.completed');
   });
 });
 

--- a/packages/foundry/src/hosting/response-store.test.ts
+++ b/packages/foundry/src/hosting/response-store.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { AccessToken, TokenCredential } from '@azure/identity';
 import type { ResponseObject } from '@polymind-inc/agent-framework-agentserver';
 import {
@@ -6,7 +9,7 @@ import {
   runWithRequestContext,
 } from '@polymind-inc/agent-framework-agentserver';
 import { ConfigurationError } from '@polymind-inc/agent-framework-core';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { FoundryResponseStore } from './response-store.js';
 import { defaultStore } from './server.js';
 
@@ -25,10 +28,14 @@ interface Call {
   body: unknown;
 }
 
+/** One shared scratch directory per test file run; each store() call gets its own subdirectory. */
+const replayScratch = await mkdtemp(join(tmpdir(), 'afjs-replay-'));
+let replayDirCount = 0;
+
 /** A store whose every request is recorded, with scripted replies. */
 function store(
-  replies: Array<{ status: number; body?: unknown }>,
-  options: { forwardCallId?: boolean } = {},
+  replies: Array<{ status?: number; body?: unknown; networkError?: boolean }>,
+  options: { forwardCallId?: boolean; replayRoot?: string } = {},
 ): {
   store: FoundryResponseStore;
   calls: Call[];
@@ -48,8 +55,11 @@ function store(
     });
     const reply = replies[Math.min(index, replies.length - 1)] ?? { status: 200 };
     index++;
+    if (reply.networkError === true) {
+      throw new TypeError('fetch failed');
+    }
     return new Response(reply.body === undefined ? null : JSON.stringify(reply.body), {
-      status: reply.status,
+      status: reply.status ?? 200,
       ...(reply.body === undefined ? {} : { headers: { 'content-type': 'application/json' } }),
     });
   }) as typeof globalThis.fetch;
@@ -59,6 +69,8 @@ function store(
       projectEndpoint: PROJECT,
       credential,
       fetch: fetchStub,
+      replayRoot: options.replayRoot ?? join(replayScratch, `store-${replayDirCount++}`),
+      retry: { baseDelayMs: 0 },
       ...(options.forwardCallId === undefined ? {} : { forwardCallId: options.forwardCallId }),
     }),
     calls,
@@ -72,6 +84,29 @@ function response(id = 'caresp_1'): ResponseObject {
 /** Runs `fn` as though it were serving a platform request. */
 async function asPlatformRequest<T>(headers: Record<string, string>, fn: () => Promise<T>): Promise<T> {
   return runWithRequestContext(createRequestContext(new Headers(headers)), fn);
+}
+
+// The write path stamps the agent identity from the environment when the response carries none, so
+// a developer shell configured for a real agent must not leak into the assertions below.
+const savedAgentEnv = {
+  name: process.env.FOUNDRY_AGENT_NAME,
+  version: process.env.FOUNDRY_AGENT_VERSION,
+};
+beforeEach(() => {
+  delete process.env.FOUNDRY_AGENT_NAME;
+  delete process.env.FOUNDRY_AGENT_VERSION;
+});
+afterEach(() => {
+  if (savedAgentEnv.name !== undefined) process.env.FOUNDRY_AGENT_NAME = savedAgentEnv.name;
+  if (savedAgentEnv.version !== undefined) process.env.FOUNDRY_AGENT_VERSION = savedAgentEnv.version;
+});
+
+/** The reference the store stamps when neither the response nor the environment names an agent. */
+const DEFAULT_REFERENCE = { type: 'agent_reference', name: 'server-default-agent' };
+
+/** The `agent_reference` a recorded create actually sent. */
+function sentReference(call: Call | undefined): unknown {
+  return (call?.body as { response?: ResponseObject } | undefined)?.response?.agent_reference;
 }
 
 describe('FoundryResponseStore', () => {
@@ -110,9 +145,10 @@ describe('FoundryResponseStore', () => {
     // Create is `POST responses`, not a PUT on the id.
     expect(calls[0]).toMatchObject({ method: 'POST' });
     expect(calls[0]?.url).toBe(`${PROJECT}/storage/responses?api-version=v1`);
-    // Both lists are always present, empty included, matching the reference serializer.
+    // Both lists are always present, empty included, matching the reference serializer. The
+    // response gains the agent reference the service requires on every write.
     expect(calls[0]?.body).toEqual({
-      response: response(),
+      response: { ...response(), agent_reference: DEFAULT_REFERENCE },
       input_items: [{ type: 'message', id: 'in_1' }],
       history_item_ids: [],
     });
@@ -123,7 +159,11 @@ describe('FoundryResponseStore', () => {
 
     await subject.put({ response: response() });
 
-    expect(calls[0]?.body).toEqual({ response: response(), input_items: [], history_item_ids: [] });
+    expect(calls[0]?.body).toEqual({
+      response: { ...response(), agent_reference: DEFAULT_REFERENCE },
+      input_items: [],
+      history_item_ids: [],
+    });
   });
 
   it('falls back to an update when the response already exists', async () => {
@@ -135,8 +175,9 @@ describe('FoundryResponseStore', () => {
       `${PROJECT}/storage/responses?api-version=v1`,
       `${PROJECT}/storage/responses/caresp_1?api-version=v1`,
     ]);
-    // The update carries the response itself, not the create envelope.
-    expect(calls[1]?.body).toEqual(response());
+    // The update carries the response itself, not the create envelope — with the same stamp,
+    // because the service validates the agent reference on updates too.
+    expect(calls[1]?.body).toEqual({ ...response(), agent_reference: DEFAULT_REFERENCE });
   });
 
   it('falls back to an update when the conflict arrives as a 400 with a conflict code', async () => {
@@ -336,22 +377,430 @@ describe('default store selection', () => {
     expect(defaultStore(false).constructor.name).toBe('InMemoryResponseProvider');
   });
 
-  it('uses the sandbox filesystem in a container, even a fully provisioned one', () => {
-    // The three variables .NET requires before it activates *its* Foundry provider. We do not:
-    // a real deployment answers `POST /storage/responses` with an opaque 500 even from inside the
-    // container, which would fail every turn. `FoundryResponseStore` is opt-in.
+  it('activates the Foundry storage service in a container, the way Python does', () => {
     process.env.FOUNDRY_PROJECT_ENDPOINT = PROJECT;
     process.env.FOUNDRY_AGENT_NAME = 'weather-agent';
     process.env.FOUNDRY_AGENT_VERSION = '1';
 
-    expect(defaultStore(true).constructor.name).toBe('FileResponseProvider');
+    expect(defaultStore(true).constructor.name).toBe('FoundryResponseStore');
   });
 
-  it('uses the sandbox filesystem for a half-configured container too', () => {
+  it('activates it on the project endpoint alone — the agent identity has a default', () => {
     process.env.FOUNDRY_PROJECT_ENDPOINT = PROJECT;
     delete process.env.FOUNDRY_AGENT_NAME;
     delete process.env.FOUNDRY_AGENT_VERSION;
 
+    expect(defaultStore(true).constructor.name).toBe('FoundryResponseStore');
+  });
+
+  it('falls back to the sandbox filesystem when a hosted container has no endpoint', () => {
+    // Should not happen — the platform injects FOUNDRY_PROJECT_ENDPOINT — but a misconfigured
+    // container serving turns off its sandbox beats one that cannot start.
+    delete process.env.FOUNDRY_PROJECT_ENDPOINT;
+
     expect(defaultStore(true).constructor.name).toBe('FileResponseProvider');
+  });
+});
+
+describe('agent reference stamping', () => {
+  // The storage service validates that every create and update carries an agent reference with a
+  // non-empty name, and rejects one without it as an opaque 500 (measured against a live project
+  // from inside a hosted container). The store therefore never sends a response without one.
+
+  it('stamps the environment agent identity onto a response that lacks one', async () => {
+    process.env.FOUNDRY_AGENT_NAME = 'weather-agent';
+    process.env.FOUNDRY_AGENT_VERSION = '3';
+    const { store: subject, calls } = store([{ status: 201 }]);
+
+    await subject.put({ response: response() });
+
+    expect(sentReference(calls[0])).toEqual({
+      type: 'agent_reference',
+      name: 'weather-agent',
+      version: '3',
+    });
+  });
+
+  it('falls back to the default agent name when the environment has none', async () => {
+    const { store: subject, calls } = store([{ status: 201 }]);
+
+    await subject.put({ response: response() });
+
+    expect(sentReference(calls[0])).toEqual(DEFAULT_REFERENCE);
+  });
+
+  it('passes a caller-supplied agent reference through unchanged', async () => {
+    process.env.FOUNDRY_AGENT_NAME = 'weather-agent';
+    const { store: subject, calls } = store([{ status: 201 }]);
+    const supplied = { type: 'agent_reference' as const, name: 'router-agent', version: '2' };
+
+    await subject.put({ response: { ...response(), agent_reference: supplied } });
+
+    expect(sentReference(calls[0])).toEqual(supplied);
+  });
+
+  it('normalizes a malformed discriminator from a direct caller', async () => {
+    const { store: subject, calls } = store([{ status: 201 }]);
+
+    await subject.put({
+      response: {
+        ...response(),
+        agent_reference: { type: 'other', name: 'router' } as never,
+      },
+    });
+
+    expect(sentReference(calls[0])).toEqual({ type: 'agent_reference', name: 'router' });
+  });
+
+  it('treats a blank agent name as absent rather than sending it to fail', async () => {
+    const { store: subject, calls } = store([{ status: 201 }]);
+
+    await subject.put({
+      response: { ...response(), agent_reference: { type: 'agent_reference', name: '  ' } },
+    });
+
+    expect(sentReference(calls[0])).toEqual(DEFAULT_REFERENCE);
+  });
+});
+
+describe('history references', () => {
+  it('sends already-stored items as references and only new ones as input items', async () => {
+    // Re-sending a stored item under its own id makes the create fail with an "already exists"
+    // body that masquerades as a duplicate create (measured live); the split is the fix.
+    const { store: subject, calls } = store([{ status: 201 }]);
+
+    await subject.put({
+      response: response(),
+      inputItems: [
+        { type: 'message', id: 'msg_old1' },
+        { type: 'message', id: 'msg_old2' },
+        { type: 'message', id: 'msg_new1' },
+      ],
+      historyItemIds: ['msg_old1', 'msg_old2'],
+    });
+
+    expect(calls[0]?.body).toMatchObject({
+      input_items: [{ type: 'message', id: 'msg_new1' }],
+      history_item_ids: ['msg_old1', 'msg_old2'],
+    });
+  });
+
+  it('surfaces the create failure when the conflict reading proves wrong', async () => {
+    // A duplicate-*item* failure arrives dressed as a duplicate create; the update fallback then
+    // 404s because nothing exists under the id. The create's own answer is the diagnostic — a
+    // bare 404 would point at the wrong problem entirely.
+    const { store: subject, calls } = store([
+      { status: 400, body: { error: { code: 'invalid_request', message: 'Item msg_1 already exists.' } } },
+      { status: 404, body: { error: { code: 'not_found', message: 'Response caresp_1 not found.' } } },
+    ]);
+
+    await expect(subject.put({ response: response() })).rejects.toThrow(/returned 400.*already exists/s);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('resolves a conversation id through the service linkage without trying it as a response', async () => {
+    // A conversation-shaped id goes straight to the linkage routes: no alias record exists, so a
+    // `GET responses/{id}` first would be a guaranteed miss on every conversation turn.
+    const { store: subject, calls } = store([
+      { status: 200, body: ['msg_1', 'msg_2'] },
+      {
+        status: 200,
+        body: [{ type: 'message', id: 'msg_1' }, null, { type: 'message', id: 'msg_2' }],
+      },
+    ]);
+
+    const items = await subject.history('caconv_1', 'alice');
+
+    expect(items?.map((item) => item.id)).toEqual(['msg_1', 'msg_2']);
+    expect(calls[0]?.url).toContain('history/item_ids?');
+    expect(calls[0]?.url).toContain('conversation_id=caconv_1');
+    expect(calls[1]?.url).toContain('items/batch/retrieve');
+    expect(calls[1]?.body).toEqual({ item_ids: ['msg_1', 'msg_2'] });
+  });
+
+  it('reports an unknown conversation as absent', async () => {
+    const { store: subject } = store([{ status: 404 }, { status: 404 }]);
+    expect(await subject.history('caconv_missing', 'alice')).toBeUndefined();
+  });
+});
+
+describe('write reconciliation', () => {
+  it('treats a retried create whose first attempt actually landed as success', async () => {
+    // The first POST persists server-side but the connection drops before the answer arrives.
+    // The retry then reads as a duplicate, the update fallback is refused because the stored
+    // response is already terminal — and yet the service holds exactly what we wrote. That is
+    // success, not a storage error.
+    const { store: subject, calls } = store([
+      { networkError: true },
+      { status: 409, body: { error: { code: 'conflict', message: 'already exists' } } },
+      {
+        status: 400,
+        body: { error: { code: 'bad_request', message: 'terminal state: Completed' } },
+      },
+      { status: 200, body: response() },
+    ]);
+
+    await expect(subject.put({ response: response() })).resolves.toBeUndefined();
+    // create (failed) → create (conflict) → update (refused) → reconciling GET.
+    expect(calls).toHaveLength(4);
+    expect(calls[3]).toMatchObject({ method: 'GET' });
+  });
+
+  it('does not mistake another turn under the same id for a retried success', async () => {
+    // A clean conflict — no ambiguous failure preceded it — is an id collision, not a lost
+    // answer. Reconciliation must not even be attempted: a stored response that happens to share
+    // the status would otherwise be claimed as this write's outcome.
+    const { store: subject, calls } = store([
+      { status: 409, body: { error: { code: 'conflict', message: 'already exists' } } },
+      {
+        status: 400,
+        body: { error: { code: 'bad_request', message: 'terminal state: Completed' } },
+      },
+    ]);
+
+    await expect(subject.put({ response: response() })).rejects.toThrow(/returned 400/);
+    // No reconciling GET: create (conflict) → update (refused) → failure.
+    expect(calls).toHaveLength(2);
+  });
+
+  it('still fails when the stored outcome is not the one this write described', async () => {
+    // The ambiguity is real, but what the service holds is a *different* completed turn — same
+    // status, different output. Claiming it as ours would leave the service holding the other
+    // turn while this caller believes its own was stored.
+    const { store: subject } = store([
+      { networkError: true },
+      { status: 409, body: { error: { code: 'conflict', message: 'already exists' } } },
+      {
+        status: 400,
+        body: { error: { code: 'bad_request', message: 'terminal state: Completed' } },
+      },
+      {
+        status: 200,
+        body: { ...response(), output: [{ type: 'message', id: 'msg_other' }] },
+      },
+    ]);
+
+    await expect(subject.put({ response: response() })).rejects.toThrow(/returned 400/);
+  });
+});
+
+describe('replay mirror integrity', () => {
+  it('keeps the generation when the service still holds this turn, output included', async () => {
+    const terminal = { ...response(), output: [{ type: 'message', id: 'msg_1' }] };
+    const { store: subject } = store([
+      { status: 201 },
+      { status: 200, body: terminal },
+      { status: 200, body: { object: 'list', data: [] } },
+    ]);
+
+    await subject.put({ response: terminal, userId: 'alice', generation: 'gen-1' });
+
+    expect((await subject.get('caresp_1', 'alice'))?.generation).toBe('gen-1');
+  });
+
+  it('does not pair a stale log with a reused id even inside one second', async () => {
+    // `created_at` is whole-second, so a delete-and-recreate can land on the same value. The
+    // output item ids cannot collide — the service rejects a duplicate item id outright — so
+    // they are the identity that survives the tie.
+    const oldTurn = { ...response(), output: [{ type: 'message', id: 'msg_old' }] };
+    const newTurn = { ...response(), output: [{ type: 'message', id: 'msg_new' }] };
+    const { store: subject } = store([
+      { status: 201 },
+      { status: 200, body: newTurn },
+      { status: 200, body: { object: 'list', data: [] } },
+    ]);
+
+    await subject.put({ response: oldTurn, userId: 'alice', generation: 'gen-old' });
+    await subject.putEvents('caresp_1', 'alice', [{ type: 'response.created' }], 'gen-old');
+
+    const stored = await subject.get('caresp_1', 'alice');
+    expect(stored?.generation).toBeUndefined();
+  });
+
+  it('serves the remote response when the mirror record is unreadable', async () => {
+    const replayRoot = join(replayScratch, `corrupt-${replayDirCount++}`);
+    await mkdir(replayRoot, { recursive: true });
+    await writeFile(join(replayRoot, 'caresp_1.json'), '{not json');
+    const { store: subject } = store(
+      [
+        { status: 200, body: response() },
+        { status: 200, body: { object: 'list', data: [] } },
+      ],
+      { replayRoot },
+    );
+
+    const stored = await subject.get('caresp_1', 'alice');
+
+    expect(stored?.response.id).toBe('caresp_1');
+    expect(stored?.generation).toBeUndefined();
+  });
+
+  it('answers replay as unavailable when the events log is unreadable', async () => {
+    const replayRoot = join(replayScratch, `corrupt-events-${replayDirCount++}`);
+    await mkdir(join(replayRoot, 'events'), { recursive: true });
+    await writeFile(join(replayRoot, 'events', 'caresp_1.json'), '{not json');
+    const { store: subject } = store([{ status: 201 }], { replayRoot });
+
+    await subject.put({ response: response(), userId: 'alice', generation: 'gen-1' });
+
+    expect(await subject.getEvents('caresp_1', 'alice', 'gen-1')).toBeUndefined();
+  });
+
+  it('keeps a remote delete a success when the mirror cannot be cleaned', async () => {
+    const blockedRoot = join(replayScratch, `blocked-del-${replayDirCount++}`);
+    await writeFile(blockedRoot, 'a file where the directory should be');
+    const { store: subject } = store([{ status: 204 }], { replayRoot: blockedRoot });
+
+    await expect(subject.delete('caresp_1', 'alice')).resolves.toBe(true);
+  });
+
+  it('does not attach a stale generation to a response the service replaced', async () => {
+    // Another sandbox deleted the id and reused it for a new turn; this sandbox's mirror still
+    // holds the old turn. The service response and the mirror no longer describe the same turn,
+    // so the generation must not transfer — otherwise the old events replay as the new stream.
+    const { store: subject } = store([
+      { status: 201 },
+      // The service now answers with a *different* turn under the same id.
+      { status: 200, body: { ...response(), created_at: 999 } },
+      { status: 200, body: { object: 'list', data: [] } },
+    ]);
+
+    await subject.put({ response: response(), userId: 'alice', generation: 'gen-old' });
+    await subject.putEvents('caresp_1', 'alice', [{ type: 'response.created' }], 'gen-old');
+
+    const stored = await subject.get('caresp_1', 'alice');
+    expect(stored?.generation).toBeUndefined();
+  });
+
+  it('keeps remote persistence a success when the local mirror cannot be written', async () => {
+    // The mirror is auxiliary: replay becomes unavailable (fail closed), but the response is
+    // durably stored and the turn must not be reported as a storage failure.
+    const blockedRoot = join(replayScratch, `blocked-${replayDirCount++}`);
+    await writeFile(blockedRoot, 'a file where the directory should be');
+    const { store: subject } = store(
+      [
+        { status: 201 },
+        { status: 200, body: response() },
+        { status: 200, body: { object: 'list', data: [] } },
+      ],
+      { replayRoot: blockedRoot },
+    );
+
+    await expect(
+      subject.put({ response: response(), userId: 'alice', generation: 'gen-1' }),
+    ).resolves.toBeUndefined();
+    expect(await subject.getEvents('caresp_1', 'alice', 'gen-1')).toBeUndefined();
+  });
+});
+
+describe('bounded retry', () => {
+  it('retries a transient failure and succeeds', async () => {
+    const { store: subject, calls } = store([{ status: 503 }, { status: 201 }]);
+
+    await subject.put({ response: response() });
+
+    expect(calls).toHaveLength(2);
+  });
+
+  it('gives up after the attempt budget and surfaces the last failure', async () => {
+    const { store: subject, calls } = store([{ status: 503 }]);
+
+    await expect(subject.put({ response: response() })).rejects.toThrow(/returned 503/);
+    expect(calls).toHaveLength(3);
+  });
+
+  it('does not retry a genuine bad request', async () => {
+    const { store: subject, calls } = store([
+      { status: 400, body: { error: { code: 'invalid_payload', message: 'Invalid payload' } } },
+    ]);
+
+    await expect(subject.put({ response: response() })).rejects.toThrow(/returned 400/);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('retries reads as well as writes', async () => {
+    const { store: subject, calls } = store([
+      { status: 502 },
+      { status: 200, body: response() },
+      { status: 200, body: { object: 'list', data: [] } },
+    ]);
+
+    const stored = await subject.get('caresp_1', 'alice');
+
+    expect(stored?.response.id).toBe('caresp_1');
+    expect(calls).toHaveLength(3);
+  });
+});
+
+describe('local replay log', () => {
+  // Foundry storage has no events route — the current reference (Python agentserver 2.0.0) keeps
+  // stream events on the sandbox filesystem and only the response resource in the service. The
+  // store mirrors that split: `putEvents`/`getEvents` persist next to the sandbox state, fenced by
+  // the generation the mirror recorded at `put`.
+
+  it('persists and replays the event stream of the stored generation', async () => {
+    const { store: subject } = store([{ status: 201 }]);
+    const events = [
+      { type: 'response.created', sequence_number: 0 },
+      { type: 'response.completed', sequence_number: 1 },
+    ];
+
+    await subject.put({ response: response(), userId: 'alice', generation: 'gen-1' });
+    await subject.putEvents('caresp_1', 'alice', events, 'gen-1');
+
+    expect(await subject.getEvents('caresp_1', 'alice', 'gen-1')).toEqual(events);
+  });
+
+  it('round-trips the generation through get, as the events contract requires', async () => {
+    const { store: subject } = store([
+      { status: 201 },
+      { status: 200, body: response() },
+      { status: 200, body: { object: 'list', data: [] } },
+    ]);
+
+    await subject.put({ response: response(), userId: 'alice', generation: 'gen-1' });
+    const stored = await subject.get('caresp_1', 'alice');
+
+    expect(stored?.generation).toBe('gen-1');
+  });
+
+  it('discards a replay log for a turn that no longer holds the id', async () => {
+    const { store: subject } = store([{ status: 201 }, { status: 201 }]);
+
+    await subject.put({ response: response(), userId: 'alice', generation: 'gen-1' });
+    await subject.put({ response: response(), userId: 'alice', generation: 'gen-2' });
+    await subject.putEvents('caresp_1', 'alice', [{ type: 'response.created' }], 'gen-1');
+
+    expect(await subject.getEvents('caresp_1', 'alice', 'gen-1')).toBeUndefined();
+    expect(await subject.getEvents('caresp_1', 'alice', 'gen-2')).toBeUndefined();
+  });
+
+  it('fails closed when the sandbox never saw the turn', async () => {
+    // A fresh sandbox (or a recycled container) has no mirror record: the fence cannot pass, so
+    // the write is a no-op and the read stays empty rather than fabricating a log.
+    const { store: subject } = store([{ status: 201 }]);
+
+    await subject.putEvents('caresp_ghost', 'alice', [{ type: 'response.created' }], 'gen-1');
+
+    expect(await subject.getEvents('caresp_ghost', 'alice', 'gen-1')).toBeUndefined();
+  });
+
+  it('drops the replay log with the response', async () => {
+    const { store: subject } = store([{ status: 201 }, { status: 200 }]);
+
+    await subject.put({ response: response(), userId: 'alice', generation: 'gen-1' });
+    await subject.putEvents('caresp_1', 'alice', [{ type: 'response.created' }], 'gen-1');
+    await subject.delete('caresp_1', 'alice');
+
+    expect(await subject.getEvents('caresp_1', 'alice', 'gen-1')).toBeUndefined();
+  });
+
+  it('keeps one user’s replay log invisible to another', async () => {
+    const { store: subject } = store([{ status: 201 }]);
+
+    await subject.put({ response: response(), userId: 'alice', generation: 'gen-1' });
+    await subject.putEvents('caresp_1', 'alice', [{ type: 'response.created' }], 'gen-1');
+
+    expect(await subject.getEvents('caresp_1', 'mallory', 'gen-1')).toBeUndefined();
   });
 });

--- a/packages/foundry/src/hosting/response-store.test.ts
+++ b/packages/foundry/src/hosting/response-store.test.ts
@@ -26,6 +26,8 @@ interface Call {
   url: string;
   headers: Record<string, string>;
   body: unknown;
+  /** The Response object this call was answered with, absent when the call threw. */
+  reply?: Response;
 }
 
 /** One shared scratch directory per test file run; each store() call gets its own subdirectory. */
@@ -47,21 +49,23 @@ function store(
     new Headers(init?.headers).forEach((value, name) => {
       headers[name] = value;
     });
-    calls.push({
+    const call: Call = {
       method: init?.method ?? 'GET',
       url: String(url),
       headers,
       body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
-    });
+    };
+    calls.push(call);
     const reply = replies[Math.min(index, replies.length - 1)] ?? { status: 200 };
     index++;
     if (reply.networkError === true) {
       throw new TypeError('fetch failed');
     }
-    return new Response(reply.body === undefined ? null : JSON.stringify(reply.body), {
+    call.reply = new Response(reply.body === undefined ? null : JSON.stringify(reply.body), {
       status: reply.status ?? 200,
       ...(reply.body === undefined ? {} : { headers: { 'content-type': 'application/json' } }),
     });
+    return call.reply;
   }) as typeof globalThis.fetch;
 
   return {
@@ -716,6 +720,20 @@ describe('bounded retry', () => {
 
     await expect(subject.put({ response: response() })).rejects.toThrow(/returned 400/);
     expect(calls).toHaveLength(1);
+  });
+
+  it('cancels the body of a response it discards for a retry', async () => {
+    // An unconsumed body keeps its connection busy in undici; a reply the loop moves past must
+    // release it rather than leave that to GC.
+    const { store: subject, calls } = store([
+      { status: 503, body: { error: { code: 'server_error', message: 'busy' } } },
+      { status: 201 },
+    ]);
+
+    await subject.put({ response: response() });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.reply?.bodyUsed).toBe(true);
   });
 
   it('retries reads as well as writes', async () => {

--- a/packages/foundry/src/hosting/response-store.ts
+++ b/packages/foundry/src/hosting/response-store.ts
@@ -2,12 +2,22 @@ import type { TokenCredential } from '@azure/identity';
 import { DefaultAzureCredential } from '@azure/identity';
 import type {
   OutputItem,
+  ResponseEvent,
+  ResponseGeneration,
   ResponseObject,
   ResponseOwner,
   ResponseProvider,
   StoredResponse,
 } from '@polymind-inc/agent-framework-agentserver';
-import { platformHeaders, projectEndpoint } from '@polymind-inc/agent-framework-agentserver';
+import {
+  FileResponseProvider,
+  historyOf,
+  ID_PREFIX,
+  platformHeaders,
+  projectEndpoint,
+  resolveAgentReference,
+  stateRoot,
+} from '@polymind-inc/agent-framework-agentserver';
 import { ConfigurationError } from '@polymind-inc/agent-framework-core';
 import { tokenProvider } from '../credential.js';
 import { FOUNDRY_API_VERSION, normalizeProjectEndpoint } from '../target.js';
@@ -36,14 +46,28 @@ export interface FoundryResponseStoreConfig {
   /**
    * Whether to forward `x-agent-foundry-call-id` on storage requests. Defaults to `true`.
    *
-   * The two reference implementations disagree, which is why this is a knob rather than a
-   * constant: .NET forwards it (`FoundryStorageProvider.ApplyPlatformHeaders`, whose comment says
-   * the service resolves the caller context from it), Python does not — its storage pipeline
-   * carries a bearer token and nothing else. Measured against a live project, the header makes no
-   * difference to whether a write succeeds, so the default stays with .NET rather than moving on
-   * a hypothesis that did not hold.
+   * Leave it on. Measured against a live project from inside a hosted container: a write
+   * **without** the call id fails with the service's opaque 500, and the same write with it
+   * succeeds — the service resolves the caller context from the header, exactly as the .NET
+   * provider's comment says (`FoundryStorageProvider.ApplyPlatformHeaders`; Python's
+   * `_apply_platform_headers` forwards the same single header). The knob exists for diagnostics,
+   * not because the header is optional in practice.
    */
   forwardCallId?: boolean;
+  /**
+   * Where the local replay mirror lives — the store's half of the split described in the class
+   * documentation ("Events live beside the sandbox"). Defaults to
+   * `${stateRoot()}/foundry-responses`: beside the sandbox state, in its own directory so it can
+   * never collide with a `FileResponseProvider` a host might also be running.
+   */
+  replayRoot?: string;
+  /**
+   * Bounded retry for transient storage failures: three attempts total, exponential backoff with
+   * this base (default 500ms, so 500ms then 1s — pass `0` in tests to disable the wait).
+   * Statuses 408, 429, 500, 502, 503 and 504 and thrown network errors are retried, matching the
+   * reference pipeline's policy; everything else surfaces immediately.
+   */
+  retry?: { baseDelayMs?: number };
 }
 
 /**
@@ -99,6 +123,41 @@ function isDuplicateCreate(body: string): boolean {
   return typeof message === 'string' && message.toLowerCase().includes('already exists');
 }
 
+/** The statuses worth another attempt, matching the reference retry policy's set. */
+const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([408, 429, 500, 502, 503, 504]);
+
+/** The total request budget per call, including the first attempt. */
+const RETRY_ATTEMPTS = 3;
+
+function delay(ms: number): Promise<void> {
+  return ms <= 0 ? Promise.resolve() : new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** The ids of a response's output items, in order. */
+function outputIds(response: ResponseObject): string[] {
+  return (Array.isArray(response.output) ? response.output : [])
+    .map((item) => item.id)
+    .filter((id): id is string => typeof id === 'string');
+}
+
+/**
+ * Whether the local mirror record and the service's answer describe the same turn.
+ *
+ * `created_at` alone is whole-second, so a delete-and-recreate of one id can land on the same
+ * value. The first output item id breaks the tie: the service rejects a duplicate item id
+ * outright (measured), so two turns can never share one. Two *outputless* turns of one id in one
+ * second remain indistinguishable — the residual window is a turn with no output, replaced
+ * within the same second, replayed from another sandbox.
+ */
+function sameTurn(local: ResponseObject, remote: ResponseObject): boolean {
+  return (
+    typeof local.created_at === 'number' &&
+    local.created_at === remote.created_at &&
+    local.status === remote.status &&
+    outputIds(local)[0] === outputIds(remote)[0]
+  );
+}
+
 /**
  * Keeps responses in the Foundry platform's storage service.
  *
@@ -122,17 +181,14 @@ function isDuplicateCreate(body: string): boolean {
  * - A stored response holds the whole conversation. It is protected by the project's access
  *   control, not by anything this client does.
  *
- * ## No retry, timeout or abort — and why
+ * ## Retry, but no timeout or abort
  *
- * Every call here is a bare `fetch`: one attempt, no backoff, no deadline, no `signal`. Both
- * references get retry from their platform HTTP stack — Python builds an `AsyncPipelineClient`
- * with `policies.AsyncRetryPolicy()` (`store/_foundry_provider.py:181-204`), .NET a
- * `ClientOptions`-derived `HttpPipeline` (`Internal/FoundryStorageClientOptions.cs`) — so a
- * faithful port is not a flag but a policy: attempt count, exponential backoff, `Retry-After`,
- * the retryable-status set, and a decision about retrying a **non-idempotent** `POST responses`.
- * A retry policy is deliberately not implemented yet. It would also be the wrong first move here:
- * this write path was measured answering `500` against a live project, and `500` is *in* the
- * retryable set, so a retry policy would multiply the one failure that has actually been observed.
+ * Transient failures get a bounded retry (see {@link FoundryResponseStoreConfig.retry}), the way
+ * both references get one from their platform HTTP stack — Python an `AsyncPipelineClient` with
+ * `policies.AsyncRetryPolicy()` (`store/_foundry_provider.py:181-204`), .NET a
+ * `ClientOptions`-derived `HttpPipeline`. Retrying the **non-idempotent** `POST responses` is
+ * safe here for the same reason it is in Python: a create that landed before its response was
+ * lost answers the retry as a duplicate, which `put` already treats as the update branch.
  *
  * **Abort propagation is a separate claim, and it does not hold.** Neither reference cancels a
  * storage call from the request. Python's provider takes no cancellation argument at all; .NET's
@@ -145,24 +201,60 @@ function isDuplicateCreate(body: string): boolean {
  * also why background runs are independent of the request signal to begin with. Threading a
  * `signal` through `ResponseProvider` would therefore be a deviation, not parity.
  *
+ * ## The write path needs the agent reference, and the credential decides everything
+ *
+ * Two facts, both measured against a live project (2026-08-08):
+ *
+ * - The service validates that every `POST responses` / `POST responses/{id}` body carries an
+ *   `agent_reference` with a non-empty `name` — and rejects one without it as an **opaque
+ *   `500`**, not a diagnosable 400. The name is not checked for existence. Python documents the
+ *   same service behaviour (`_build_server_error_payload`: the crash marker "MUST stamp it or the
+ *   failed terminal never persists"). `put` therefore stamps {@link resolveAgentReference}'s
+ *   fallback onto a response that arrives without one, instead of letting the turn die opaquely.
+ * - Writes are gated on the **hosted-agent credential**. From a workstation login, every storage
+ *   write answers the same opaque `500` regardless of payload (the tasks API states the rule
+ *   honestly: `403 hosted_agent_required`); from inside a deployed container with the managed
+ *   identity, the same writes succeed. This store is therefore only expected to work in a hosted
+ *   container — which is where it runs.
+ *
+ * One more measured rule: an update on a response already in a terminal state answers
+ * `400 "…terminal state"`. The protocol writes each turn's terminal exactly once, so the branch
+ * is not special-cased here; it surfaces as the storage failure it is.
+ *
+ * ## Events live beside the sandbox, not in the service
+ *
+ * The storage service has **no events API**. The current reference (Python
+ * `azure-ai-agentserver` 2.0.0) persists a background response's stream events on the sandbox
+ * filesystem and only the response resource in the service; this store makes the same split with
+ * a local {@link FileResponseProvider} mirror. `put`/`get`/`delete` keep the mirror in step so
+ * the {@link ResponseProvider.putEvents} generation fence works exactly as it does for the file
+ * store, and a sandbox that never saw the turn fails closed: the replay log is discarded rather
+ * than fabricated, the same durability the reference offers. Every mirror access is
+ * **best-effort**: a missing, unreadable or unwritable mirror only makes stream replay
+ * unavailable — it never fails the response operation the service already answered.
+ *
  * @remarks
  * The routes, verbs, `api-version` and request envelope all match
  * `azure-ai-agentserver-responses`' `FoundryStorageProvider` and .NET's, field for field
  * (`POST responses` to create, `POST responses/{id}` to update, `GET`/`DELETE responses/{id}`,
- * `GET responses/{id}/input_items`).
- *
- * **The read path is verified against a live project; the write path fails there.**
- * `POST /storage/responses` answers an opaque `500` — from a workstation *and* from inside a
- * deployed container, with and without the call id. The same route answers `400 Invalid payload`
- * for a malformed body, so the service accepts this envelope as well-formed and then fails behind
- * its own validation; there is no remaining client-side variable to change. That is why
- * `ResponsesHostServer` defaults to the sandbox filesystem and this store is opt-in.
+ * `GET responses/{id}/input_items`, `GET history/item_ids` and `POST items/batch/retrieve` for
+ * conversation resolution).
  */
 export class FoundryResponseStore implements ResponseProvider {
+  /**
+   * `true`: the service links a response to its conversation from the resource's `conversation`
+   * field, and {@link history} resolves a conversation id through the service's own routes. The
+   * alias record local stores use would re-send stored item ids, which the service rejects.
+   */
+  readonly linksConversationsServiceSide = true;
+
   readonly #endpoint: string;
   readonly #getToken: () => Promise<string>;
   readonly #fetch: typeof globalThis.fetch;
   readonly #forwardCallId: boolean;
+  /** The local half of the split: the replay log and the generation fence. */
+  readonly #replay: FileResponseProvider;
+  readonly #retryBaseDelayMs: number;
 
   constructor(options: FoundryResponseStoreConfig = {}) {
     const endpoint = options.projectEndpoint ?? projectEndpoint();
@@ -176,6 +268,10 @@ export class FoundryResponseStore implements ResponseProvider {
     this.#getToken = tokenProvider(options.credential ?? new DefaultAzureCredential());
     this.#fetch = options.fetch ?? globalThis.fetch;
     this.#forwardCallId = options.forwardCallId ?? true;
+    this.#replay = new FileResponseProvider({
+      root: options.replayRoot ?? `${stateRoot()}/foundry-responses`,
+    });
+    this.#retryBaseDelayMs = options.retry?.baseDelayMs ?? 500;
   }
 
   /** The storage base URL, for diagnostics. */
@@ -193,21 +289,54 @@ export class FoundryResponseStore implements ResponseProvider {
     path: string,
     options: { body?: unknown; query?: Record<string, string> } = {},
   ): Promise<Response> {
-    const headers: Record<string, string> = {
-      authorization: `Bearer ${await this.#getToken()}`,
-      accept: 'application/json',
-      // Attached per call, never captured at construction: one container serves many users, so
-      // anything request-scoped has to come from the request in flight.
-      ...(this.#forwardCallId ? platformHeaders() : {}),
-    };
-    if (options.body !== undefined) {
-      headers['content-type'] = 'application/json';
+    return (await this.#attempt(method, path, options)).response;
+  }
+
+  /**
+   * One request through the bounded retry.
+   *
+   * `ambiguous` is `true` when an earlier attempt failed in a way that says nothing about whether
+   * the service applied it — a dropped connection, or a retryable status — which is the only
+   * situation in which a later "already exists" may describe *this* write rather than a
+   * collision.
+   */
+  async #attempt(
+    method: string,
+    path: string,
+    options: { body?: unknown; query?: Record<string, string> } = {},
+  ): Promise<{ response: Response; ambiguous: boolean }> {
+    let ambiguous = false;
+    for (let attempt = 0; ; attempt++) {
+      const last = attempt === RETRY_ATTEMPTS - 1;
+      // Rebuilt per attempt: the token may have refreshed, and the platform headers belong to the
+      // request in flight, never to construction time — one container serves many users.
+      const headers: Record<string, string> = {
+        authorization: `Bearer ${await this.#getToken()}`,
+        accept: 'application/json',
+        ...(this.#forwardCallId ? platformHeaders() : {}),
+      };
+      if (options.body !== undefined) {
+        headers['content-type'] = 'application/json';
+      }
+      try {
+        const response = await this.#fetch(this.#url(path, options.query ?? {}), {
+          method,
+          headers,
+          ...(options.body === undefined ? {} : { body: JSON.stringify(options.body) }),
+        });
+        if (last || !RETRYABLE_STATUSES.has(response.status)) {
+          return { response, ambiguous };
+        }
+        ambiguous = true;
+      } catch (error) {
+        // A network-level failure is transient by definition; the last one surfaces as-is.
+        if (last) {
+          throw error;
+        }
+        ambiguous = true;
+      }
+      await delay(this.#retryBaseDelayMs * 2 ** attempt);
     }
-    return this.#fetch(this.#url(path, options.query ?? {}), {
-      method,
-      headers,
-      ...(options.body === undefined ? {} : { body: JSON.stringify(options.body) }),
-    });
   }
 
   /**
@@ -246,7 +375,7 @@ export class FoundryResponseStore implements ResponseProvider {
     return new Error(`Foundry storage returned ${status} for ${what}.${detail === '' ? '' : ` ${detail}`}`);
   }
 
-  async get(id: string, _owner: ResponseOwner): Promise<StoredResponse | undefined> {
+  async get(id: string, owner: ResponseOwner): Promise<StoredResponse | undefined> {
     const response = await this.#request('GET', `responses/${encodeURIComponent(id)}`);
     if (response.status === 404) {
       return undefined;
@@ -254,9 +383,33 @@ export class FoundryResponseStore implements ResponseProvider {
     if (!response.ok) {
       throw await FoundryResponseStore.#failure(response, `GET responses/${id}`);
     }
-    // The service stores the response resource itself; input items are a separate route.
+    // The service stores the response resource itself; input items are a separate route, and the
+    // local mirror read is independent of both.
     const stored = (await response.json()) as ResponseObject;
-    return { response: stored, inputItems: await this.#inputItems(id) };
+    const [inputItems, local] = await Promise.all([this.#inputItems(id), this.#mirrorRecord(id, owner)]);
+    const result: StoredResponse = { response: stored, inputItems };
+    // The events contract requires the generation to round-trip through `put` and `get` — but
+    // only when the mirror still describes the turn the service answered with (see {@link
+    // sameTurn}); a stale record's generation would replay the *old* turn's events as the new
+    // stream. No mirror record, or a mismatched one, simply means no generation.
+    if (local !== undefined && sameTurn(local.response, stored)) {
+      if (local.generation !== undefined) {
+        result.generation = local.generation;
+      }
+      if (local.userId !== undefined) {
+        result.userId = local.userId;
+      }
+    }
+    return result;
+  }
+
+  /** The mirror record, or `undefined` when it is missing or unreadable (replay then fails closed). */
+  async #mirrorRecord(id: string, owner: ResponseOwner): Promise<StoredResponse | undefined> {
+    try {
+      return await this.#replay.get(id, owner);
+    } catch {
+      return undefined;
+    }
   }
 
   /**
@@ -308,46 +461,215 @@ export class FoundryResponseStore implements ResponseProvider {
    * throw is wrong the conversation is gone.
    */
   async put(stored: StoredResponse): Promise<void> {
+    // The service rejects a write whose response names no agent — as an opaque 500 — so the
+    // reference is always resolved here: the protocol layer stamps every resource it builds, and
+    // this re-resolution is the net for direct callers (a well-formed reference rebuilds as-is).
+    const response = {
+      ...stored.response,
+      agent_reference: resolveAgentReference(stored.response.agent_reference),
+    };
+    // Items the service already holds travel as references. Re-sending one under its own id
+    // makes the create fail — with an "already exists" body that reads like a duplicate-create,
+    // which is why the split is done here and not diagnosed later.
+    const historyIds = new Set(stored.historyItemIds ?? []);
     const body: CreateBody = {
-      response: stored.response,
-      input_items: stored.inputItems ?? [],
-      history_item_ids: [],
+      response,
+      input_items: (stored.inputItems ?? []).filter(
+        (item) => typeof item.id !== 'string' || !historyIds.has(item.id),
+      ),
+      history_item_ids: [...historyIds],
     };
 
-    const created = await this.#request('POST', 'responses', { body });
-    if (created.ok) {
+    await this.#writeRemote(response, body);
+    // Every successful remote write funnels through this one call: the mirror is what the
+    // generation fence compares against, so a success path that skipped it would break replay.
+    await this.#mirror(stored);
+  }
+
+  /** Writes the response to the service — create, else update — resolving on success. */
+  async #writeRemote(response: ResponseObject, body: CreateBody): Promise<void> {
+    const created = await this.#attempt('POST', 'responses', { body });
+    if (created.response.ok) {
       return;
     }
-    const createdBody = await FoundryResponseStore.#body(created);
-    const conflict = created.status === 409 || (created.status === 400 && isDuplicateCreate(createdBody));
+    const createdBody = await FoundryResponseStore.#body(created.response);
+    const conflict =
+      created.response.status === 409 || (created.response.status === 400 && isDuplicateCreate(createdBody));
     if (!conflict) {
-      throw FoundryResponseStore.#failureFrom(created.status, createdBody, 'POST responses');
+      throw FoundryResponseStore.#failureFrom(created.response.status, createdBody, 'POST responses');
     }
 
-    const updated = await this.#request('POST', `responses/${encodeURIComponent(stored.response.id)}`, {
-      body: stored.response,
+    const updated = await this.#request('POST', `responses/${encodeURIComponent(response.id)}`, {
+      body: response,
     });
-    if (!updated.ok) {
-      throw await FoundryResponseStore.#failure(updated, `POST responses/${stored.response.id}`);
+    if (updated.status === 404) {
+      // The conflict reading was wrong: nothing exists under this id, so the create failed for a
+      // reason its "already exists"-flavoured body obscured (a duplicate *item*, most likely).
+      // The create's own answer is the true diagnostic, not this 404.
+      throw FoundryResponseStore.#failureFrom(created.response.status, createdBody, 'POST responses');
+    }
+    if (updated.ok) {
+      return;
+    }
+    // A refused update after a conflicted create is a failure — unless an earlier attempt of
+    // *this* create failed ambiguously (its answer was lost on the wire) and what the service
+    // holds is exactly the outcome this write described. A clean conflict is an id collision:
+    // reconciliation is not even attempted, or another turn's outcome could be claimed as ours.
+    if (!(created.ambiguous && (await this.#alreadyApplied(response)))) {
+      throw await FoundryResponseStore.#failure(updated, `POST responses/${response.id}`);
     }
   }
 
-  async delete(id: string, _owner: ResponseOwner): Promise<boolean> {
-    const response = await this.#request('DELETE', `responses/${encodeURIComponent(id)}`);
-    if (response.status === 404) {
+  /** Whether the stored record under this id is the very outcome this write described. */
+  async #alreadyApplied(response: ResponseObject): Promise<boolean> {
+    try {
+      const existing = await this.#request('GET', `responses/${encodeURIComponent(response.id)}`);
+      if (!existing.ok) {
+        return false;
+      }
+      const parsed = (await existing.json()) as ResponseObject;
+      // Identity, not plausibility: the fields that describe the turn's outcome all have to
+      // match. Output is compared by item ids — the service enforces their uniqueness, so a
+      // different turn can never share them, while echoed items may gain normalized fields.
+      return (
+        parsed.created_at === response.created_at &&
+        parsed.status === response.status &&
+        JSON.stringify(outputIds(parsed)) === JSON.stringify(outputIds(response)) &&
+        JSON.stringify(parsed.error ?? null) === JSON.stringify(response.error ?? null) &&
+        JSON.stringify(parsed.incomplete_details ?? null) ===
+          JSON.stringify(response.incomplete_details ?? null)
+      );
+    } catch {
+      // The reconciliation read is an extra chance to recognize success, never a new failure
+      // mode: when it cannot answer, the update's own error stands.
       return false;
     }
-    if (!response.ok) {
+  }
+
+  /**
+   * Records the turn locally after the service accepted it, so the generation fence has something
+   * to compare against. Written *after* the service write on purpose: a mirror of a write the
+   * service refused would let a replay log attach to a turn that never existed.
+   *
+   * Best-effort, like every mirror access: a mirror the sandbox cannot write must not turn a
+   * durably persisted response into a reported storage failure. On a failed write the stale
+   * record is dropped instead, so replay fails closed while the turn does not.
+   *
+   * Only the fence fields are kept — `created_at`, `status`, the first output item stub,
+   * `generation`, `userId`. The transcript itself lives in the service; mirroring it too would
+   * rewrite the whole conversation to local disk on every turn, growing by a turn each turn.
+   */
+  async #mirror(stored: StoredResponse): Promise<void> {
+    const marker = (Array.isArray(stored.response.output) ? stored.response.output : [])
+      .slice(0, 1)
+      .map((item) => ({ type: item.type, id: item.id }));
+    try {
+      await this.#replay.put({
+        ...stored,
+        inputItems: [],
+        historyItemIds: [],
+        response: { ...stored.response, output: marker as OutputItem[] },
+      });
+    } catch {
+      try {
+        await this.#replay.delete(stored.response.id, stored.userId);
+      } catch {
+        // The directory itself is unwritable; there is no record to drop.
+      }
+    }
+  }
+
+  async delete(id: string, owner: ResponseOwner): Promise<boolean> {
+    const response = await this.#request('DELETE', `responses/${encodeURIComponent(id)}`);
+    if (!response.ok && response.status !== 404) {
       throw await FoundryResponseStore.#failure(response, `DELETE responses/${id}`);
     }
-    return true;
+    // The replay log and its fence go with the response either way — even on a 404, because the
+    // service and the sandbox can disagree after a recycle, and a stale local log must not
+    // survive the id it belonged to. Best-effort: an uncleanable mirror does not undo the
+    // service-side delete.
+    try {
+      await this.#replay.delete(id, owner);
+    } catch {
+      // Replay for this id already fails closed without the mirror.
+    }
+    return response.status !== 404;
+  }
+
+  async putEvents(
+    id: string,
+    owner: ResponseOwner,
+    events: readonly ResponseEvent[],
+    generation: ResponseGeneration,
+  ): Promise<void> {
+    // The mirror record written by `put` is the fence: the delegate compares generations under
+    // its per-id queue, exactly as the file store does.
+    await this.#replay.putEvents(id, owner, events, generation);
+  }
+
+  async getEvents(
+    id: string,
+    owner: ResponseOwner,
+    generation: ResponseGeneration,
+  ): Promise<ResponseEvent[] | undefined> {
+    // Best-effort read: an unreadable log answers as no log, never as a failed route.
+    try {
+      return await this.#replay.getEvents(id, owner, generation);
+    } catch {
+      return undefined;
+    }
   }
 
   async history(id: string, owner: ResponseOwner): Promise<OutputItem[] | undefined> {
+    // A response id resolves from its own record; a conversation id through the service's own
+    // linkage (no alias record exists — see `linksConversationsServiceSide`). The prefix decides
+    // which to try first, so the common case pays one lookup instead of a guaranteed miss; the
+    // other path stays as the fallback for an id shape this guess got wrong.
+    if (id.startsWith(`${ID_PREFIX.response}_`)) {
+      return (await this.#recordHistory(id, owner)) ?? (await this.#conversationHistory(id));
+    }
+    return (await this.#conversationHistory(id)) ?? (await this.#recordHistory(id, owner));
+  }
+
+  /** The transcript of one stored response, or `undefined` when the id is not a response. */
+  async #recordHistory(id: string, owner: ResponseOwner): Promise<OutputItem[] | undefined> {
     const stored = await this.get(id, owner);
-    // The service also exposes `history/item_ids` and `items/batch/retrieve` for this, which would
-    // avoid re-reading the response. Their payload shapes are not verified here, so the transcript
-    // is assembled from the two routes that are.
-    return stored === undefined ? undefined : [...(stored.inputItems ?? []), ...stored.response.output];
+    return stored === undefined ? undefined : historyOf(stored);
+  }
+
+  /** The transcript of a conversation, or `undefined` when the conversation is unknown. */
+  async #conversationHistory(id: string): Promise<OutputItem[] | undefined> {
+    const ids = await this.#historyItemIds(id);
+    if (ids === undefined) {
+      return undefined;
+    }
+    if (ids.length === 0) {
+      return [];
+    }
+    const retrieved = await this.#request('POST', 'items/batch/retrieve', {
+      body: { item_ids: ids },
+    });
+    if (!retrieved.ok) {
+      throw await FoundryResponseStore.#failure(retrieved, 'POST items/batch/retrieve');
+    }
+    // The service preserves order and answers a missing id with a null gap.
+    const items = (await retrieved.json()) as Array<OutputItem | null>;
+    return items.filter((item): item is OutputItem => item !== null && typeof item === 'object');
+  }
+
+  /** The conversation's transcript item ids, or `undefined` when the conversation is unknown. */
+  async #historyItemIds(conversationId: string): Promise<string[] | undefined> {
+    const response = await this.#request('GET', 'history/item_ids', {
+      // The page size mirrors the input_items read; the route answers a bare array.
+      query: { limit: '100', conversation_id: conversationId },
+    });
+    if (response.status === 404) {
+      return undefined;
+    }
+    if (!response.ok) {
+      throw await FoundryResponseStore.#failure(response, 'GET history/item_ids');
+    }
+    const ids = (await response.json()) as unknown;
+    return Array.isArray(ids) ? ids.filter((id): id is string => typeof id === 'string') : [];
   }
 }

--- a/packages/foundry/src/hosting/response-store.ts
+++ b/packages/foundry/src/hosting/response-store.ts
@@ -175,9 +175,12 @@ function sameTurn(local: ResponseObject, remote: ResponseObject): boolean {
  * - `x-agent-user-id` is deliberately not sent — see `platformHeaders`. It is a global cross-agent
  *   identifier, and the service does not accept it. This is also why the `owner` argument every
  *   `ResponseProvider` method takes is accepted but not applied here: the partition is enforced
- *   service-side, before this client sees anything. The parameter stays in the signature because
- *   the abstraction — not the implementation — is what has to carry the guarantee for the stores
- *   that *can* be reached across users.
+ *   service-side, from the call id, before this client sees anything — measured: a read outside
+ *   the caller context answers 404 even for an id that exists. That covers every service route
+ *   this store uses, the conversation-linkage reads included. The parameter stays in the
+ *   signature because the abstraction — not the implementation — is what has to carry the
+ *   guarantee for the stores that *can* be reached across users, and the local replay mirror
+ *   does apply it.
  * - A stored response holds the whole conversation. It is protected by the project's access
  *   control, not by anything this client does.
  *
@@ -328,6 +331,9 @@ export class FoundryResponseStore implements ResponseProvider {
           return { response, ambiguous };
         }
         ambiguous = true;
+        // A discarded response's body would otherwise hold its connection until GC; cancelling
+        // is best-effort resource hygiene, never a failure.
+        await response.body?.cancel().catch(() => {});
       } catch (error) {
         // A network-level failure is transient by definition; the last one surfaces as-is.
         if (last) {

--- a/packages/foundry/src/hosting/server.ts
+++ b/packages/foundry/src/hosting/server.ts
@@ -3,10 +3,12 @@ import {
   FileResponseProvider,
   InMemoryResponseProvider,
   isHosted,
+  projectEndpoint,
   ResponsesServer,
 } from '@polymind-inc/agent-framework-agentserver';
 import type { FoundryHandlerConfig } from './handler.js';
 import { createFoundryHandler } from './handler.js';
+import { FoundryResponseStore } from './response-store.js';
 
 /** Construction options for {@link ResponsesHostServer}. */
 export interface ResponsesHostServerConfig
@@ -24,35 +26,27 @@ export interface ResponsesHostServerConfig
 /**
  * Picks the response store the environment calls for.
  *
- * In a container: the sandbox filesystem. Locally: memory, so nothing outlives the process.
+ * In a container: the Foundry storage service, the way Python's `ResponsesHostServer` activates
+ * its provider when hosted — responses then survive sandbox recycling and conversations can move
+ * between sandboxes. Locally: memory, so nothing outlives the process. A hosted container that
+ * somehow lacks the platform-injected project endpoint falls back to the sandbox filesystem
+ * rather than refusing to start.
  *
- * @remarks
- * **This is not what the reference implementations do, and the reason is measured rather than
- * argued.** Both of them switch a hosted container to Foundry storage automatically (Python
- * `_routing.py`, .NET `ResponsesServerServiceCollectionExtensions`), and this package originally
- * followed them. A real deployment showed that `POST /storage/responses` answers an opaque `500`
- * — from *inside* a
- * container the platform provisioned, with its managed identity and the platform's own
- * `x-agent-foundry-call-id`. Every turn then fails, because a response that cannot be stored is a
- * conversation that cannot be continued. A default that makes the container unusable is the wrong
- * default whatever the reference does, so `FoundryResponseStore` became opt-in:
+ * The storage service requires the hosted-agent credential and the platform call id on every
+ * write, and an `agent_reference` on every persisted response (all measured against the live
+ * service) — the store and the protocol layer supply all three. To keep a deployed container off
+ * the storage service, pass the store explicitly:
  *
  * ```ts
- * new ResponsesHostServer({ agent, store: new FoundryResponseStore() })
+ * new ResponsesHostServer({ agent, store: new FileResponseProvider() })
  * ```
- *
- * The file store works because the platform keeps a conversation on one sandbox: it stamps
- * `agent_session_id` on every request and holds it constant across the turns of a conversation, so
- * a follow-up turn lands on the same filesystem and resolves its `previous_response_id` — verified
- * end to end on a real deployment. What it does not survive is a conversation moving between
- * sandboxes, or a sandbox being recycled.
  */
 export function defaultStore(hosted: boolean): ResponseProvider {
   if (!hosted) {
     // A local run is self-contained; nothing should outlive the process.
     return new InMemoryResponseProvider();
   }
-  return new FileResponseProvider();
+  return projectEndpoint() === undefined ? new FileResponseProvider() : new FoundryResponseStore();
 }
 
 /**


### PR DESCRIPTION
Closes #24

## Problem

`FoundryResponseStore` could not write: `POST /storage/responses` answered an opaque `500`, background execution was fail-closed with the documented 501, and the store was opt-in with the sandbox filesystem as the hosted default.

## What the live service actually requires (measured from inside a deployed container)

Probing with a diagnostic agent isolated the rules behind the opaque 500, none of which are documented:

1. **Every write must carry an `agent_reference` with a non-empty name** (existence is not checked; the discriminator is tolerated either way).
2. **Every write must forward `x-agent-foundry-call-id`**, and writes are gated on the hosted-agent credential — from a workstation login everything fails with the same opaque 500 (the tasks API states it honestly: `403 hosted_agent_required`).
3. **Re-sending an already-stored item under its own id fails the create**, with an "already exists" body that masquerades as a duplicate-create — this is what killed every continuation turn. Already-stored items must travel as `history_item_ids` references, which the service resolves back into the transcript on read.

Also measured: updates are refused once a response is terminal, item ids and response ids are format-validated, message content must be a parts array, and the conversation linkage resolves through `GET history/item_ids` + `POST items/batch/retrieve`.

## Changes

**Protocol layer (`agentserver`)**
- Every response resource is stamped with a resolved `agent_reference` (request → `FOUNDRY_AGENT_NAME`/`_VERSION` → default), normalized to the literal discriminator.
- Deferred work is bound to the turn's request context: `persistSnapshot` re-enters it explicitly (a foreground stream persists from the SSE consumer's pull, outside the request scope) and the event stream is bound once for both the OTel context and the request context via a generalized `bindIterable`.
- `StoredResponse.historyItemIds` carries which input items are replayed history; `ResponseProvider.linksConversationsServiceSide` lets a service-linked store suppress the conversation alias record local stores need.

**`FoundryResponseStore`**
- `putEvents`/`getEvents` implemented with a local replay mirror beside the sandbox state — the same split the Python reference (agentserver 2.0.0) makes, since the storage service has no events API. The mirror is fence-only (constant size) and best-effort: unreadable or unwritable mirrors only disable stream replay, never the response operations.
- Turn identity for the replay fence: `created_at` + `status` + the first output item id, whose global uniqueness the service enforces — a deleted-and-reused id cannot pair with a stale log even inside the same second.
- Bounded retry (3 attempts, reference status set, exponential backoff). A refused update after a conflicted create reconciles only when this create's own answer was ambiguously lost *and* the stored outcome is identity-equal (`created_at`, `status`, output item ids, `error`, `incomplete_details`) to what was written.
- Conversation ids resolve through the service linkage routes, chosen by id prefix with a fallback for unrecognized shapes.
- With the write path working, `defaultStore` activates the Foundry store in hosted containers, matching the reference implementations; a missing endpoint falls back to the sandbox filesystem, and `store: new FileResponseProvider()` opts a deployment out.

## Tests

- A stateful double of the storage service encodes the measured behaviours (agent-reference validation, call-id gating, duplicate-item rejection, reference resolution, conversation linkage) and drives end-to-end regression tests: background create → completion → stream replay → cursor resume, continuation via `previous_response_id`, conversation continuation with no alias record, and foreground `stream: true` persisting with the call id intact.
- Store-level tests cover the envelope split, retry budget, reconciliation (including the id-collision and different-outcome refusals), replay-fence integrity across reused ids, and mirror corruption/permission failures.
- Every fix was written reproduction-first and confirmed by temporarily reverting it; two review rounds (five findings each) are regression-tested the same way.

## Live verification

Against a real Foundry project, from a deployed container: normal, streamed and continuation turns; background create, completion, stream replay and `starting_after` cursor resume; delete; GET/input_items consistency across six container replacements; and the default-activation path with no explicit store configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)