### PR TITLE
Record system instructions on chat spans only when content capture is enabled

### DIFF
--- a/examples/02-foundry/02-hosted-agent/README.md
+++ b/examples/02-foundry/02-hosted-agent/README.md
@@ -173,6 +173,11 @@ Locally, point OTLP at any collector (an Aspire dashboard, Jaeger):
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 pnpm --filter example-02-foundry host
 ```
 
-Message _content_ (prompts, tool arguments, results) is never recorded on spans unless you opt in
-with `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` — set it in `agent.yaml`'s
-`environment_variables` if your tracing backend is allowed to see conversations.
+Message _content_ (prompts, system instructions, tool arguments, results) is never recorded on
+spans unless you opt in with `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` — set it in
+`agent.yaml`'s `environment_variables` if your tracing backend is allowed to see conversations.
+(The Python hosting SDK turns content capture **on** unless that variable says otherwise, so a
+Python agent shows message text in the portal where this host stays silent by default — that
+difference is deliberate.) If you set it, verify it actually reached the registered version with
+`GET /agents/<name>/versions/<n>`: as noted above, `environment_variables` does not arrive
+through every deployment flow.

--- a/packages/core/src/client/function-invocation.ts
+++ b/packages/core/src/client/function-invocation.ts
@@ -10,8 +10,7 @@ import type { FunctionMiddleware, FunctionMiddlewareContext } from '../middlewar
 import { runMiddlewareChain, terminateMiddleware } from '../middleware/middleware.js';
 import { readRunScope, stripRunScope } from '../middleware/run-scope.js';
 import { GEN_AI, GEN_AI_OPERATION } from '../observability/attributes.js';
-import { captureMessageContent } from '../observability/settings.js';
-import { recordSpanError, setAttr, spanName, withSpan } from '../observability/tracing.js';
+import { capturesContent, recordSpanError, setAttr, spanName, withSpan } from '../observability/tracing.js';
 import { createResponseStream } from '../streaming/response-stream.js';
 import {
   approvalReason,
@@ -374,7 +373,7 @@ async function invokeOne(
       ...(target.description === '' ? {} : { [GEN_AI.toolDescription]: target.description }),
     },
     async (span) => {
-      if (captureMessageContent()) {
+      if (capturesContent(span)) {
         setAttr(span, GEN_AI.toolArguments, stringifyForSpan(call.arguments));
       }
       // Middleware runs inside the span: a middleware that answers for the tool still produced the
@@ -427,7 +426,7 @@ async function invokeOne(
       if (settled.status === 'exception') {
         // Reported to the model as a result rather than thrown, so the span records it explicitly.
         recordSpanError(span, settled.error);
-      } else if (settled.userInputRequests === undefined && captureMessageContent()) {
+      } else if (settled.userInputRequests === undefined && capturesContent(span)) {
         setAttr(span, GEN_AI.toolResult, stringifyForSpan(settled.result));
       }
       return settled;

--- a/packages/core/src/client/telemetry.ts
+++ b/packages/core/src/client/telemetry.ts
@@ -5,8 +5,8 @@ import {
   finishChatSpan,
   inActiveSpan,
   recordSpanError,
-  setAttr,
   setMessageContent,
+  setSystemInstructions,
   spanName,
   startSpan,
   withActiveSpan,
@@ -109,9 +109,7 @@ export function withChatTelemetry<TOptions extends ChatOptions>(
         span = chatSpan;
         startedAt = performance.now();
         setMessageContent(chatSpan, GEN_AI.inputMessages, messages);
-        if (options?.instructions !== undefined) {
-          setAttr(chatSpan, GEN_AI.systemInstructions, options.instructions);
-        }
+        setSystemInstructions(chatSpan, options?.instructions);
         try {
           // Inside the `try`: a client that rejects the call synchronously — a bad model name, a
           // missing key — would otherwise leave this span open and unrecorded, because the failure

--- a/packages/core/src/observability/tracing.test.ts
+++ b/packages/core/src/observability/tracing.test.ts
@@ -218,6 +218,28 @@ describe('GenAI tracing', () => {
     expect(invoke.attributes[GEN_AI.outputMessages]).toBeUndefined();
   });
 
+  it('keeps system instructions off the chat span until content capture is opted in', async () => {
+    // Regression: instructions used to be stamped unconditionally, leaking prompt
+    // text with capture off. The reference implementations emit the attribute only when
+    // sensitive-data capture is enabled.
+    const mock = new MockChatClient([{ contents: [textContent('x')], finishReason: 'stop' }]);
+    await new Agent({ client: mock, name: 'bot', instructions: 'You are terse.' }).run('q');
+
+    const chat = must(byName('chat mock-model'));
+    expect(chat.attributes[GEN_AI.systemInstructions]).toBeUndefined();
+  });
+
+  it('records system instructions as a parts array once opted in', async () => {
+    configureObservability({ captureMessageContent: true });
+    const mock = new MockChatClient([{ contents: [textContent('x')], finishReason: 'stop' }]);
+    await new Agent({ client: mock, name: 'bot', instructions: 'You are terse.' }).run('q');
+
+    const chat = must(byName('chat mock-model'));
+    expect(chat.attributes[GEN_AI.systemInstructions]).toBe(
+      JSON.stringify([{ type: 'text', content: 'You are terse.' }]),
+    );
+  });
+
   it('records message content once opted in', async () => {
     configureObservability({ captureMessageContent: true });
     const mock = new MockChatClient([{ contents: [textContent('the answer')], finishReason: 'stop' }]);

--- a/packages/core/src/observability/tracing.ts
+++ b/packages/core/src/observability/tracing.ts
@@ -1,5 +1,7 @@
 import type { Attributes, AttributeValue, Span } from '@opentelemetry/api';
 import { context, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
+import type { Content } from '../types/content.js';
+import { textContent } from '../types/content.js';
 import type { Message } from '../types/message.js';
 import type { ChatResponse, ResponseBase } from '../types/response.js';
 import type { UsageDetails } from '../types/usage.js';
@@ -44,15 +46,29 @@ export function setResponseAttributes(
  * Only the fields the convention asks for, so a span does not carry provider objects or base64
  * payloads: those belong in the transcript, not in a trace.
  */
+/** One part of the sensitive-data serialization: only the field the convention asks for. */
+function spanPart(content: Content): { type: string; content?: string } {
+  return content.type === 'text' ? { type: 'text', content: content.text } : { type: content.type };
+}
+
 export function serializeMessagesForSpan(messages: readonly Message[]): string {
   return JSON.stringify(
     messages.map((msg) => ({
       role: msg.role,
-      parts: msg.contents.map((content) =>
-        content.type === 'text' ? { type: 'text', content: content.text } : { type: content.type },
-      ),
+      parts: msg.contents.map(spanPart),
     })),
   );
+}
+
+/**
+ * Whether message text may be recorded on `span`: the caller opted in, and the span is actually
+ * recording (a non-recording span would throw the serialization work away).
+ *
+ * Every attribute that carries prompt, completion or tool content answers to this one predicate —
+ * it is the single place to audit what gates sensitive data.
+ */
+export function capturesContent(span: Span): boolean {
+  return span.isRecording() && captureMessageContent();
 }
 
 /**
@@ -63,7 +79,7 @@ export function serializeMessagesForSpan(messages: readonly Message[]): string {
  * because both carry message text.
  */
 export function setMessageContent(span: Span, key: string, messages: readonly Message[]): void {
-  if (!captureMessageContent() || messages.length === 0) {
+  if (messages.length === 0 || !capturesContent(span)) {
     return;
   }
   span.setAttribute(key, serializeMessagesForSpan(messages));
@@ -71,6 +87,19 @@ export function setMessageContent(span: Span, key: string, messages: readonly Me
   for (const msg of messages) {
     addMessageEvent(span, msg, output);
   }
+}
+
+/**
+ * Records the system instructions, gated the same way as message content — they are prompt text.
+ *
+ * Serialized as a parts array (`[{ "type": "text", "content": ... }]`), the shape the .NET and
+ * Python implementations emit for this attribute, not the bare string.
+ */
+export function setSystemInstructions(span: Span, instructions: string | undefined): void {
+  if (instructions === undefined || instructions === '' || !capturesContent(span)) {
+    return;
+  }
+  span.setAttribute(GEN_AI.systemInstructions, JSON.stringify([spanPart(textContent(instructions))]));
 }
 
 /**


### PR DESCRIPTION
## Problem

The chat telemetry layer stamped `gen_ai.system_instructions` on every chat span unconditionally, as a bare string. With sensitive-data capture off (the default), the system prompt still ended up in plain text in the tracing backend — measured on a live Foundry deployment, where every turn carried the full instructions. The OpenTelemetry GenAI conventions treat this attribute as opt-in, and both the .NET and Python implementations emit it only when content capture is enabled, serialized as a parts array (`[{"type":"text","content":…}]`), not a bare string.

## Change

- `gen_ai.system_instructions` is now recorded only when content capture is enabled, in the reference implementations' parts-array shape.
- All content-carrying attributes (input/output messages, system instructions, tool call arguments and results) now answer to a single predicate, `capturesContent()`, which is the one place to audit what gates sensitive data. It also checks `span.isRecording()`, so non-recording spans no longer pay for serialization that gets thrown away.
- The parts shape is defined once (`spanPart`) and shared between the message serializer and the instructions attribute.
- The hosted-agent example README documents the opt-in, including that the Python hosting SDK defaults content capture **on** while this host stays off, and that `environment_variables` should be verified after deployment.

## Testing

- Two regression tests written first and measured failing against the previous code (attribute leaked when capture is off; bare-string shape when on), passing after the fix, and failing again with the fix temporarily reverted.
- `pnpm check` passes.

Verified on a live Foundry deployment: all spans of an instrumented turn are free of `gen_ai.system_instructions` with capture off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)