### PR TITLE
Instrument outbound fetch calls in the hosted telemetry pipeline

### DIFF
--- a/examples/02-foundry/02-hosted-agent/README.md
+++ b/examples/02-foundry/02-hosted-agent/README.md
@@ -163,8 +163,9 @@ and never forwarded anywhere) and `x-request-id` (echoed back).
 
 Nothing to wire up: `serve` configures OpenTelemetry at startup, the way the reference hosts do.
 A Foundry deployment injects `APPLICATIONINSIGHTS_CONNECTION_STRING`, so traces (`invoke_agent` /
-`chat` / `execute_tool` spans with GenAI attributes) and token-usage metrics appear in the
-project's observability page / Application Insights without any code — the startup log prints
+`chat` / `execute_tool` spans with GenAI attributes, plus HTTP client spans for the outbound
+`fetch` calls — the model and storage requests) and token-usage metrics appear in the project's
+observability page / Application Insights without any code — the startup log prints
 `exporting telemetry via: azure-monitor` when the wiring is live.
 
 Locally, point OTLP at any collector (an Aspire dashboard, Jaeger):

--- a/packages/agentserver/package.json
+++ b/packages/agentserver/package.json
@@ -61,6 +61,7 @@
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.221.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
+    "@opentelemetry/instrumentation-undici": "^0.18.0",
     "@opentelemetry/resources": "^2.10.0",
     "@opentelemetry/sdk-metrics": "^2.10.0",
     "@opentelemetry/sdk-trace-base": "^2.10.0",

--- a/packages/agentserver/src/observability.test.ts
+++ b/packages/agentserver/src/observability.test.ts
@@ -1,4 +1,4 @@
-import { context as contextApi, metrics, propagation, trace } from '@opentelemetry/api';
+import { context as contextApi, metrics, propagation, SpanKind, trace } from '@opentelemetry/api';
 import type * as SdkMetrics from '@opentelemetry/sdk-metrics';
 import {
   BasicTracerProvider,
@@ -240,6 +240,65 @@ describe('setupHostObservability', () => {
     await expect(serve(server, { port: 0, host: '127.0.0.1', handleSignals: false })).rejects.toThrow(
       /Unsupported OTLP protocol/,
     );
+  });
+
+  it('records outbound fetch calls as HTTP client spans', async () => {
+    const httpSpans = new InMemorySpanExporter();
+    const { setupHostObservability } = await freshSetup();
+    const handle = await setupHostObservability({ spanProcessors: [new SimpleSpanProcessor(httpSpans)] });
+
+    // The `finally` unsubscribes the undici channels even when an assertion throws, so later
+    // tests always see an uninstrumented process.
+    try {
+      const { createServer } = await import('node:http');
+      const server = createServer((_req, res) => res.end('ok'));
+      await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+      const { port } = server.address() as { port: number };
+      try {
+        await (await fetch(`http://127.0.0.1:${port}/via-fetch`)).text();
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+
+      const clients = httpSpans.getFinishedSpans().filter((span) => span.kind === SpanKind.CLIENT);
+      expect(clients.length).toBeGreaterThanOrEqual(1);
+      expect(String(clients[0]?.attributes['url.full'])).toContain('/via-fetch');
+      // The local listener served the call, but no server span exists for it: the platform's
+      // gateway already records one per turn, and the listener would emit one per readiness probe.
+      expect(httpSpans.getFinishedSpans().filter((span) => span.kind === SpanKind.SERVER)).toEqual([]);
+    } finally {
+      await handle.shutdown();
+    }
+  });
+
+  it('disables the fetch instrumentation when another SDK owns the global tracer provider', async () => {
+    // The setup warns that a lost global registration leaves this pipeline inert. The undici
+    // subscription is bound to this pipeline's provider directly, so without an explicit disable
+    // it would keep exporting HTTP client spans the warning just declared impossible — and
+    // duplicate the embedder's own, if their SDK instruments fetch too.
+    const embedders = new NodeTracerProvider();
+    embedders.register();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const ourSpans = new InMemorySpanExporter();
+    const { setupHostObservability } = await freshSetup();
+    const handle = await setupHostObservability({ spanProcessors: [new SimpleSpanProcessor(ourSpans)] });
+    try {
+      const { createServer } = await import('node:http');
+      const server = createServer((_req, res) => res.end('ok'));
+      await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+      const { port } = server.address() as { port: number };
+      try {
+        await (await fetch(`http://127.0.0.1:${port}/inert`)).text();
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+
+      expect(ourSpans.getFinishedSpans()).toEqual([]);
+    } finally {
+      await handle.shutdown();
+      await embedders.shutdown();
+    }
   });
 
   it('is idempotent', async () => {

--- a/packages/agentserver/src/observability.test.ts
+++ b/packages/agentserver/src/observability.test.ts
@@ -261,8 +261,10 @@ describe('setupHostObservability', () => {
       }
 
       const clients = httpSpans.getFinishedSpans().filter((span) => span.kind === SpanKind.CLIENT);
-      expect(clients.length).toBeGreaterThanOrEqual(1);
-      expect(String(clients[0]?.attributes['url.full'])).toContain('/via-fetch');
+      // Located by URL rather than position: finished-span order is not guaranteed, and other
+      // client spans may exist alongside the one this test issued.
+      const fetchSpan = clients.find((span) => String(span.attributes['url.full']).includes('/via-fetch'));
+      expect(fetchSpan).toBeDefined();
       // The local listener served the call, but no server span exists for it: the platform's
       // gateway already records one per turn, and the listener would emit one per readiness probe.
       expect(httpSpans.getFinishedSpans().filter((span) => span.kind === SpanKind.SERVER)).toEqual([]);

--- a/packages/agentserver/src/observability/setup.ts
+++ b/packages/agentserver/src/observability/setup.ts
@@ -22,6 +22,7 @@ import type { TracerProvider } from '@opentelemetry/api';
 import { metrics, trace } from '@opentelemetry/api';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
 import { defaultResource, resourceFromAttributes } from '@opentelemetry/resources';
 import type { PushMetricExporter } from '@opentelemetry/sdk-metrics';
 import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
@@ -300,6 +301,30 @@ async function configureHostObservability(options: HostObservabilityOptions): Pr
     });
   }
 
+  // Outbound HTTP visibility, matching what the reference hosts inherit from their OTel distros:
+  // the model and storage calls appear as client spans nested under the framework's spans.
+  //
+  // Undici only, deliberately. Its instrumentation rides `diagnostics_channel`, so it works in
+  // the ESM bundle a hosted container actually runs. `@opentelemetry/instrumentation-http` would
+  // not: it patches the `node:http` module through the CommonJS require path, which an ESM import
+  // never crosses, leaving classic-stack clients (for example the managed-identity token calls)
+  // uninstrumented either way. Server-side request spans are also out: the platform's gateway
+  // already records one per turn, and the listener would emit one for every readiness probe.
+  //
+  // Wired through the instance API — not `registerInstrumentations`, which would drag in a
+  // second copy of the instrumentation base package (undici pins its own) plus the
+  // module-patching machinery a channel-based instrumentation never touches. Constructed with
+  // the default config on purpose: the class gates span creation on `getConfig().enabled` at
+  // event time, so `{ enabled: false }` + `enable()` subscribes but then discards every request
+  // (measured). The constructor subscribes immediately; the provider attaches on the next line,
+  // before anything can fetch.
+  //
+  // Only the tracer is bound to this pipeline — and the global-registration check below revokes
+  // even that if another SDK holds the global slot. Metrics stay on the global meter API, so
+  // they land in whichever meter provider actually owns the process.
+  const undiciInstrumentation = new UndiciInstrumentation();
+  undiciInstrumentation.setTracerProvider(tracerProvider);
+
   const flush = async (): Promise<void> => {
     // Metrics too — the reference flushes only spans, but a frozen sandbox that never reaches
     // the periodic reader would otherwise lose every histogram. Bounded
@@ -326,6 +351,7 @@ async function configureHostObservability(options: HostObservabilityOptions): Pr
           active = undefined;
         }
         setTelemetryFlusher(undefined);
+        undiciInstrumentation.disable();
         return Promise.all([tracerProvider.shutdown(), meterProvider?.shutdown()]).then(() => undefined);
       })();
       return shutdownPromise;
@@ -348,8 +374,12 @@ async function configureHostObservability(options: HostObservabilityOptions): Pr
   // A telemetry problem must never take the container down, so a lost
   // registration is reported, not thrown. `undefined` means "cannot tell" and says nothing.
   if (isGlobalTracerProvider(tracerProvider) === false) {
+    // The fetch instrumentation is bound to this pipeline's provider directly, so it would keep
+    // exporting HTTP client spans the warning below declares impossible — duplicated ones, if
+    // the SDK that won the slot instruments fetch itself. Disabled, so "inert" stays true.
+    undiciInstrumentation.disable();
     warn(
-      'another OpenTelemetry SDK already registered the global tracer provider, so this pipeline will receive no spans: the Foundry enrichment processor and the exporters configured above are inert. Configure host observability before registering your own SDK.',
+      'another OpenTelemetry SDK already registered the global tracer provider, so this pipeline will receive no spans: the Foundry enrichment processor and the exporters configured above are inert, and the fetch instrumentation has been disabled. Configure host observability before registering your own SDK.',
     );
   }
   if (meterProvider !== undefined && !metrics.setGlobalMeterProvider(meterProvider)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.221.0
         version: 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici':
+        specifier: ^0.18.0
+        version: 0.18.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
       '@opentelemetry/resources':
         specifier: ^2.10.0
         version: 2.10.0(@opentelemetry/api@1.9.1)
@@ -777,6 +780,10 @@ packages:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
 
+  '@opentelemetry/api-logs@0.207.0':
+    resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.220.0':
     resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
     engines: {node: '>=8.0.0'}
@@ -827,6 +834,18 @@ packages:
 
   '@opentelemetry/exporter-trace-otlp-http@0.221.0':
     resolution: {integrity: sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-undici@0.18.0':
+    resolution: {integrity: sha512-NalxLuZV621Xq4IhQkC+OXoZjAT8Xf6vYRdTjHitOXMU+4l/peRY05V7wGr4d7huf+vjyQry0XKlyhsEr4ouNw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+
+  '@opentelemetry/instrumentation@0.207.0':
+    resolution: {integrity: sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1468,6 +1487,16 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1521,6 +1550,9 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1758,6 +1790,9 @@ packages:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
+  import-in-the-middle@2.0.6:
+    resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
+
   import-without-cache@0.4.0:
     resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
     engines: {node: ^22.18.0 || >=24.0.0}
@@ -1956,6 +1991,9 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2063,6 +2101,10 @@ packages:
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -2752,6 +2794,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@opentelemetry/api-logs@0.207.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api-logs@0.220.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -2806,6 +2852,24 @@ snapshots:
       '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/instrumentation-undici@0.18.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.207.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@opentelemetry/otlp-exporter-base@0.221.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -3272,6 +3336,12 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn-import-attributes@1.9.5(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
+
+  acorn@8.18.0: {}
+
   agent-base@7.1.4: {}
 
   ansi-regex@5.0.1: {}
@@ -3325,6 +3395,8 @@ snapshots:
       get-intrinsic: 1.3.0
 
   chai@6.2.2: {}
+
+  cjs-module-lexer@2.2.0: {}
 
   cliui@8.0.1:
     dependencies:
@@ -3577,6 +3649,13 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  import-in-the-middle@2.0.6:
+    dependencies:
+      acorn: 8.18.0
+      acorn-import-attributes: 1.9.5(acorn@8.18.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
   import-without-cache@0.4.0: {}
 
   inherits@2.0.4: {}
@@ -3738,6 +3817,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  module-details-from-path@1.0.4: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.16: {}
@@ -3823,6 +3904,13 @@ snapshots:
       unpipe: 1.0.0
 
   require-directory@2.1.1: {}
+
+  require-in-the-middle@8.0.1(supports-color@7.2.0):
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   resolve-pkg-maps@1.0.0: {}
 


### PR DESCRIPTION
## Problem

Comparing traces from a deployed agent against the Python hosted agent showed a large gap: the Python host emits HTTP client spans for the model call, the storage write and token acquisition (via its OpenTelemetry distro auto-instrumentation), while this host emitted only the framework spans. A 7-second `chat` span gave no indication of where the time went.

## Change

`setupHostObservability` now enables `@opentelemetry/instrumentation-undici`, so outbound `fetch` calls — the model requests and Foundry storage writes — appear as HTTP client spans nested under the `chat` / `invoke_agent` spans.

Scope decisions, each measured:

- **Undici only.** Its instrumentation rides `diagnostics_channel`, so it works in the self-contained ESM bundle a hosted container runs. `@opentelemetry/instrumentation-http` patches the `node:http` module through the CommonJS require path, which an ESM import never crosses — a test showed it produces no spans in this deployment shape, so classic-stack clients (e.g. managed-identity token calls) remain uninstrumented for now.
- **No incoming-request spans.** The platform gateway already records a server span per turn, and instrumenting the listener would emit one for every readiness probe.
- **Instance API, not `registerInstrumentations`.** The helper would drag in a second copy of the instrumentation base package (undici pins its own) plus module-patching machinery a channel-based instrumentation never touches. One pitfall is documented in code: the instrumentation gates span creation on `getConfig().enabled` at event time, so it must be constructed enabled.
- **Disabled when the global registration is lost.** If another SDK already owns the global tracer provider, this pipeline is inert — the instrumentation is disabled too, so it cannot keep exporting spans through exporters the winning SDK knows nothing about (or duplicate its spans).

## Testing

- Unit tests: a fetch through the pipeline yields a CLIENT span (and no SERVER span); with a foreign global provider registered first, the pipeline exports nothing. Both written first and measured failing, with a temporary revert re-confirming each.
- `pnpm check` passes.
- Live verification on a Foundry deployment: a tool-calling turn shows both model requests and the storage write as HTTP dependencies in Application Insights, with correct parent spans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)