### PR TITLE
Attribute hosted telemetry to the deployed agent for the Foundry portal

### DIFF
--- a/packages/agentserver/src/observability.test.ts
+++ b/packages/agentserver/src/observability.test.ts
@@ -210,6 +210,27 @@ describe('GenAIMainAgentSpanProcessor', () => {
     expect(finished?.attributes['microsoft.gen_ai.main_agent.name']).toBe('late-bot');
   });
 
+  it('stamps nothing from a remote parent, whose attributes are not readable', () => {
+    const { exporter, provider } = pipeline(new GenAIMainAgentSpanProcessor());
+    // The shape the propagator hands the server: a valid but remote span context, as the Foundry
+    // gateway's traceparent produces. There are no attributes to read, so nothing propagates.
+    const remoteParent = trace.wrapSpanContext({
+      traceId: '0af7651916cd43dd8448eb211c80319c',
+      spanId: 'b7ad6b7169203331',
+      traceFlags: 1,
+      isRemote: true,
+    });
+
+    provider
+      .getTracer('test')
+      .startSpan('chat model', {}, trace.setSpan(contextApi.active(), remoteParent))
+      .end();
+
+    const [finished] = exporter.getFinishedSpans();
+    expect(finished).toBeDefined();
+    expect(Object.keys(finished?.attributes ?? {})).toEqual([]);
+  });
+
   it('leaves an already-stamped span alone', () => {
     const { exporter, provider } = pipeline(new GenAIMainAgentSpanProcessor());
 

--- a/packages/agentserver/src/observability.test.ts
+++ b/packages/agentserver/src/observability.test.ts
@@ -12,6 +12,7 @@ import { platformHeaders } from './context.js';
 import { ProtocolError } from './errors.js';
 import { FOUNDRY_ATTR, FOUNDRY_BAGGAGE, FoundryEnrichmentSpanProcessor } from './observability/enrichment.js';
 import { flushTelemetry, setTelemetryFlusher } from './observability/flush.js';
+import { GenAIMainAgentSpanProcessor } from './observability/main-agent.js';
 // Type-only, and never used as a value: the setup module is re-imported per test through
 // `vi.resetModules()`, so importing it here would pin the very instance those tests replace.
 import type * as HostObservabilitySetup from './observability/setup.js';
@@ -135,6 +136,100 @@ describe('FoundryEnrichmentSpanProcessor', () => {
   });
 });
 
+describe('GenAIMainAgentSpanProcessor', () => {
+  function pipeline(...processors: import('@opentelemetry/sdk-trace-base').SpanProcessor[]): {
+    exporter: InMemorySpanExporter;
+    provider: BasicTracerProvider;
+  } {
+    const exporter = new InMemorySpanExporter();
+    const provider = new BasicTracerProvider({
+      spanProcessors: [...processors, new SimpleSpanProcessor(exporter)],
+    });
+    return { exporter, provider };
+  }
+
+  it('promotes the invoke_agent span itself, reading the enrichment-stamped identity', () => {
+    const { exporter, provider } = pipeline(
+      new FoundryEnrichmentSpanProcessor({ agentName: 'deployed-name', agentVersion: '7', agentId: 'mi-id' }),
+      new GenAIMainAgentSpanProcessor(),
+    );
+
+    provider
+      .getTracer('test')
+      .startSpan('invoke_agent bot', {
+        attributes: {
+          'gen_ai.operation.name': 'invoke_agent',
+          'gen_ai.agent.name': 'in-code-bot',
+          'gen_ai.agent.id': 'in-code-id',
+        },
+      })
+      .end();
+
+    // The main-agent processor runs after enrichment, so the platform identity wins over the
+    // in-code agent name — matching what the reference host reports.
+    const [finished] = exporter.getFinishedSpans();
+    expect(finished?.attributes['microsoft.gen_ai.main_agent.name']).toBe('deployed-name');
+    expect(finished?.attributes['microsoft.gen_ai.main_agent.id']).toBe('mi-id');
+    expect(finished?.attributes['microsoft.gen_ai.main_agent.version']).toBe('7');
+  });
+
+  it('copies the parent identity and project ids onto children as they start', () => {
+    const { exporter, provider } = pipeline(new GenAIMainAgentSpanProcessor());
+    const tracer = provider.getTracer('test');
+
+    const parent = tracer.startSpan('invoke_agent bot', {
+      attributes: {
+        'gen_ai.agent.name': 'bot',
+        'gen_ai.agent.id': 'id-1',
+        'gen_ai.conversation.id': 'conv-9',
+        'microsoft.foundry.project.id': '/subscriptions/s/rg/r/projects/p',
+      },
+    });
+    const child = tracer.startSpan('chat model', {}, trace.setSpan(contextApi.active(), parent));
+    child.end();
+    parent.end();
+
+    const finished = exporter.getFinishedSpans().find((span) => span.name === 'chat model');
+    expect(finished?.attributes['microsoft.gen_ai.main_agent.name']).toBe('bot');
+    expect(finished?.attributes['microsoft.gen_ai.main_agent.id']).toBe('id-1');
+    expect(finished?.attributes['microsoft.gen_ai.main_agent.conversation_id']).toBe('conv-9');
+    expect(finished?.attributes['microsoft.foundry.project.id']).toBe('/subscriptions/s/rg/r/projects/p');
+  });
+
+  it('retries from the parent at end when the parent was stamped after the child started', () => {
+    const { exporter, provider } = pipeline(new GenAIMainAgentSpanProcessor());
+    const tracer = provider.getTracer('test');
+
+    const parent = tracer.startSpan('invoke_agent bot');
+    const child = tracer.startSpan('chat model', {}, trace.setSpan(contextApi.active(), parent));
+    parent.setAttribute('gen_ai.agent.name', 'late-bot');
+    child.end();
+    parent.end();
+
+    const finished = exporter.getFinishedSpans().find((span) => span.name === 'chat model');
+    expect(finished?.attributes['microsoft.gen_ai.main_agent.name']).toBe('late-bot');
+  });
+
+  it('leaves an already-stamped span alone', () => {
+    const { exporter, provider } = pipeline(new GenAIMainAgentSpanProcessor());
+
+    provider
+      .getTracer('test')
+      .startSpan('invoke_agent bot', {
+        attributes: {
+          'gen_ai.operation.name': 'invoke_agent',
+          'gen_ai.agent.name': 'own-name',
+          'microsoft.gen_ai.main_agent.name': 'preset',
+        },
+      })
+      .end();
+
+    const [finished] = exporter.getFinishedSpans();
+    expect(finished?.attributes['microsoft.gen_ai.main_agent.name']).toBe('preset');
+    expect(finished?.attributes['microsoft.gen_ai.main_agent.id']).toBeUndefined();
+  });
+});
+
 describe('setupHostObservability', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -164,6 +259,40 @@ describe('setupHostObservability', () => {
     expect(span.isRecording()).toBe(true);
     span.end();
     await handle.flush();
+  });
+
+  it('stamps the Foundry resource attributes and the main-agent identity through the pipeline', async () => {
+    vi.stubEnv('FOUNDRY_AGENT_NAME', 'probe-agent');
+    vi.stubEnv('FOUNDRY_AGENT_VERSION', '42');
+    vi.stubEnv('FOUNDRY_PROJECT_ENDPOINT', 'https://res.services.ai.azure.com/api/projects/p');
+    vi.stubEnv('FOUNDRY_PROJECT_ARM_ID', '/subscriptions/s/rg/r/projects/p');
+    const spans = new InMemorySpanExporter();
+    const { setupHostObservability } = await freshSetup();
+    const handle = await setupHostObservability({ spanProcessors: [new SimpleSpanProcessor(spans)] });
+    try {
+      trace
+        .getTracer('probe')
+        .startSpan('invoke_agent bot', { attributes: { 'gen_ai.operation.name': 'invoke_agent' } })
+        .end();
+
+      const [finished] = spans.getFinishedSpans();
+      // The .NET host's resource-detector attributes, alongside the service identity.
+      expect(finished?.resource.attributes['service.name']).toBe('probe-agent');
+      expect(finished?.resource.attributes['foundry.agent.name']).toBe('probe-agent');
+      expect(finished?.resource.attributes['foundry.agent.version']).toBe('42');
+      expect(finished?.resource.attributes['foundry.project.endpoint']).toBe(
+        'https://res.services.ai.azure.com/api/projects/p',
+      );
+      expect(finished?.resource.attributes['foundry.project.arm_id']).toBe(
+        '/subscriptions/s/rg/r/projects/p',
+      );
+      // Enrichment stamps the deployed identity at end, and the main-agent processor — running
+      // after it — promotes exactly that identity on the invoke_agent span.
+      expect(finished?.attributes['microsoft.gen_ai.main_agent.name']).toBe('probe-agent');
+      expect(finished?.attributes['microsoft.gen_ai.main_agent.version']).toBe('42');
+    } finally {
+      await handle.shutdown();
+    }
   });
 
   it('turns on Azure Monitor export when the platform injects a connection string', async () => {

--- a/packages/agentserver/src/observability.ts
+++ b/packages/agentserver/src/observability.ts
@@ -9,6 +9,7 @@
 export type { FoundryIdentity } from './observability/enrichment.js';
 export { FOUNDRY_ATTR, FOUNDRY_BAGGAGE, FoundryEnrichmentSpanProcessor } from './observability/enrichment.js';
 export { flushTelemetry, setTelemetryFlusher } from './observability/flush.js';
+export { GenAIMainAgentSpanProcessor } from './observability/main-agent.js';
 export type { HostExporter, HostObservability, HostObservabilityOptions } from './observability/setup.js';
 export { activeHostObservability, setupHostObservability } from './observability/setup.js';
 export { extractTraceContext } from './observability/trace-context.js';

--- a/packages/agentserver/src/observability/main-agent.ts
+++ b/packages/agentserver/src/observability/main-agent.ts
@@ -1,0 +1,134 @@
+/**
+ * The main-agent stamp: `microsoft.gen_ai.main_agent.*` propagated onto every span in a trace, so
+ * downstream telemetry is attributed to the top-level (user-facing) agent rather than an internal
+ * sub-agent. A port of the Microsoft OpenTelemetry distro's `GenAIMainAgentSpanProcessor`, which
+ * the Python and .NET hosts inherit from that distro.
+ *
+ * These four keys are also the only `microsoft.*`-prefixed span attributes the Azure Monitor JS
+ * exporter forwards — the rest of the prefix is dropped at export time — so they are what the
+ * Foundry portal can actually read from a Node host.
+ */
+
+import type { Span as ApiSpan, AttributeValue, Context } from '@opentelemetry/api';
+import { trace } from '@opentelemetry/api';
+import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { FOUNDRY_ATTR } from './enrichment.js';
+
+const MAIN_AGENT_PREFIX = 'microsoft.gen_ai.main_agent.';
+
+/**
+ * Each row: the main-agent attribute to write, and the plain agent attribute it falls back to
+ * when the parent (or, for self-promotion, the span itself) has not been stamped yet.
+ */
+const PROPAGATION: readonly (readonly [target: string, fallback: string])[] = [
+  [`${MAIN_AGENT_PREFIX}name`, FOUNDRY_ATTR.agentName],
+  [`${MAIN_AGENT_PREFIX}id`, FOUNDRY_ATTR.agentId],
+  [`${MAIN_AGENT_PREFIX}version`, FOUNDRY_ATTR.agentVersion],
+  [`${MAIN_AGENT_PREFIX}conversation_id`, FOUNDRY_ATTR.conversationId],
+];
+
+/** Project-scope keys, carried down so every span of a trace names the same project. */
+const PROJECT_ID_KEYS: readonly string[] = ['gen_ai.azure_ai_project.id', FOUNDRY_ATTR.projectId];
+
+/**
+ * Reads a span's attributes when the implementation exposes them.
+ *
+ * The API's `Span` deliberately has no attribute accessor; the SDK's does. A remote parent — a
+ * bare `SpanContext` wrapped by the propagator — yields nothing, and then no propagation happens,
+ * exactly as in the reference processor.
+ */
+function attributesOf(span: ApiSpan): Record<string, unknown> {
+  const attributes = (span as { attributes?: unknown }).attributes;
+  return typeof attributes === 'object' && attributes !== null ? (attributes as Record<string, unknown>) : {};
+}
+
+export class GenAIMainAgentSpanProcessor implements SpanProcessor {
+  /**
+   * span id → parent span, so {@link onEnd} can retry the copy for children whose parent
+   * attributes were not yet written when the child started. Entries leave when the span ends.
+   */
+  readonly #parents = new Map<string, ApiSpan>();
+
+  onStart(span: Span, parentContext: Context): void {
+    const parent = trace.getSpan(parentContext);
+    if (parent === undefined || !trace.isSpanContextValid(parent.spanContext())) {
+      return;
+    }
+    this.#parents.set(span.spanContext().spanId, parent);
+
+    const parentAttributes = attributesOf(parent);
+    for (const [target, fallback] of PROPAGATION) {
+      const value = parentAttributes[target] ?? parentAttributes[fallback];
+      if (value !== undefined) {
+        span.setAttribute(target, value as AttributeValue);
+      }
+    }
+    for (const key of PROJECT_ID_KEYS) {
+      const value = parentAttributes[key];
+      if (value !== undefined) {
+        span.setAttribute(key, value as AttributeValue);
+      }
+    }
+  }
+
+  onEnd(span: ReadableSpan): void {
+    const spanId = span.spanContext().spanId;
+    const parent = this.#parents.get(spanId);
+    this.#parents.delete(spanId);
+
+    const attributes = span.attributes as Record<string, unknown>;
+    const parentAttributes = parent === undefined ? {} : attributesOf(parent);
+    const updates: Record<string, unknown> = {};
+
+    if (!Object.keys(attributes).some((key) => key.startsWith(MAIN_AGENT_PREFIX))) {
+      // Self-promotion: the top-level invoke_agent span names itself the main agent. Running
+      // after the Foundry enrichment processor, the values it copies are the platform's deployed
+      // identity, not whatever the in-process framework called the agent.
+      if (attributes['gen_ai.operation.name'] === 'invoke_agent') {
+        for (const [target, source] of PROPAGATION) {
+          const value = attributes[source];
+          if (value !== undefined) {
+            updates[target] = value;
+          }
+        }
+      }
+      // Parent fallback, winning over self-promotion as in the reference: covers children whose
+      // parent was stamped only after the child had already started.
+      if (parent !== undefined) {
+        for (const [target, fallback] of PROPAGATION) {
+          const value = parentAttributes[target] ?? parentAttributes[fallback];
+          if (value !== undefined) {
+            updates[target] = value;
+          }
+        }
+      }
+    }
+
+    if (parent !== undefined) {
+      for (const key of PROJECT_ID_KEYS) {
+        if (attributes[key] === undefined && parentAttributes[key] !== undefined) {
+          updates[key] = parentAttributes[key];
+        }
+      }
+    }
+
+    // The SDK refuses setAttribute on an ended span, so this writes the attribute record
+    // directly — the same workaround the enrichment processor uses.
+    try {
+      for (const [key, value] of Object.entries(updates)) {
+        attributes[key] = value;
+      }
+    } catch {
+      // A frozen attribute record loses the main-agent stamp on this span, nothing more.
+    }
+  }
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  shutdown(): Promise<void> {
+    this.#parents.clear();
+    return Promise.resolve();
+  }
+}

--- a/packages/agentserver/src/observability/main-agent.ts
+++ b/packages/agentserver/src/observability/main-agent.ts
@@ -42,9 +42,18 @@ function attributesOf(span: ApiSpan): Record<string, unknown> {
   return typeof attributes === 'object' && attributes !== null ? (attributes as Record<string, unknown>) : {};
 }
 
+/**
+ * The map key for one span. Span ids are unique only within a trace, so the trace id has to be
+ * part of the key — two concurrent traces may legally carry the same span id.
+ */
+function spanKey(span: { spanContext(): { traceId: string; spanId: string } }): string {
+  const { traceId, spanId } = span.spanContext();
+  return `${traceId}-${spanId}`;
+}
+
 export class GenAIMainAgentSpanProcessor implements SpanProcessor {
   /**
-   * span id → parent span, so {@link onEnd} can retry the copy for children whose parent
+   * trace+span id → parent span, so {@link onEnd} can retry the copy for children whose parent
    * attributes were not yet written when the child started. Entries leave when the span ends.
    */
   readonly #parents = new Map<string, ApiSpan>();
@@ -54,7 +63,7 @@ export class GenAIMainAgentSpanProcessor implements SpanProcessor {
     if (parent === undefined || !trace.isSpanContextValid(parent.spanContext())) {
       return;
     }
-    this.#parents.set(span.spanContext().spanId, parent);
+    this.#parents.set(spanKey(span), parent);
 
     const parentAttributes = attributesOf(parent);
     for (const [target, fallback] of PROPAGATION) {
@@ -72,9 +81,9 @@ export class GenAIMainAgentSpanProcessor implements SpanProcessor {
   }
 
   onEnd(span: ReadableSpan): void {
-    const spanId = span.spanContext().spanId;
-    const parent = this.#parents.get(spanId);
-    this.#parents.delete(spanId);
+    const key = spanKey(span);
+    const parent = this.#parents.get(key);
+    this.#parents.delete(key);
 
     const attributes = span.attributes as Record<string, unknown>;
     const parentAttributes = parent === undefined ? {} : attributesOf(parent);

--- a/packages/agentserver/src/observability/setup.ts
+++ b/packages/agentserver/src/observability/setup.ts
@@ -40,11 +40,13 @@ import {
   isOtlpEnabled,
   otlpProtocol,
   projectArmId,
+  projectEndpoint,
   resolveAgentId,
 } from '../config.js';
 import { raceTimeout } from '../wait.js';
 import { FoundryEnrichmentSpanProcessor } from './enrichment.js';
 import { setTelemetryFlusher } from './flush.js';
+import { GenAIMainAgentSpanProcessor } from './main-agent.js';
 
 /** `service.name` when the container contract did not name the agent (the reference's value). */
 const DEFAULT_SERVICE_NAME = 'azure.ai.agentserver';
@@ -222,11 +224,20 @@ async function configureHostObservability(options: HostObservabilityOptions): Pr
 
   const name = agentName();
   const version = agentVersion();
-  // `service.name` is what App Insights shows as the cloud role name.
+  const endpoint = projectEndpoint();
+  const armId = projectArmId();
+  // `service.name` is what App Insights shows as the cloud role name. The `foundry.*` entries are
+  // the .NET host's resource-detector attributes: unlike `microsoft.*` span attributes they
+  // survive every exporter, so a backend that keys on resources can attribute this process to its
+  // Foundry project and agent.
   const resource = defaultResource().merge(
     resourceFromAttributes({
       'service.name': name ?? DEFAULT_SERVICE_NAME,
       ...(version === undefined ? {} : { 'service.version': version }),
+      ...(name === undefined ? {} : { 'foundry.agent.name': name }),
+      ...(version === undefined ? {} : { 'foundry.agent.version': version }),
+      ...(endpoint === undefined ? {} : { 'foundry.project.endpoint': endpoint }),
+      ...(armId === undefined ? {} : { 'foundry.project.arm_id': armId }),
     }),
   );
 
@@ -234,12 +245,18 @@ async function configureHostObservability(options: HostObservabilityOptions): Pr
     agentName: name,
     agentVersion: version,
     agentId: resolveAgentId(),
-    projectId: projectArmId(),
+    projectId: armId,
     blueprintId: blueprintClientId(),
     tenantId: agentTenantId(),
   });
 
-  const spanProcessors: SpanProcessor[] = [enrichment, ...(options.spanProcessors ?? [])];
+  // Order matters: the main-agent processor runs after enrichment, so an invoke_agent span
+  // promoting itself reads the platform identity the enrichment just stamped.
+  const spanProcessors: SpanProcessor[] = [
+    enrichment,
+    new GenAIMainAgentSpanProcessor(),
+    ...(options.spanProcessors ?? []),
+  ];
   const metricExporters: PushMetricExporter[] = [];
   const exporters: HostExporter[] = [];
 


### PR DESCRIPTION
## Problem

Telemetry from a hosted container was hard for the platform to attribute. The Azure Monitor JS exporter forwards only four `microsoft.*`-prefixed span attributes — `microsoft.gen_ai.main_agent.{name,id,version,conversation_id}` — and drops the rest of the prefix at export time, so the Foundry identity the enrichment processor stamps (`microsoft.foundry.project.id`, tenant, blueprint) never reaches Application Insights from a Node host. The Python and .NET hosts additionally stamp the main-agent attributes through their OpenTelemetry distro, and .NET publishes `foundry.*` resource attributes; this host did neither.

## Change

Two additions to the hosted observability setup, both ports of what the reference hosts inherit:

**Main-agent span processor** (the Microsoft OpenTelemetry distro semantics, matched branch for branch):
- On start, a child span receives `microsoft.gen_ai.main_agent.*` — falling back to the parent's plain `gen_ai.agent.*` / `gen_ai.conversation.id` — and the project-id attributes from its parent.
- On end, an unstamped `invoke_agent` span promotes its own agent identity, and a parent that was stamped only after the child started is retried.
- It runs **after** the Foundry enrichment processor, so the promoted identity is the platform deployment (`FOUNDRY_AGENT_NAME`), not the in-process agent name — child spans keep the in-process values they copied at start, which is the reference behaviour observed from the Python host.
- A remote parent (the gateway''s propagated context) has no readable attributes and propagates nothing, as in the reference.

**Foundry resource attributes**: `foundry.agent.name`, `foundry.agent.version`, `foundry.project.endpoint`, `foundry.project.arm_id` — the .NET host''s resource-detector keys. Unlike `microsoft.*` span attributes, resource attributes survive every exporter, so backends that key on resources can attribute the process to its project.

## Testing

- Unit tests for the processor: enrichment-then-promotion ordering, parent-to-child copy at start, late-parent retry at end, and no overwrite of an already-stamped span. An integration test drives the full `setupHostObservability` pipeline and asserts both the resource attributes and the promoted identity; reverting the wiring makes it fail (measured).
- `pnpm check` passes.
- Live verification on a Foundry deployment: the `invoke_agent` span reports `main_agent.name = <deployed name>` / `version = <deployed version>`, child spans (chat, tool, HTTP client) inherit the attribution, and the resource record in Application Insights carries all four `foundry.*` attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)