### PR TITLE
Mint platform ids for input items that arrive without one

### DIFF
--- a/packages/agentserver/src/ids.ts
+++ b/packages/agentserver/src/ids.ts
@@ -38,6 +38,76 @@ export const ID_PREFIX = {
   oauthConsentRequest: 'oacr',
 } as const;
 
+/**
+ * The prefix an item of each wire `type` mints its id under.
+ *
+ * The full per-type dispatch of the reference's id factories (Python `IdGenerator.new_item_id`),
+ * entry for entry — a type missing here is silently left out of persistence, so partial coverage
+ * would punch holes in the stored transcript. A type absent from the reference dispatch has no
+ * known prefix, and no valid platform id can be minted for it.
+ *
+ * One deliberate divergence: the reference dispatch mints `oauth` for `oauth_consent_request`,
+ * but its own hosting layer (and this package's `OutputBuilder`) mint `oacr` for the same item
+ * type; `oacr` is kept so an item's id prefix does not depend on which layer minted it.
+ */
+const ITEM_ID_PREFIX: Record<string, string> = {
+  message: ID_PREFIX.message,
+  output_message: 'om',
+  function_call: ID_PREFIX.functionCall,
+  function_call_output: ID_PREFIX.functionCallOutput,
+  custom_tool_call: ID_PREFIX.customToolCall,
+  custom_tool_call_output: ID_PREFIX.customToolCallOutput,
+  computer_call: ID_PREFIX.computerCall,
+  computer_call_output: 'cuo',
+  file_search_call: ID_PREFIX.fileSearchCall,
+  web_search_call: ID_PREFIX.webSearchCall,
+  image_generation_call: ID_PREFIX.imageGenerationCall,
+  code_interpreter_call: ID_PREFIX.codeInterpreterCall,
+  local_shell_call: 'lsh',
+  local_shell_call_output: 'lsho',
+  shell_call: 'lsh',
+  shell_call_output: 'lsho',
+  apply_patch_call: 'ap',
+  apply_patch_call_output: 'apo',
+  mcp_list_tools: ID_PREFIX.mcpListTools,
+  mcp_call: ID_PREFIX.mcpCall,
+  mcp_approval_request: ID_PREFIX.mcpApprovalRequest,
+  mcp_approval_response: 'mcpa',
+  reasoning: ID_PREFIX.reasoning,
+  compaction: 'cmp',
+  compaction_summary: 'cmp',
+  structured_outputs: ID_PREFIX.functionCallOutput,
+  tool_search_call: 'ts',
+  tool_search_output: 'tso',
+  additional_tools: 'adt',
+  oauth_consent_request: ID_PREFIX.oauthConsentRequest,
+  memory_search_call: 'mem',
+  workflow_action: 'wfa',
+  a2a_preview_call: 'a2a',
+  a2a_preview_call_output: 'a2ao',
+  bing_grounding_call: 'bg',
+  bing_grounding_call_output: 'bgo',
+  sharepoint_grounding_preview_call: 'sp',
+  sharepoint_grounding_preview_call_output: 'spo',
+  azure_ai_search_call: 'ais',
+  azure_ai_search_call_output: 'aiso',
+  bing_custom_search_preview_call: 'bcs',
+  bing_custom_search_preview_call_output: 'bcso',
+  openapi_call: 'oa',
+  openapi_call_output: 'oao',
+  browser_automation_preview_call: 'ba',
+  browser_automation_preview_call_output: 'bao',
+  fabric_dataagent_preview_call: 'fda',
+  fabric_dataagent_preview_call_output: 'fdao',
+  azure_function_call: 'azf',
+  azure_function_call_output: 'azfo',
+};
+
+/** The id prefix for an item wire `type`, or `undefined` when the type has none. */
+export function itemIdPrefix(type: string): string | undefined {
+  return ITEM_ID_PREFIX[type];
+}
+
 function randomBytes(length: number): Uint8Array {
   const bytes = new Uint8Array(length);
   crypto.getRandomValues(bytes);

--- a/packages/agentserver/src/ids.ts
+++ b/packages/agentserver/src/ids.ts
@@ -105,7 +105,9 @@ const ITEM_ID_PREFIX: Record<string, string> = {
 
 /** The id prefix for an item wire `type`, or `undefined` when the type has none. */
 export function itemIdPrefix(type: string): string | undefined {
-  return ITEM_ID_PREFIX[type];
+  // Own-entry lookup only: `type` is caller-supplied, and a name like `__proto__` or
+  // `constructor` would otherwise resolve to an inherited value and mint a garbage prefix.
+  return Object.hasOwn(ITEM_ID_PREFIX, type) ? ITEM_ID_PREFIX[type] : undefined;
 }
 
 function randomBytes(length: number): Uint8Array {

--- a/packages/agentserver/src/server.test.ts
+++ b/packages/agentserver/src/server.test.ts
@@ -243,6 +243,30 @@ describe('routes', () => {
     ]);
   });
 
+  it('treats a prototype-inherited type name as unknown, not as a prefix', async () => {
+    // `__proto__` and `constructor` resolve to inherited values on a plain-object prefix table;
+    // minting from one would produce an id like `[object Object]_…`. Such a type has no own
+    // entry, so the item is handled exactly like any other unknown type: left out of persistence.
+    const server = makeServer();
+    const created = (await (
+      await server.handle(
+        post({
+          input: [
+            { type: '__proto__' },
+            { type: 'constructor' },
+            { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
+          ],
+        }),
+      )
+    ).json()) as ResponseObject;
+
+    const items = await server.handle(
+      new Request(`http://localhost:8088/responses/${created.id}/input_items`),
+    );
+    const list = (await items.json()) as { data: Array<{ type: string }> };
+    expect(list.data.map((item) => item.type)).toEqual(['message']);
+  });
+
   it('leaves an id-less input item of unknown type out of persistence', async () => {
     // No known prefix means no valid platform id can be minted for it, and sending it id-less
     // fails the whole persist. Python's `to_output_item` drops unrecognized types the same way.

--- a/packages/agentserver/src/server.test.ts
+++ b/packages/agentserver/src/server.test.ts
@@ -2,6 +2,7 @@ import { getEventListeners } from 'node:events';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { HEADERS } from './context.js';
 import { ProtocolError } from './errors.js';
+import { partitionKeyOf } from './ids.js';
 import type { HandlerContext, ResponseHandler } from './server.js';
 import { ResponsesServer } from './server.js';
 import { encodeEvent } from './sse.js';
@@ -178,6 +179,91 @@ describe('routes', () => {
 
     const gone = await server.handle(new Request(`http://localhost:8088/responses/${created.id}`));
     expect(gone.status).toBe(404);
+  });
+
+  it('mints platform ids for input items that arrive without one', async () => {
+    // Callers — the Foundry Playground among them — send `input` as an item array with no ids,
+    // and the Foundry storage service refuses an id-less item with an opaque 500, which turned
+    // every such turn's persist into a `storage_error` terminal. Python's hosting assigns ids at
+    // conversion (`to_output_item`); the same normalization happens here.
+    const server = makeServer();
+    const created = (await (
+      await server.handle(
+        post({
+          input: [
+            { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
+            { type: 'function_call_output', call_id: 'call_1', output: '"ok"' },
+          ],
+        }),
+      )
+    ).json()) as ResponseObject;
+
+    const items = await server.handle(
+      new Request(`http://localhost:8088/responses/${created.id}/input_items?order=asc`),
+    );
+    const list = (await items.json()) as { data: Array<{ type: string; id?: string }> };
+
+    expect(list.data.map((item) => item.type)).toEqual(['message', 'function_call_output']);
+    expect(list.data[0]?.id).toMatch(/^msg_/);
+    expect(list.data[1]?.id).toMatch(/^fco_/);
+    // Minted ids co-locate with the response, like every other id the turn mints.
+    expect(partitionKeyOf(list.data[0]?.id)).toBe(partitionKeyOf(created.id));
+  });
+
+  it('mints ids across the reference id-generator dispatch, not just the common types', async () => {
+    // The prefix table has to cover everything Python's `IdGenerator.new_item_id` covers: a type
+    // missing from it is silently left out of persistence, and the next turn replays a
+    // conversation with a hole in it.
+    const server = makeServer();
+    const created = (await (
+      await server.handle(
+        post({
+          input: [
+            { type: 'output_message', role: 'assistant', content: [] },
+            { type: 'computer_call_output', call_id: 'call_1', output: { type: 'screenshot' } },
+            { type: 'shell_call', action: { commands: [] } },
+            { type: 'apply_patch_call', operation: {} },
+            { type: 'mcp_approval_response', approval_request_id: 'mcpr_x', approve: true },
+          ],
+        }),
+      )
+    ).json()) as ResponseObject;
+
+    const items = await server.handle(
+      new Request(`http://localhost:8088/responses/${created.id}/input_items?order=asc`),
+    );
+    const list = (await items.json()) as { data: Array<{ type: string; id?: string }> };
+
+    expect(list.data.map((item) => `${item.type}:${item.id?.split('_')[0]}`)).toEqual([
+      'output_message:om',
+      'computer_call_output:cuo',
+      'shell_call:lsh',
+      'apply_patch_call:ap',
+      'mcp_approval_response:mcpa',
+    ]);
+  });
+
+  it('leaves an id-less input item of unknown type out of persistence', async () => {
+    // No known prefix means no valid platform id can be minted for it, and sending it id-less
+    // fails the whole persist. Python's `to_output_item` drops unrecognized types the same way.
+    // The item still reached the model as input; only the stored transcript omits it.
+    const server = makeServer();
+    const created = (await (
+      await server.handle(
+        post({
+          input: [
+            { type: 'mystery_item' },
+            { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
+          ],
+        }),
+      )
+    ).json()) as ResponseObject;
+
+    const items = await server.handle(
+      new Request(`http://localhost:8088/responses/${created.id}/input_items`),
+    );
+    const list = (await items.json()) as { data: Array<{ type: string }> };
+    expect(list.data.map((item) => item.type)).toEqual(['message']);
   });
 
   it('lists input items newest-first by default, and accepts order case-insensitively', async () => {

--- a/packages/agentserver/src/server.ts
+++ b/packages/agentserver/src/server.ts
@@ -25,7 +25,7 @@ import {
   unavailable,
   upstreamError,
 } from './errors.js';
-import { ID_PREFIX, newId, newResponseId } from './ids.js';
+import { ID_PREFIX, itemIdPrefix, newId, newResponseId } from './ids.js';
 import type { LifecycleViolation } from './lifecycle.js';
 import { applyCancelledTerminal, enforceLifecycle, ResponseTracker } from './lifecycle.js';
 import { flushTelemetry } from './observability/flush.js';
@@ -1004,7 +1004,14 @@ export class ResponsesServer {
 
       // A string `input` is shorthand for one user message. Normalizing it here is what keeps it
       // in the stored transcript: left as-is it would simply vanish, and the next turn would
-      // replay a conversation missing everything the caller actually said.
+      // replay a conversation missing everything the caller actually said. An item array is
+      // normalized too: callers — the Foundry Playground among them — send items with no ids,
+      // and a service-side store refuses an id-less item (Foundry answers an opaque 500), which
+      // would turn the whole persist into a `storage_error` terminal. An item that already
+      // carries an id keeps it — replayed history is deduplicated against the store by exactly
+      // that id — and an id-less item of a type with no known prefix stays out of persistence
+      // (Python `to_output_item` drops unrecognized types the same way): no valid id can be
+      // minted for it, and it already reached the model as input.
       const inputItems: OutputItem[] =
         typeof created.input === 'string'
           ? created.input === ''
@@ -1018,7 +1025,13 @@ export class ResponsesServer {
                 },
               ]
           : Array.isArray(created.input)
-            ? (created.input as OutputItem[])
+            ? (created.input as OutputItem[]).flatMap((item): OutputItem[] => {
+                if (typeof item.id === 'string' && item.id !== '') {
+                  return [item];
+                }
+                const prefix = itemIdPrefix(item.type);
+                return prefix === undefined ? [] : [{ ...item, id: newId(prefix, responseId) }];
+              })
             : [];
       const storedInputItems = [...history, ...inputItems];
       // The replayed history is already held by a service-side store under these very ids, so it


### PR DESCRIPTION
## What

Normalizes array-form `input` before persistence: an item that arrives without an id is minted a platform id under its type's prefix (co-located with the response's partition), an item that already carries an id keeps it, and an id-less item of an unrecognized type is left out of persistence.

## Why

The Foundry storage service refuses an id-less item with an opaque 500. Callers — the Foundry Playground among them — send `input` as an item array with no ids, and the array passthrough put those items straight into `input_items`, so **every Playground turn's terminal persist failed** and the caller saw `response.failed` with `storage_error` ("An internal error occurred while storing the response…"). A plain string `input` was unaffected because its normalization already mints an id.

The failure was captured off a real Playground turn: the persisted create carried `"input_items":[{"type":"message","role":"user","content":[…]}]` — no `id` — and a direct call with the same shape reproduces it without a conversation or streaming involved.

## How

- `ITEM_ID_PREFIX` (package-internal, `ids.ts`) mirrors the reference id generator's per-type dispatch entry for entry — 50 types, verified 1:1 against the Python implementation — so no supported type silently drops out of the stored transcript.
- One deliberate divergence, documented in code: `oauth_consent_request` mints `oacr` (what both the reference hosting layer and this package's `OutputBuilder` mint) rather than the dispatch table's `oauth`, so an item's prefix does not depend on which layer minted it.
- Existing ids are preserved rather than re-minted: replayed history items are deduplicated against a service-side store by exactly those ids.

## Testing

- Reproduction-first: new tests assert id-less `message` / `function_call_output` items get `msg_` / `fco_` ids sharing the response's partition key, a five-type sweep across the wider dispatch (`output_message`, `computer_call_output`, `shell_call`, `apply_patch_call`, `mcp_approval_response`), and that an id-less unknown type stays out of persistence. All fail against the previous code (verified by temporarily reverting the fix).
- Verified on a deployed hosted agent: an id-less array-input turn — including the Playground's exact shape (conversation + streaming) — now completes; before the fix it terminated with `storage_error`.
- Full gate (`pnpm check`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
