### PR TITLE
Relax the public API surface freeze while keeping the feature gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,5 +137,6 @@ programming model.
 - **`@polymind-inc/agent-framework-agentserver`** — Microsoft Foundry Responses container protocol
   v2.0.0 server, independent of the rest of the framework.
 
-The API surface of this release is frozen as Baseline v0.1 (2026-08-02). Known limitations are
-listed in the root [README](README.md).
+The API surface of this release was frozen as Baseline v0.1 (2026-08-02); the freeze was later
+lifted in favor of the policy described in [Stability and versioning](README.md#stability-and-versioning).
+Known limitations are listed in the root [README](README.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ The points below are the ones most often gotten wrong.
    core — it has to keep running on Deno, Bun, edge runtimes and in browsers.
 5. **API surface changes are grounded in the reference implementations; new features are gated.**
    The public API is no longer frozen, but a change to its surface must be justified by alignment
-   with the upstream implementations — name the reference behaviour it matches. Breaking changes
+   with the reference implementations — name the reference behaviour it matches. Breaking changes
    are called out in the changelog (during `0.x`, minor releases may break). New functionality —
    a new package, a new API area, workflows — is not built without an explicit request or an
    issue asking for it; quality, performance and parity work take priority.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,12 @@ The points below are the ones most often gotten wrong.
 4. **The core has exactly one runtime dependency**, `@opentelemetry/api`. Schema libraries are
    accepted through the Standard Schema interface, never depended on. No Node-specific APIs in the
    core — it has to keep running on Deno, Bun, edge runtimes and in browsers.
-5. **The public API is frozen as Baseline v0.1.** Deviating from it is a deliberate act that gets
-   discussed in an issue before it gets written.
+5. **API surface changes are grounded in the reference implementations; new features are gated.**
+   The public API is no longer frozen, but a change to its surface must be justified by alignment
+   with the upstream implementations — name the reference behaviour it matches. Breaking changes
+   are called out in the changelog (during `0.x`, minor releases may break). New functionality —
+   a new package, a new API area, workflows — is not built without an explicit request or an
+   issue asking for it; quality, performance and parity work take priority.
 6. **Fix bugs reproduction-first.** Write a test that fails against the current code, make the fix,
    then temporarily revert the fix and confirm the test fails again.
 7. **Comments are self-contained.** They explain the code to a first-time reader. No references to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,12 @@ needs to be called out in the pull request.
 on. Node-specific APIs do not belong in the core; the core has to keep running on Deno, Bun, edge
 runtimes and in browsers.
 
-**5. The public API is frozen as Baseline v0.1.** Changes to the frozen surface are possible but
-deliberate — open an issue describing the deviation and the reference behaviour that motivates it
-before writing the code.
+**5. API surface changes are grounded in the reference implementations.** The public API is not
+frozen, but a change to its surface must be motivated by alignment with the upstream
+implementations — the pull request names the reference behaviour it matches. Breaking changes are
+called out in the changelog. New functionality — a new package, a new API area, workflows — starts
+from an issue that asks for it, not from a pull request; quality, performance and parity work take
+priority over new features.
 
 ## Fixing a bug
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ on. Node-specific APIs do not belong in the core; the core has to keep running o
 runtimes and in browsers.
 
 **5. API surface changes are grounded in the reference implementations.** The public API is not
-frozen, but a change to its surface must be motivated by alignment with the upstream
+frozen, but a change to its surface must be motivated by alignment with the reference
 implementations — the pull request names the reference behaviour it matches. Breaking changes are
 called out in the changelog. New functionality — a new package, a new API area, workflows — starts
 from an issue that asks for it, not from a pull request; quality, performance and parity work take

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ environment variables each one needs.
 ## Stability and versioning
 
 The public API is stable but not frozen: surface changes are made deliberately, motivated by
-alignment with the upstream implementations. During `0.x`, **minor releases may contain breaking
+alignment with the reference implementations. During `0.x`, **minor releases may contain breaking
 changes**; patch releases are fixes only. All packages are versioned and released in
 lockstep, so a single [`CHANGELOG.md`](CHANGELOG.md) entry covers the set. Releases are published
 from CI with [npm provenance][provenance].

--- a/README.md
+++ b/README.md
@@ -219,7 +219,8 @@ environment variables each one needs.
 
 ## Stability and versioning
 
-The public API is frozen as **Baseline v0.1**. During `0.x`, **minor releases may contain breaking
+The public API is stable but not frozen: surface changes are made deliberately, motivated by
+alignment with the upstream implementations. During `0.x`, **minor releases may contain breaking
 changes**; patch releases are fixes only. All packages are versioned and released in
 lockstep, so a single [`CHANGELOG.md`](CHANGELOG.md) entry covers the set. Releases are published
 from CI with [npm provenance][provenance].


### PR DESCRIPTION
## What

Updates the stability policy in CLAUDE.md, CONTRIBUTING.md and README.md: the public API is no longer frozen as Baseline v0.1.

## The new rules

- **Surface changes go through normal pull-request review.** The requirement that stays deliberately strict: every surface change must be motivated by alignment with the upstream reference implementations (.NET, Python, Go), and the pull request names the reference behaviour it matches. Breaking changes are called out in the changelog; during `0.x`, minor releases may break.
- **New functionality remains gated.** A new package, a new API area, or workflows work starts from an issue that asks for it, not from a pull request. Quality, performance and parity work keep priority over new features.
- **Unchanged**: wire compatibility, the naming generation, the core's single-dependency budget, and the reproduction-first fix workflow.

## Why

The surface has been stable through the quality-focused releases up to 0.2.2. The freeze had been blocking internal-consistency work (sharing duplicated helpers across packages requires new internal exports) at a point where the API itself no longer needs that protection. The upstream-alignment requirement replaces the freeze as the guard against casual surface drift.

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)