### PR TITLE
Deduplicate shared logic and reduce streaming hot-path overhead

### DIFF
--- a/packages/agentserver/src/server.ts
+++ b/packages/agentserver/src/server.ts
@@ -130,6 +130,52 @@ function storageFailed(response: ResponseObject): ResponseObject {
 }
 
 /**
+ * The persist-before-terminal contract, shared by the foreground SSE stream and the background
+ * driver: the turn is offered to the store *before* its terminal event reaches any consumer, so a
+ * caller that reads `response.completed` can come back with `previous_response_id`. When the store
+ * refuses, the terminal the consumer reads is a `response.failed` carrying `storage_error`
+ * instead. Persisting is attempted at most once — .NET does not retry a failed persist, and
+ * neither does this.
+ */
+class TerminalPersister {
+  readonly #persist: () => Promise<void>;
+  readonly #tracker: ResponseTracker;
+  #attempted = false;
+
+  constructor(persist: () => Promise<void>, tracker: ResponseTracker) {
+    this.#persist = persist;
+    this.#tracker = tracker;
+  }
+
+  /** Persists ahead of the terminal `event`; on a store refusal returns the storage failure instead. */
+  async onTerminal(event: ResponseEvent): Promise<ResponseEvent> {
+    this.#attempted = true;
+    try {
+      await this.#persist();
+      return event;
+    } catch {
+      return { type: 'response.failed', response: storageFailed(this.#tracker.response) };
+    }
+  }
+
+  /**
+   * The teardown fallback for a stream torn down before any terminal event came through: records
+   * the partial turn — it is resumable with `previous_response_id`. A store failure here has no
+   * caller left to tell, so it is deliberately swallowed.
+   */
+  async ensureAttempted(): Promise<void> {
+    if (this.#attempted) {
+      return;
+    }
+    try {
+      await this.#persist();
+    } catch {
+      // Nothing to answer: the caller is gone.
+    }
+  }
+}
+
+/**
  * The cancel refusals for each terminal state, worded exactly as the reference words them
  * (Python `_endpoint_handler._CANCEL_TERMINAL_ERRORS`). `cancelled` is missing on purpose:
  * cancelling an already-cancelled response is idempotent and answers 200.
@@ -1193,7 +1239,7 @@ export class ResponsesServer {
   }): Promise<void> {
     const { run, responseId, claim, events, persist, releaseSignals } = args;
     const sequence = new SequenceNumberWriter();
-    let persistAttempted = false;
+    const persister = new TerminalPersister(persist, run.tracker);
     try {
       try {
         for await (const raw of events) {
@@ -1207,16 +1253,7 @@ export class ResponsesServer {
               // outlive its grace by any amount.
               event = cancelledTerminal(run.tracker);
             }
-            // Persist *before* the terminal event reaches any follower:
-            // a caller that reads `response.completed` — live or replayed — must be able to come
-            // back with `previous_response_id`. When the store refuses, the terminal every
-            // follower reads is a `response.failed` carrying `storage_error`.
-            persistAttempted = true;
-            try {
-              await persist();
-            } catch {
-              event = { type: 'response.failed', response: storageFailed(run.tracker.response) };
-            }
+            event = await persister.onTerminal(event);
           }
           run.deliver(sequence.stamp(event));
         }
@@ -1231,7 +1268,7 @@ export class ResponsesServer {
         const cause = error instanceof ProtocolError && error.cause !== undefined ? error.cause : error;
         const message =
           cause instanceof Error ? (cause.message === '' ? cause.name : cause.message) : String(cause);
-        let event = run.cancelRequested
+        const event = run.cancelRequested
           ? // Same override as the loop above: a handler that throws *after* the cancel route
             // answered still ends as `cancelled`, not as `failed` (the reference applies
             // `_maybe_override_to_cancelled` on the resolved terminal whatever produced it).
@@ -1239,23 +1276,11 @@ export class ResponsesServer {
           : run.tracker.lifecycleEvent('response.failed', 'failed', {
               error: { code: 'server_error', message, type: 'server_error' },
             });
-        persistAttempted = true;
-        try {
-          await persist();
-        } catch {
-          event = { type: 'response.failed', response: storageFailed(run.tracker.response) };
-        }
-        run.deliver(sequence.stamp(event));
+        run.deliver(sequence.stamp(await persister.onTerminal(event)));
       }
-      if (!persistAttempted) {
-        // Unreachable while `enforceLifecycle` guarantees a terminal event; kept so a future
-        // regression cannot silently drop a finished turn.
-        try {
-          await persist();
-        } catch {
-          // Nobody left to tell.
-        }
-      }
+      // Unreachable while `enforceLifecycle` guarantees a terminal event; kept so a future
+      // regression cannot silently drop a finished turn.
+      await persister.ensureAttempted();
       if (run.streamed && !run.overflowed) {
         await this.#storeReplayLog(responseId, run, claim);
       }
@@ -1366,26 +1391,14 @@ export class ResponsesServer {
     }
 
     const sequence = new SequenceNumberWriter();
+    const persister = new TerminalPersister(persist, tracker);
     const numbered = async function* (): AsyncGenerator<ResponseEvent> {
-      // Whether the turn has been offered to the store, successfully or not. `.NET` does not
-      // retry a failed persist, and neither does this.
-      let persistAttempted = false;
       try {
         let pending = first;
         while (pending.done !== true) {
           let event = pending.value;
           if (isTerminalEventType(String(event.type))) {
-            // Persist *before* the terminal event is delivered (.NET's streaming contract): a
-            // caller that reads `response.completed` must be able to come back with
-            // `previous_response_id`. When the store refuses, the terminal the caller reads is a
-            // `response.failed` carrying `storage_error` — not a `completed` for a turn that no
-            // longer exists anywhere.
-            persistAttempted = true;
-            try {
-              await persist();
-            } catch {
-              event = { type: 'response.failed', response: storageFailed(tracker.response) };
-            }
+            event = await persister.onTerminal(event);
           }
           yield sequence.stamp(event);
           pending = await iterator.next();
@@ -1393,20 +1406,13 @@ export class ResponsesServer {
       } finally {
         // The client-disconnect path: the stream was torn down before the terminal event came
         // through. Close the handler chain first so its own `finally` blocks run, then record the
-        // partial turn — it is resumable with `previous_response_id`. A store failure here has no
-        // caller left to tell, so it is deliberately swallowed.
+        // partial turn.
         try {
           await iterator.return?.();
         } catch {
           // The generator's own failure must not mask the teardown.
         }
-        if (!persistAttempted) {
-          try {
-            await persist();
-          } catch {
-            // Nothing to answer: the caller is gone.
-          }
-        }
+        await persister.ensureAttempted();
         releaseSignals();
         // Stream over — flush before the platform freezes the sandbox (the reference's
         // `trace_stream` flushes in its own `finally` the same way).

--- a/packages/agentserver/src/store/memory.ts
+++ b/packages/agentserver/src/store/memory.ts
@@ -58,21 +58,28 @@ export class InMemoryResponseProvider implements ResponseProvider {
     assertOwnerCanWrite(this.#responses.get(id), id, owner);
   }
 
+  /**
+   * Evicts oldest-first until `map` is under the shared cap, cascading each eviction into
+   * `alsoDrop` — the response is what makes its event stream reachable, so keeping orphaned
+   * events would let the eviction bound be dodged through the second map.
+   */
+  #evictOldest(map: Map<string, unknown>, alsoDrop?: Map<string, unknown>): void {
+    while (map.size >= this.#maxResponses) {
+      const oldest = map.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      map.delete(oldest);
+      alsoDrop?.delete(oldest);
+    }
+  }
+
   async put(stored: StoredResponse): Promise<void> {
     const id = stored.response.id;
     assertWritable(this.#responses.get(id), stored);
     // Overwriting an existing id does not grow the map, so only a genuinely new entry evicts.
     if (!this.#responses.has(id)) {
-      while (this.#responses.size >= this.#maxResponses) {
-        const oldest = this.#responses.keys().next().value;
-        if (oldest === undefined) {
-          break;
-        }
-        this.#responses.delete(oldest);
-        // The response is what makes its event stream reachable; keeping orphaned events would
-        // let the eviction bound be dodged through the second map.
-        this.#events.delete(oldest);
-      }
+      this.#evictOldest(this.#responses, this.#events);
     }
     this.#responses.set(id, stored);
   }
@@ -98,13 +105,7 @@ export class InMemoryResponseProvider implements ResponseProvider {
       throw notFound(id);
     }
     if (!this.#events.has(id)) {
-      while (this.#events.size >= this.#maxResponses) {
-        const oldest = this.#events.keys().next().value;
-        if (oldest === undefined) {
-          break;
-        }
-        this.#events.delete(oldest);
-      }
+      this.#evictOldest(this.#events);
     }
     this.#events.set(id, { owner, generation, events: [...events] });
   }

--- a/packages/core/src/client/client-errors.ts
+++ b/packages/core/src/client/client-errors.ts
@@ -7,6 +7,7 @@
  * helpers capture that contract once, for both the request phase and the streaming phase.
  */
 
+import { errorMessageOf } from '../errors.js';
 import { abortErrorFrom, isAbortError } from '../streaming/abort.js';
 
 /**
@@ -59,8 +60,7 @@ export function createClientErrorNormalizer(options: ClientErrorNormalizerOption
     if (abortErrorClass !== undefined && error instanceof abortErrorClass) {
       return abortErrorFrom(signal, error);
     }
-    const detail = error instanceof Error ? error.message : String(error);
-    return wrap(error, detail);
+    return wrap(error, errorMessageOf(error));
   };
 }
 

--- a/packages/core/src/client/function-invocation.ts
+++ b/packages/core/src/client/function-invocation.ts
@@ -1,6 +1,7 @@
 import type { AgentSession } from '../agent/session.js';
 import {
   ConfigurationError,
+  errorMessageOf,
   MiddlewareTerminated,
   ToolInvocationError,
   throwIfAborted,
@@ -219,11 +220,12 @@ function collectExecutableCalls(messages: Message[]): FunctionCallContent[] {
 
 type InvocationStatus = 'completed' | 'not_found' | 'exception';
 
-interface InvocationResult {
+/** The outcome of one tool invocation. `R` is the type `result` carries at this stage. */
+interface Invocation<R> {
   status: InvocationStatus;
   call: FunctionCallContent;
-  /** Whatever the tool — or a middleware standing in for it — produced, before normalization. */
-  result?: unknown;
+  /** Set exactly when `status` is `'completed'` and no approval was raised. */
+  result?: R;
   error?: unknown;
   /** A middleware called `terminate()`: report this round, then stop calling the model. */
   terminated?: boolean;
@@ -238,13 +240,8 @@ interface InvocationResult {
   errorReport?: ExceptionReport;
 }
 
-/** The two strings an exception `function_result` carries: what the model reads, and the marker. */
-interface ExceptionReport {
-  /** Replaces the generic `Error: Function failed.` text. */
-  result: string;
-  /** Replaces the thrown error's message in `FunctionResultContent.exception`. */
-  exception: string;
-}
+/** Whatever the tool — or a middleware standing in for it — produced, before normalization. */
+type InvocationResult = Invocation<unknown>;
 
 /**
  * An invocation whose result has been normalized to what a `function_result` can carry.
@@ -253,16 +250,14 @@ interface ExceptionReport {
  * so a return value JSON cannot encode becomes the same result any other failing tool produces
  * instead of throwing out of the loop and failing the run.
  */
-interface SettledInvocation {
-  status: InvocationStatus;
-  call: FunctionCallContent;
-  /** Set exactly when `status` is `'completed'` and no approval was raised. */
-  result?: string | Content[];
-  error?: unknown;
-  terminated?: boolean;
-  approvalRequest?: FunctionApprovalRequestContent;
-  userInputRequests?: UserInputRequestContent[];
-  errorReport?: ExceptionReport;
+type SettledInvocation = Invocation<string | Content[]>;
+
+/** The two strings an exception `function_result` carries: what the model reads, and the marker. */
+interface ExceptionReport {
+  /** Replaces the generic `Error: Function failed.` text. */
+  result: string;
+  /** Replaces the thrown error's message in `FunctionResultContent.exception`. */
+  exception: string;
 }
 
 /**
@@ -322,10 +317,6 @@ interface RoundOutcome {
   approvals: UserInputRequestContent[];
   /** `true` when a middleware ended the loop. */
   terminated?: boolean;
-}
-
-function errorMessageOf(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 export class FunctionInvocationLimitError extends ToolInvocationError {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -133,3 +133,8 @@ export class StreamConsumedError extends AgentFrameworkError {
 export function throwIfAborted(signal?: AbortSignal): void {
   signal?.throwIfAborted();
 }
+
+/** The human-readable summary of a thrown value: `error.message` for an `Error`, `String(error)` otherwise. */
+export function errorMessageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/core/src/middleware/middleware.ts
+++ b/packages/core/src/middleware/middleware.ts
@@ -1,6 +1,7 @@
 import type { AgentSession } from '../agent/session.js';
 import type { ChatClient, ChatOptions } from '../client/chat-client.js';
 import { ConfigurationError, MiddlewareTerminated } from '../errors.js';
+import { HOSTED_TOOL_CAPABILITY_METHODS } from '../tools/hosted.js';
 import type { AnyFunctionTool, Tool } from '../tools/tool.js';
 import type { Message } from '../types/message.js';
 import type { AgentResponse, AgentResponseUpdate } from '../types/response.js';
@@ -292,14 +293,6 @@ export function terminateMiddleware(): never {
   throw new MiddlewareTerminated();
 }
 
-/** The hosted-tool capability methods a wrapping client must carry over from the wrapped one. */
-const CAPABILITY_METHODS = [
-  'getWebSearchTool',
-  'getFileSearchTool',
-  'getCodeInterpreterTool',
-  'getMCPTool',
-] as const;
-
 /**
  * Attaches middleware to a {@link ChatClient}, so an agent built on it picks them up.
  *
@@ -323,7 +316,7 @@ export function withMiddleware<TOptions extends ChatOptions>(
   // has to carry the underlying client's capability methods or `supportsMCP` and friends would
   // report a capable client as incapable after wrapping.
   const capabilities: Record<string, unknown> = {};
-  for (const method of CAPABILITY_METHODS) {
+  for (const method of HOSTED_TOOL_CAPABILITY_METHODS) {
     const fn = (client as unknown as Record<string, unknown>)[method];
     if (typeof fn === 'function') {
       capabilities[method] = fn.bind(client);

--- a/packages/core/src/observability/tracing.ts
+++ b/packages/core/src/observability/tracing.ts
@@ -51,13 +51,13 @@ function spanPart(content: Content): { type: string; content?: string } {
   return content.type === 'text' ? { type: 'text', content: content.text } : { type: content.type };
 }
 
+/** One message of the sensitive-data serialization, as a JSON object string. */
+function serializeMessageForSpan(msg: Message): string {
+  return JSON.stringify({ role: msg.role, parts: msg.contents.map(spanPart) });
+}
+
 export function serializeMessagesForSpan(messages: readonly Message[]): string {
-  return JSON.stringify(
-    messages.map((msg) => ({
-      role: msg.role,
-      parts: msg.contents.map(spanPart),
-    })),
-  );
+  return `[${messages.map(serializeMessageForSpan).join(',')}]`;
 }
 
 /**
@@ -82,11 +82,14 @@ export function setMessageContent(span: Span, key: string, messages: readonly Me
   if (messages.length === 0 || !capturesContent(span)) {
     return;
   }
-  span.setAttribute(key, serializeMessagesForSpan(messages));
+  // Each message is serialized once; the aggregate attribute and the per-message events share the
+  // same strings, so a long transcript pays one serialization pass instead of two.
+  const serialized = messages.map(serializeMessageForSpan);
+  span.setAttribute(key, `[${serialized.join(',')}]`);
   const output = key === GEN_AI.outputMessages;
-  for (const msg of messages) {
-    addMessageEvent(span, msg, output);
-  }
+  messages.forEach((msg, index) => {
+    addMessageEvent(span, msg, output, serialized[index]);
+  });
 }
 
 /**
@@ -110,14 +113,14 @@ export function setSystemInstructions(span: Span, instructions: string | undefin
  * depends only on `@opentelemetry/api`. The event name and the serialized payload match, so the
  * two implementations produce the same shape.
  */
-export function addMessageEvent(span: Span, message: Message, output: boolean): void {
+export function addMessageEvent(span: Span, message: Message, output: boolean, serialized?: string): void {
   const name = output
     ? GEN_AI_MESSAGE_EVENT.choice
     : (GEN_AI_MESSAGE_EVENT[message.role as keyof typeof GEN_AI_MESSAGE_EVENT] ?? GEN_AI_MESSAGE_EVENT.user);
   span.addEvent(name, {
     [GEN_AI.eventName]: name,
     ...(message.role === undefined ? {} : { role: message.role }),
-    content: serializeMessagesForSpan([message]),
+    content: `[${serialized ?? serializeMessageForSpan(message)}]`,
   });
 }
 

--- a/packages/core/src/streaming/response-stream.ts
+++ b/packages/core/src/streaming/response-stream.ts
@@ -230,7 +230,7 @@ class HybridResponseStream<TUpdate, TFinal> implements ResponseStream<TUpdate, T
         throw this.#failure.error;
       }
       await this.#runCleanup();
-      await this.#finalize();
+      await this.#finalizeForHooks();
       return { done: true, value: undefined };
     }
 
@@ -253,6 +253,21 @@ class HybridResponseStream<TUpdate, TFinal> implements ResponseStream<TUpdate, T
       if (this.#failure !== undefined) {
         throw this.#failure.error;
       }
+      await this.#finalizeForHooks();
+    }
+  }
+
+  /**
+   * Finalizes at end of iteration only when a result hook is waiting on it.
+   *
+   * The hooks' timing is load-bearing — history persistence and telemetry teardown must observe
+   * the folded result when the source ends, not when the caller happens to ask for it. Without
+   * hooks the fold is pure and memoized, so it is deferred to {@link finalResponse}: an inner
+   * stream in a layered pipeline is drained by the layer above and its own fold is never read,
+   * which would otherwise cost a full pass over the run's updates per layer.
+   */
+  async #finalizeForHooks(): Promise<void> {
+    if (this.#init.onResult !== undefined && this.#init.onResult.length > 0) {
       await this.#finalize();
     }
   }

--- a/packages/core/src/tools/hosted.ts
+++ b/packages/core/src/tools/hosted.ts
@@ -89,7 +89,29 @@ export interface SupportsMCPTool {
   getMCPTool(options: MCPToolOptions): HostedTool;
 }
 
-function hasMethod(value: object, name: string): boolean {
+/** The method names of the duck-typed hosted-tool capability protocol defined above. */
+type CapabilityMethod = keyof (SupportsWebSearchTool &
+  SupportsFileSearchTool &
+  SupportsCodeInterpreterTool &
+  SupportsMCPTool);
+
+/**
+ * Every capability method, keyed exhaustively so the compiler flags this record when a capability
+ * interface is added to {@link CapabilityMethod} but not listed here (and vice versa). The
+ * `supports*` predicates below and `withMiddleware`'s capability carry-over both consume this
+ * list, so a capability missing from it would silently vanish when a client is wrapped.
+ */
+const CAPABILITY_METHOD_RECORD: Record<CapabilityMethod, true> = {
+  getWebSearchTool: true,
+  getFileSearchTool: true,
+  getCodeInterpreterTool: true,
+  getMCPTool: true,
+};
+
+/** The hosted-tool capability methods a wrapping client must carry over from the wrapped one. */
+export const HOSTED_TOOL_CAPABILITY_METHODS: readonly string[] = Object.keys(CAPABILITY_METHOD_RECORD);
+
+function hasMethod(value: object, name: CapabilityMethod): boolean {
   return typeof (value as Record<string, unknown>)[name] === 'function';
 }
 

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -1,5 +1,5 @@
 import type { AgentSession } from '../agent/session.js';
-import { AgentFrameworkError, ConfigurationError, ToolInvocationError } from '../errors.js';
+import { AgentFrameworkError, ConfigurationError, errorMessageOf, ToolInvocationError } from '../errors.js';
 import type { Content } from '../types/content.js';
 import type { Message } from '../types/message.js';
 import type { JsonSchema, SchemaInput } from './json-schema.js';
@@ -270,7 +270,7 @@ export function normalizeToolResult(value: unknown): string | Content[] {
     encoded = JSON.stringify(value);
   } catch (error) {
     throw new AgentFrameworkError(
-      `A tool returned a value that cannot be JSON-encoded: ${error instanceof Error ? error.message : String(error)}`,
+      `A tool returned a value that cannot be JSON-encoded: ${errorMessageOf(error)}`,
       { cause: error },
     );
   }

--- a/packages/core/src/types/response.ts
+++ b/packages/core/src/types/response.ts
@@ -188,14 +188,28 @@ function isValidCreatedAt(value: string | undefined): boolean {
   return value !== undefined && value !== '';
 }
 
-function appendRaw(current: unknown, incoming: unknown): unknown {
+function appendRaw(current: unknown, incoming: unknown, owned: WeakSet<object>): unknown {
   if (incoming === undefined || incoming === null) {
     return current;
   }
   if (current === undefined) {
     return incoming;
   }
-  return Array.isArray(current) ? [...current, incoming] : [current, incoming];
+  // Streams carry one raw event per update, so this append runs per delta. Push in place when the
+  // accumulating array was created by this fold (O(1) per update); copy a caller-supplied array
+  // once so it is never mutated.
+  if (Array.isArray(current)) {
+    if (owned.has(current)) {
+      current.push(incoming);
+      return current;
+    }
+    const copy = [...current, incoming];
+    owned.add(copy);
+    return copy;
+  }
+  const pair = [current, incoming];
+  owned.add(pair);
+  return pair;
 }
 
 interface FoldState {
@@ -210,6 +224,8 @@ interface FoldState {
   continuationToken: ContinuationToken | undefined;
   additionalProperties: Record<string, unknown> | undefined;
   rawRepresentation: unknown;
+  /** Arrays created by this fold's `appendRaw`, safe to extend in place. */
+  ownedRaw: WeakSet<object>;
 }
 
 function foldUpdate(state: FoldState, update: ChatResponseUpdate | AgentResponseUpdate): void {
@@ -249,8 +265,8 @@ function foldUpdate(state: FoldState, update: ChatResponseUpdate | AgentResponse
     state.additionalProperties = { ...state.additionalProperties, ...update.additionalProperties };
   }
   if (update.rawRepresentation !== undefined) {
-    msg.rawRepresentation = appendRaw(msg.rawRepresentation, update.rawRepresentation);
-    state.rawRepresentation = appendRaw(state.rawRepresentation, update.rawRepresentation);
+    msg.rawRepresentation = appendRaw(msg.rawRepresentation, update.rawRepresentation, state.ownedRaw);
+    state.rawRepresentation = appendRaw(state.rawRepresentation, update.rawRepresentation, state.ownedRaw);
   }
 
   state.responseId = orLater(update.responseId, state.responseId);
@@ -286,6 +302,7 @@ function fold(updates: readonly (ChatResponseUpdate | AgentResponseUpdate)[]): F
     continuationToken: undefined,
     additionalProperties: undefined,
     rawRepresentation: undefined,
+    ownedRaw: new WeakSet(),
   };
   for (const update of updates) {
     foldUpdate(state, update);
@@ -317,12 +334,7 @@ export function mergeUpdates<T = undefined>(updates: readonly AgentResponseUpdat
   const init: AgentResponseInit<T> = { messages: state.messages };
   if (state.agentId !== undefined) init.agentId = state.agentId;
   if (state.responseId !== undefined) init.responseId = state.responseId;
-  if (state.createdAt !== undefined) init.createdAt = state.createdAt;
-  if (state.finishReason !== undefined) init.finishReason = state.finishReason;
-  if (state.usageDetails !== undefined) init.usageDetails = state.usageDetails;
-  if (state.continuationToken !== undefined) init.continuationToken = state.continuationToken;
-  if (state.additionalProperties !== undefined) init.additionalProperties = state.additionalProperties;
-  if (state.rawRepresentation !== undefined) init.rawRepresentation = state.rawRepresentation;
+  setFoldMetadata(init, state);
   return agentResponse<T>(init);
 }
 
@@ -333,13 +345,21 @@ export function mergeChatUpdates<T = undefined>(updates: readonly ChatResponseUp
   if (state.responseId !== undefined) init.responseId = state.responseId;
   if (state.conversationId !== undefined) init.conversationId = state.conversationId;
   if (state.model !== undefined) init.model = state.model;
+  setFoldMetadata(init, state);
+  return chatResponse<T>(init);
+}
+
+/** Copies the folded response-level metadata common to both response flavors onto the init. */
+function setFoldMetadata(
+  init: ChatResponseInit<unknown> | AgentResponseInit<unknown>,
+  state: FoldState,
+): void {
   if (state.createdAt !== undefined) init.createdAt = state.createdAt;
   if (state.finishReason !== undefined) init.finishReason = state.finishReason;
   if (state.usageDetails !== undefined) init.usageDetails = state.usageDetails;
   if (state.continuationToken !== undefined) init.continuationToken = state.continuationToken;
   if (state.additionalProperties !== undefined) init.additionalProperties = state.additionalProperties;
   if (state.rawRepresentation !== undefined) init.rawRepresentation = state.rawRepresentation;
-  return chatResponse<T>(init);
 }
 
 /** Constructor input common to both update flavors: {@link ResponseUpdateBase} without `text`. */

--- a/packages/core/src/types/serialization.ts
+++ b/packages/core/src/types/serialization.ts
@@ -15,32 +15,40 @@ export interface SerializedMessage {
   [key: string]: unknown;
 }
 
-const KNOWN_CONTENT_TYPES: ReadonlySet<string> = new Set<ContentType>([
-  'text',
-  'text_reasoning',
-  'data',
-  'uri',
-  'error',
-  'function_call',
-  'function_result',
-  'usage',
-  'function_approval_request',
-  'function_approval_response',
-  'hosted_file',
-  'hosted_vector_store',
-  'code_interpreter_tool_call',
-  'code_interpreter_tool_result',
-  'image_generation_tool_call',
-  'image_generation_tool_result',
-  'mcp_server_tool_call',
-  'mcp_server_tool_result',
-  'search_tool_call',
-  'search_tool_result',
-  'shell_tool_call',
-  'shell_tool_result',
-  'shell_command_output',
-  'oauth_consent_request',
-]);
+/**
+ * Every wire `type` literal this version models, keyed exhaustively so the compiler rejects both a
+ * stray entry and a missing one whenever the {@link Content} union changes. A variant absent from
+ * this record would otherwise deserialize as {@link UnknownContent} — its `type` silently moved to
+ * `unknownType` — even though the build models it.
+ */
+const WIRE_CONTENT_TYPES: Record<Exclude<ContentType, 'unknown'>, true> = {
+  text: true,
+  text_reasoning: true,
+  data: true,
+  uri: true,
+  error: true,
+  function_call: true,
+  function_result: true,
+  usage: true,
+  function_approval_request: true,
+  function_approval_response: true,
+  hosted_file: true,
+  hosted_vector_store: true,
+  code_interpreter_tool_call: true,
+  code_interpreter_tool_result: true,
+  image_generation_tool_call: true,
+  image_generation_tool_result: true,
+  mcp_server_tool_call: true,
+  mcp_server_tool_result: true,
+  search_tool_call: true,
+  search_tool_result: true,
+  shell_tool_call: true,
+  shell_tool_result: true,
+  shell_command_output: true,
+  oauth_consent_request: true,
+};
+
+const KNOWN_CONTENT_TYPES: ReadonlySet<string> = new Set(Object.keys(WIRE_CONTENT_TYPES));
 
 /**
  * Content keys whose values are themselves content items or lists of content items.

--- a/packages/foundry/src/hosting/output.ts
+++ b/packages/foundry/src/hosting/output.ts
@@ -160,6 +160,14 @@ function argumentsRecord(args: Record<string, unknown> | string | undefined): Re
   return {};
 }
 
+/**
+ * The wire form of a tool call's arguments: a string — possibly a partial streamed fragment —
+ * passes through, a structured object is JSON-encoded.
+ */
+function argumentsText(args: Record<string, unknown> | string): string {
+  return typeof args === 'string' ? args : JSON.stringify(args);
+}
+
 /** The code a `code_interpreter_tool_call` ran: the concatenated text of its inputs. */
 function codeOfInputs(inputs: unknown): string {
   if (!Array.isArray(inputs)) {
@@ -255,6 +263,23 @@ export class OutputBuilder {
     this.#onUnsupportedContent = options.onUnsupportedContent;
   }
 
+  /**
+   * The open item, when a tool result of `kind` addresses it.
+   *
+   * A result's `callId` may name the provider's own call id *or* the re-minted item id — the item
+   * id is regenerated when the provider's does not satisfy this protocol's format, while the
+   * result content that follows still refers to the provider's — and a result with no `callId`
+   * matches whatever call is open.
+   */
+  #openFor(kind: ItemKind, callId: string | undefined): OpenItem | undefined {
+    const open = this.#open;
+    const matches =
+      open !== undefined &&
+      open.kind === kind &&
+      (callId === undefined || callId === open.callId || callId === open.id);
+    return matches ? open : undefined;
+  }
+
   /** Emits the events for one content item. */
   *push(content: Content): Generator<ResponseEvent> {
     if (content.type === 'mcp_server_tool_result') {
@@ -262,13 +287,9 @@ export class OutputBuilder {
       // its own — the wire item carries `arguments` and `output` together (Python folds it the
       // same way before emitting the item's `done`). A result with no matching open call is
       // surfaced as a standalone `custom_tool_call_output` instead (Python `_to_outputs`).
-      const open = this.#open;
       const callId = content.callId;
-      if (
-        open !== undefined &&
-        open.kind === 'mcp_call' &&
-        (callId === undefined || callId === open.callId || callId === open.id)
-      ) {
+      const open = this.#openFor('mcp_call', callId);
+      if (open !== undefined) {
         open.item.output = mcpOutputText(content);
         yield* this.close();
         return;
@@ -287,13 +308,8 @@ export class OutputBuilder {
       // inside `action` (already on the item) and a file search's retrieved documents in
       // `results`. There is no standalone wire item for an orphan search result, so one with no
       // matching open call is reported rather than emitted.
-      const open = this.#open;
-      const callId = content.callId;
-      if (
-        open !== undefined &&
-        open.kind === 'search_call' &&
-        (callId === undefined || callId === open.callId || callId === open.id)
-      ) {
+      const open = this.#openFor('search_call', content.callId);
+      if (open !== undefined) {
         const results = (content.result as { results?: unknown } | null | undefined)?.results;
         if (open.item.type === 'file_search_call' && Array.isArray(results)) {
           open.item.results = results;
@@ -307,13 +323,8 @@ export class OutputBuilder {
     if (content.type === 'code_interpreter_tool_result') {
       // Same shape as a search result: the sandbox's outputs live on the `code_interpreter_call`
       // item itself, and an orphan result has no wire item of its own.
-      const open = this.#open;
-      const callId = content.callId;
-      if (
-        open !== undefined &&
-        open.kind === 'code_interpreter_call' &&
-        (callId === undefined || callId === open.callId || callId === open.id)
-      ) {
+      const open = this.#openFor('code_interpreter_call', content.callId);
+      if (open !== undefined) {
         open.item.outputs = codeInterpreterWireOutputs(content.outputs);
         yield* this.close();
         return;
@@ -480,10 +491,7 @@ export class OutputBuilder {
               ? hostedLabel
               : AGENT_FRAMEWORK_SERVER_LABEL,
           name: request.functionCall.name,
-          arguments:
-            typeof request.functionCall.arguments === 'string'
-              ? request.functionCall.arguments
-              : JSON.stringify(request.functionCall.arguments),
+          arguments: argumentsText(request.functionCall.arguments),
         };
         // The wire id is the *key* the decision comes back under; the request keeps its own id.
         this.surfacedApprovals.push({ wireId: id, request });
@@ -592,8 +600,7 @@ export class OutputBuilder {
         return;
       }
       case 'function_call': {
-        const args = (content as { arguments: Record<string, unknown> | string }).arguments;
-        const delta = typeof args === 'string' ? args : JSON.stringify(args);
+        const delta = argumentsText((content as { arguments: Record<string, unknown> | string }).arguments);
         if (delta === '') return;
         open.buffer += delta;
         yield {
@@ -624,8 +631,9 @@ export class OutputBuilder {
         return;
       }
       case 'mcp_call': {
-        const args = (content as { arguments?: Record<string, unknown> | string }).arguments ?? '';
-        const delta = typeof args === 'string' ? args : JSON.stringify(args);
+        const delta = argumentsText(
+          (content as { arguments?: Record<string, unknown> | string }).arguments ?? '',
+        );
         if (delta === '') return;
         open.buffer += delta;
         yield {

--- a/packages/openai/src/chat-client.ts
+++ b/packages/openai/src/chat-client.ts
@@ -32,7 +32,12 @@ import {
 } from '@polymind-inc/agent-framework-core';
 import OpenAI, { AzureOpenAI } from 'openai';
 import type { ParseContext } from './from-openai.js';
-import { createStreamParseState, parseResponse, parseStreamEvent } from './from-openai.js';
+import {
+  createStreamParseState,
+  isTerminalResponseEvent,
+  parseResponse,
+  parseStreamEvent,
+} from './from-openai.js';
 import { codeInterpreterTool, fileSearchTool, mcpTool, webSearchTool } from './hosted-tools.js';
 import type { OpenAIChatOptions } from './options.js';
 import {
@@ -397,14 +402,14 @@ export class OpenAIChatClient
    * stream at the terminal event" documents and pins the behaviour until then.
    *
    * The terminal set is exactly the events the stream parser folds as terminal
-   * (`parseStreamEvent`); an event the parser does not treat as terminal must not end the
-   * iteration early, or the two would disagree about when a stream is over.
+   * (`isTerminalResponseEvent`, shared with `parseStreamEvent`); an event the parser does not
+   * treat as terminal must not end the iteration early, or the two would disagree about when a
+   * stream is over.
    */
   static async *#untilTerminalEvent(events: AsyncIterable<unknown>): AsyncGenerator<unknown> {
     for await (const event of events) {
       yield event;
-      const type = (event as { type?: string }).type;
-      if (type === 'response.completed' || type === 'response.incomplete' || type === 'response.failed') {
+      if (isTerminalResponseEvent((event as { type?: string }).type)) {
         return;
       }
     }

--- a/packages/openai/src/from-openai.ts
+++ b/packages/openai/src/from-openai.ts
@@ -605,6 +605,25 @@ export function parseResponse(response: unknown, ctx: ParseContext = {}): ChatRe
 }
 
 /**
+ * The three events that end a Responses SSE stream; nothing meaningful follows them.
+ *
+ * Single authority for "the stream is over": the terminal case labels in {@link parseStreamEvent}
+ * and the chat client's early stream release both follow this set, so they cannot disagree about
+ * when a stream is done. A new terminal event is added here and to the matching case labels
+ * together.
+ */
+const TERMINAL_RESPONSE_EVENTS: ReadonlySet<string> = new Set([
+  'response.completed',
+  'response.incomplete',
+  'response.failed',
+]);
+
+/** Whether `type` names an event that ends a Responses SSE stream. */
+export function isTerminalResponseEvent(type: string | undefined): boolean {
+  return type !== undefined && TERMINAL_RESPONSE_EVENTS.has(type);
+}
+
+/**
  * Converts one Responses API stream event into a {@link ChatResponseUpdate}.
  *
  * Returns `undefined` for events that carry no framework-visible information (progress markers,
@@ -831,6 +850,7 @@ export function parseStreamEvent(
       break;
     }
 
+    // These labels are exactly TERMINAL_RESPONSE_EVENTS; change them only together.
     case 'response.completed':
     case 'response.incomplete':
     case 'response.failed': {


### PR DESCRIPTION
## What

A four-angle cleanup pass (reuse, simplification, efficiency, altitude) over all packages. Every change is behavior-preserving and internal — no public API changes; the few exports added are package-internal modules that are not re-exported from any package index.

### Single-authority mechanisms replacing parallel enumerations

- **Wire content types** (`core/types/serialization.ts`): the known-type set is now derived from a record keyed exhaustively by the `Content` union, so adding a content variant without registering its wire type is a compile error. Previously the variant compiled fine and silently deserialized as unknown content, breaking round-trip for a modelled type.
- **Hosted-tool capability methods** (`core/tools/hosted.ts`): the method list lives next to the capability interfaces and is consumed by both the `supports*` predicates and `withMiddleware`'s capability carry-over. Previously the wrapper kept its own copy, and a new capability missing from it would silently report as absent after wrapping.
- **Terminal SSE events** (`openai/from-openai.ts`): `isTerminalResponseEvent` is shared between the stream parser and the chat client's early stream release, so the two can no longer disagree about when a stream is over.

### Deduplication

- The agent server's persist-before-terminal contract (persist ahead of the terminal event, substitute a `storage_error` failure when the store refuses, teardown fallback) is now one `TerminalPersister` class instead of three hand-kept copies across the foreground and background drivers.
- One `errorMessageOf` helper in the core replaces three inline copies; the two invocation result types share one generic interface; the in-memory store's eviction loop, the Foundry output builder's open-item guard, and its argument stringification each collapse to a single helper; the fold metadata copied identically into both response flavors is a shared function.

### Streaming hot-path costs

- **Fold accumulation**: folding no longer copies the accumulated `rawRepresentation` array on every streamed delta — arrays the fold itself created are extended in place, caller-supplied arrays are still copied once. Turns an O(n²) per-stream accumulation into O(n) with byte-identical results.
- **Unread folds**: a stream layer without result hooks defers its final fold to `finalResponse()`. Inner layers of the run pipeline are drained by the layer above, and their folds were computed at end of iteration and never read — roughly half the full-transcript folds per streamed run were pure waste. Layers with result hooks (telemetry, history persistence) keep the eager path, so hook timing is unchanged.
- **Span content capture**: each message is serialized once and the strings are shared between the aggregate attribute and the per-message span events, halving the serialization work per captured transcript.

## Verification

`pnpm check` passes (lint, build, typecheck, all package tests, pack check). No test expectations were changed — the existing suites pin the folding, persistence and telemetry behavior these refactors preserve.

Reference note: no wire format or observable semantics are affected; the terminal-event set and the persist-before-terminal contract match the behavior already pinned by the existing tests against the reference implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)