### PR TITLE
[BREAKING] Let the provider declare which conversation ids are stable anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ The umbrella `@polymind-inc/agent-framework` package and all `@polymind-inc/agen
 packages are versioned in lockstep; one entry here covers the set. During 0.x, **minor releases may
 contain breaking changes**; patch releases are fixes only.
 
+## Unreleased
+
+- **[BREAKING] `@polymind-inc/agent-framework-core`** — the function-calling loop no longer
+  hardcodes OpenAI's `conv_` prefix when deciding whether a conversation id advances between tool
+  rounds. Which ids are stable service-side anchors is now the provider's declaration:
+  `ChatClientMetadata.stableConversationId`, a new optional predicate the loop and the agent's
+  session propagation consult. The built-in OpenAI, Azure OpenAI and Foundry clients declare it,
+  so their behavior is unchanged. **A custom `ChatClient` implementation that relied on the loop
+  pinning `conv_…` ids must now declare the predicate on its `metadata`** — without it, every
+  conversation id a round reports advances the chain, matching the .NET and Python loops.
+
 ## 0.2.2
 
 Fixes accumulated since 0.2.1, centred on running agents as Microsoft Foundry Hosted Agents:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,6 +20,11 @@ A chat client comes from a provider package — for example
 [`@polymind-inc/agent-framework-openai`](https://www.npmjs.com/package/@polymind-inc/agent-framework-openai),
 [`@polymind-inc/agent-framework-anthropic`](https://www.npmjs.com/package/@polymind-inc/agent-framework-anthropic)
 or [`@polymind-inc/agent-framework-foundry`](https://www.npmjs.com/package/@polymind-inc/agent-framework-foundry).
+A custom client implements the `ChatClient` interface directly. One that manages conversations
+service-side should declare which conversation ids are stable anchors via
+`ChatClientMetadata.stableConversationId`; the function-calling loop and the agent's session
+propagation consult that predicate, and without it every reported conversation id advances the
+chain between tool rounds.
 
 Requirements: Node.js >= 24, ESM only (no CommonJS build).
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -566,14 +566,23 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
        * transcript from the framework to the provider. Handing the framework a conversation id is
        * the caller's decision to make.
        */
+      const stableConversationId = this.#client.metadata.stableConversationId;
       const propagateConversationId = (update: ChatResponseUpdate): void => {
         const conversationId = update.conversationId;
+        const current = session.serviceSessionId;
         if (
           conversationId === undefined ||
           conversationId === '' ||
-          session.serviceSessionId === undefined ||
-          session.serviceSessionId === conversationId
+          current === undefined ||
+          current === conversationId
         ) {
+          return;
+        }
+        // An anchor the provider declares stable stays the session's id: a per-response id
+        // reported mid-run must not unhook the session from the stored conversation. The same
+        // guard the function-calling loop applies between tool rounds, applied where the
+        // reference puts it — on the session update itself (Go `updateConversationID`).
+        if (stableConversationId?.(current) === true) {
           return;
         }
         session.serviceSessionId = conversationId;

--- a/packages/core/src/agent/service-history.test.ts
+++ b/packages/core/src/agent/service-history.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import type { ChatClient, ChatOptions, ChatResponseStream } from '../client/chat-client.js';
+import type {
+  ChatClient,
+  ChatClientMetadata,
+  ChatOptions,
+  ChatResponseStream,
+} from '../client/chat-client.js';
 import { InMemoryHistoryProvider } from '../context/in-memory-history-provider.js';
 import { ConfigurationError } from '../errors.js';
 import { createResponseStream } from '../streaming/response-stream.js';
@@ -17,13 +22,14 @@ function must<T>(value: T | null | undefined): T {
 
 /** A client that answers with text and reports a service-side conversation id, like Responses. */
 class StoringClient implements ChatClient<ChatOptions> {
-  readonly metadata = { providerName: 'mock' };
+  readonly metadata: ChatClientMetadata;
   readonly calls: Array<{ messages: Message[]; conversationId: string | undefined }> = [];
   #turn = 0;
   readonly #conversationIds: string[];
 
-  constructor(conversationIds: string[]) {
+  constructor(conversationIds: string[], metadata: ChatClientMetadata = { providerName: 'mock' }) {
     this.#conversationIds = conversationIds;
+    this.metadata = metadata;
   }
 
   getResponse(messages: Message[], options?: ChatOptions): ChatResponseStream {
@@ -82,6 +88,23 @@ describe('service-managed history', () => {
       // The id is available to a caller that never waits for the final response.
       expect(session.serviceSessionId).toBe('resp_1');
     }
+  });
+
+  it('holds a session anchor the provider declares stable', async () => {
+    // The per-update propagation must apply the same guard the tool loop does: a response-chain
+    // id reported mid-run must not unhook the session from a stored conversation the provider
+    // resolves by its stable anchor.
+    const client = new StoringClient(['resp_1'], {
+      providerName: 'mock',
+      stableConversationId: (id) => id.startsWith('stable_'),
+    });
+    const agent = new Agent({ client });
+    const session = agent.createSession({ serviceSessionId: 'stable_1' });
+
+    await agent.run('hi', { session });
+
+    expect(client.calls[0]?.conversationId).toBe('stable_1');
+    expect(session.serviceSessionId).toBe('stable_1');
   });
 
   it('keeps the framework transcript when the session is not service-managed', async () => {

--- a/packages/core/src/client/chat-client.ts
+++ b/packages/core/src/client/chat-client.ts
@@ -9,6 +9,18 @@ export interface ChatClientMetadata {
   /** Used as OpenTelemetry's `gen_ai.provider.name`, for example `'openai'` or `'azure.ai.openai'`. */
   readonly providerName: string;
   readonly modelId?: string;
+  /**
+   * Whether `conversationId` names a service-side anchor that stays stable across responses, as
+   * opposed to a per-response chain that must advance to each round's reported id.
+   *
+   * Two places consult this: the function-calling loop between tool rounds, and the agent's
+   * session propagation when a run reports conversation ids. In both, an id the provider declares
+   * stable is never displaced by the id a response reports, so a service-held conversation cannot
+   * be unhooked by a response-chain fallback mid-run. Absent means no id is stable — every
+   * reported id advances the chain, which is also correct for providers whose stable ids are
+   * simply re-reported unchanged each round.
+   */
+  readonly stableConversationId?: (conversationId: string) => boolean;
 }
 
 /** How the model should pick tools. */

--- a/packages/core/src/client/function-invocation.test.ts
+++ b/packages/core/src/client/function-invocation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { ConfigurationError, SchemaResolutionError, UserInputRequiredError } from '../errors.js';
 import { functionMiddleware } from '../middleware/middleware.js';
+import { createResponseStream } from '../streaming/response-stream.js';
 import { invocationCountOf, resetInvocationCount, tool } from '../tools/tool.js';
 import type {
   Content,
@@ -10,7 +11,8 @@ import type {
   UserInputRequestContent,
 } from '../types/content.js';
 import { textContent } from '../types/content.js';
-import type { ChatOptions } from './chat-client.js';
+import { chatResponseUpdate, mergeChatUpdates } from '../types/response.js';
+import type { ChatClient, ChatClientMetadata, ChatOptions } from './chat-client.js';
 import { withFunctionInvocation } from './function-invocation.js';
 import { MockChatClient } from './test-support.js';
 
@@ -1112,5 +1114,94 @@ describe('withFunctionInvocation UserInputRequiredError', () => {
         consentLink: 'https://example.test/consent',
       }),
     ]);
+  });
+});
+
+describe('conversation chaining between rounds', () => {
+  const echo = tool({
+    name: 'echo',
+    description: 'echo',
+    parameters: echoSchema,
+    execute: async () => 'ok',
+  });
+
+  /**
+   * A two-round provider whose responses report the given conversation ids. The loop's chaining
+   * decision is driven entirely by what the round response reports and what the client's
+   * metadata declares stable, so the mock carries exactly those two knobs.
+   */
+  function chainingClient(
+    roundIds: [string, string],
+    metadata: ChatClientMetadata,
+  ): { client: ChatClient<ChatOptions>; requests: Array<ChatOptions | undefined> } {
+    const turns: Array<{ contents: Content[]; conversationId: string }> = [
+      { contents: [call('c1', 'echo', '{"value":"x"}')], conversationId: roundIds[0] },
+      { contents: [textContent('done')], conversationId: roundIds[1] },
+    ];
+    let index = 0;
+    const requests: Array<ChatOptions | undefined> = [];
+    const client: ChatClient<ChatOptions> = {
+      metadata,
+      getResponse: (_messages, options) => {
+        requests.push(options);
+        const turn = turns[Math.min(index++, turns.length - 1)] ?? { contents: [], conversationId: '' };
+        return createResponseStream({
+          start: () =>
+            (async function* () {
+              yield chatResponseUpdate({
+                contents: turn.contents,
+                role: 'assistant',
+                conversationId: turn.conversationId,
+              });
+            })(),
+          finalize: (updates) => mergeChatUpdates(updates),
+        });
+      },
+    };
+    return { client, requests };
+  }
+
+  it('holds the conversation anchor the provider declares stable', async () => {
+    // The provider says which ids are stable service-side anchors; a round that reports a
+    // response-chain id must not displace the anchor, or the next round falls off the stored
+    // conversation.
+    const { client, requests } = chainingClient(['resp_r1', 'resp_r2'], {
+      providerName: 'mock',
+      stableConversationId: (id) => id.startsWith('stable_'),
+    });
+    await withFunctionInvocation(client).getResponse([], {
+      tools: [echo],
+      conversationId: 'stable_1',
+    } as ChatOptions);
+
+    expect(requests).toHaveLength(2);
+    expect(must(requests[1]).conversationId).toBe('stable_1');
+  });
+
+  it('advances to the reported id when the provider declares no stable ids', async () => {
+    // Without the predicate every reported id advances the chain — including ids that happen to
+    // look like another provider's stable spelling. The loop owns no provider's id taxonomy.
+    const { client, requests } = chainingClient(['resp_r1', 'resp_r2'], { providerName: 'mock' });
+    await withFunctionInvocation(client).getResponse([], {
+      tools: [echo],
+      conversationId: 'conv_1',
+    } as ChatOptions);
+
+    expect(requests).toHaveLength(2);
+    expect(must(requests[1]).conversationId).toBe('resp_r1');
+  });
+
+  it('advances a non-stable id even when the provider declares a stable spelling', async () => {
+    const { client, requests } = chainingClient(['resp_r1', 'resp_r2'], {
+      providerName: 'mock',
+      stableConversationId: (id) => id.startsWith('stable_'),
+    });
+    await withFunctionInvocation(client).getResponse([], {
+      tools: [echo],
+      conversationId: 'resp_r0',
+    } as ChatOptions);
+
+    expect(requests).toHaveLength(2);
+    expect(must(requests[1]).conversationId).toBe('resp_r1');
   });
 });

--- a/packages/core/src/client/function-invocation.ts
+++ b/packages/core/src/client/function-invocation.ts
@@ -145,10 +145,13 @@ function withoutFunctionTools<TOptions extends ChatOptions>(options: TOptions): 
  *   `_tools.py`, Go `responses.go` `SetServiceID`).
  *
  * @param roundConversationId - The `conversationId` of the response this round produced.
+ * @param stableConversationId - The provider's declaration of which ids are stable anchors
+ *   ({@link ChatClientMetadata.stableConversationId}).
  */
 function optionsForNextIteration<TOptions extends ChatOptions>(
   options: TOptions,
   roundConversationId?: string,
+  stableConversationId?: (conversationId: string) => boolean,
 ): TOptions {
   const next = { ...options } as TOptions;
 
@@ -166,9 +169,11 @@ function optionsForNextIteration<TOptions extends ChatOptions>(
     // silently move a framework-managed transcript to the provider.
     current !== undefined &&
     current !== '' &&
-    // A `conv_…` conversation object is stable across responses; only a response chain advances
-    // (Go `keepConversationID`).
-    !current.startsWith('conv_') &&
+    // An id the provider declares stable is an anchor the service resolves across responses;
+    // displacing it with a round's reported id would unhook the run from the stored conversation
+    // (the provider-side guard Go keeps in `keepConversationID`). Which ids are stable is the
+    // provider's knowledge, so the loop only asks — it never inspects the id itself.
+    stableConversationId?.(current) !== true &&
     roundConversationId !== undefined &&
     roundConversationId !== '' &&
     roundConversationId !== current
@@ -1117,7 +1122,11 @@ export function withFunctionInvocation<TOptions extends ChatOptions>(
       // up in the conversation twice.
       const serviceOwnsTranscript = current.conversationId !== undefined && current.conversationId !== '';
       history = serviceOwnsTranscript ? [toolMessage] : [...history, ...roundResponse.messages, toolMessage];
-      current = optionsForNextIteration(current, roundResponse.conversationId);
+      current = optionsForNextIteration(
+        current,
+        roundResponse.conversationId,
+        client.metadata.stableConversationId,
+      );
     }
   }
 

--- a/packages/foundry/src/chat-client.test.ts
+++ b/packages/foundry/src/chat-client.test.ts
@@ -103,7 +103,22 @@ describe('FoundryChatClient', () => {
     });
 
     expect(deployment.baseURL).toBe(`${PROJECT}/openai/v1/`);
-    expect(deployment.metadata).toEqual({ providerName: 'azure.ai.foundry', modelId: 'gpt-4o' });
+    expect(deployment.metadata).toEqual({
+      providerName: 'azure.ai.foundry',
+      modelId: 'gpt-4o',
+      stableConversationId: expect.any(Function),
+    });
+  });
+
+  it('declares conv_ conversation ids stable for the tool loop, like the inner client', () => {
+    const stable = new FoundryChatClient({
+      projectEndpoint: PROJECT,
+      target: { modelDeployment: 'gpt-4o' },
+      credential: fakeCredential(),
+    }).metadata.stableConversationId;
+    expect(stable).toBeDefined();
+    expect(stable?.('conv_123')).toBe(true);
+    expect(stable?.('resp_123')).toBe(false);
   });
 
   it('exposes the SDK client and the hosted tool declarations of the inner client', () => {

--- a/packages/foundry/src/chat-client.ts
+++ b/packages/foundry/src/chat-client.ts
@@ -110,6 +110,11 @@ export class FoundryChatClient
     this.metadata = {
       providerName: 'azure.ai.foundry',
       ...(model === undefined ? {} : { modelId: model }),
+      // Foundry speaks the same Responses protocol, so which conversation ids are stable is the
+      // inner client's knowledge — re-spelling it here is how the two could drift.
+      ...(this.#inner.metadata.stableConversationId === undefined
+        ? {}
+        : { stableConversationId: this.#inner.metadata.stableConversationId }),
     };
   }
 

--- a/packages/openai/src/chat-client.test.ts
+++ b/packages/openai/src/chat-client.test.ts
@@ -674,6 +674,16 @@ describe('OpenAIChatClient configuration', () => {
     ).toBe('azure.ai.openai');
   });
 
+  it('declares conv_ conversation ids stable for the tool loop', () => {
+    // The function-calling loop consults this predicate instead of knowing the id spelling
+    // itself: a `conv_…` conversation object is a stable anchor, a `resp_…` chain advances.
+    const stable = new OpenAIChatClient({ client: fakeClient(vi.fn()), model: 'm' }).metadata
+      .stableConversationId;
+    expect(stable).toBeDefined();
+    expect(stable?.('conv_123')).toBe(true);
+    expect(stable?.('resp_123')).toBe(false);
+  });
+
   // Not a deferral: Chat Completions is out of scope for good (see `OpenAIChatClientOptions.api`).
   it('rejects the chat completions API', () => {
     expect(

--- a/packages/openai/src/chat-client.ts
+++ b/packages/openai/src/chat-client.ts
@@ -134,6 +134,18 @@ function withServedModel(context: ParseContext, servedModel: string | undefined)
   return servedModel === undefined ? context : { ...context, model: servedModel, servedModel };
 }
 
+/**
+ * Whether a conversation id names a Responses API conversation *object* — a service-side anchor
+ * that stays stable across responses — as opposed to a response id chained through
+ * `previous_response_id`, which advances every round.
+ *
+ * The single spelling of this distinction: the request builder maps the id onto the right wire
+ * parameter with it, and the tool loop consults it through `metadata.stableConversationId`.
+ */
+function isConversationObjectId(id: string): boolean {
+  return id.startsWith('conv_');
+}
+
 /** Whether a raw Responses API conversation value refers to service-managed history. */
 function isServiceConversation(value: unknown): boolean {
   if (typeof value === 'string') {
@@ -252,6 +264,7 @@ export class OpenAIChatClient
     this.metadata = {
       providerName: detectProviderName(this.#client),
       ...(config.model === undefined ? {} : { modelId: config.model }),
+      stableConversationId: isConversationObjectId,
     };
   }
 
@@ -335,7 +348,7 @@ export class OpenAIChatClient
     // (`stop`, `seed`, `frequencyPenalty`, `presencePenalty` are Chat Completions concepts.)
 
     if (conversationId !== undefined && conversationId !== '') {
-      if (conversationId.startsWith('conv_')) {
+      if (isConversationObjectId(conversationId)) {
         request.conversation = conversationId;
       } else {
         request.previous_response_id = conversationId;


### PR DESCRIPTION
## What

The function-calling loop decided whether a conversation id advances between tool rounds by testing for OpenAI's `conv_` prefix — one provider's id taxonomy, hardcoded in the layer every provider runs through. A provider whose stable conversation ids are spelled differently had its runs silently re-chained every round (or never advanced).

This PR replaces the hardcoded prefix with a provider declaration: **`ChatClientMetadata.stableConversationId`**, a new optional predicate naming which conversation ids are stable service-side anchors.

- **The function-calling loop** consults it between tool rounds: an id the provider declares stable is never displaced by the id a round response reports, so a service-held conversation cannot be unhooked by a response-chain fallback mid-run. A plain response chain still advances each round.
- **The agent's session propagation** applies the same guard per update, so `session.serviceSessionId` also keeps its anchor — across awaited runs, streamed runs, and abandoned streams alike.
- **Absent, every reported id advances the chain**, matching the .NET and Python loops.

The OpenAI / Azure OpenAI client declares the predicate from the same single spelling its request builder already uses to map the id onto `conversation` vs `previous_response_id`; the Foundry client reuses the inner client's declaration rather than re-spelling it.

## Reference alignment

None of the reference implementations keeps this knowledge in the shared loop:

- **.NET** (MEAI `FunctionInvokingChatClient`) and **Python** (`_tools.py`) advance the loop's conversation id unconditionally and let the provider control what it reports.
- **Go** keeps the guard inside its OpenAI provider (`keepConversationID` in `responses.go`), which updates the session itself before `SetServiceID`.

Since this implementation carries the id through `ChatOptions`, the Go guard maps onto a metadata declaration — the loop asks the provider instead of inspecting the id, and the guard sits on both places that write the id forward (next-round options and the session), mirroring where Go puts it.

## Breaking change

**A custom `ChatClient` implementation that relied on the loop pinning `conv_…` ids must now declare the predicate on its `metadata`.** Without it, every conversation id a round reports advances the chain. The built-in OpenAI, Azure OpenAI and Foundry clients are unaffected. Called out in the changelog under Unreleased; the core README documents the declaration for custom client authors.

## Verification

- Reproduction-first: five new tests (loop anchor hold, loop default advance, both provider declarations, session anchor hold) were confirmed failing against the previous code, and confirmed failing again with the implementation temporarily reverted.
- `pnpm check` passes: lint, build, typecheck, all package tests, pack check.
- No existing test pinned the old hardcoded behavior — these tests are the first to pin the chaining contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)