### PR TITLE
[BREAKING] Expose a typed hosted execution context to tools and context providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **`@polymind-inc/agent-framework-foundry`** — the hosting layer now exposes the turn's typed
+  execution context to code running inside the agent
+  ([#23](https://github.com/polymind-inc/agent-framework-js/issues/23)). `getHostedAgentContext()`
+  (exported from `/hosting`) returns a frozen per-turn `HostedAgentContext` — the platform user id
+  and call id, the correlation id, the response and conversation ids, the resolved agent
+  reference, the sandbox session id, and the turn's `AbortSignal` — from any tool, context
+  provider or middleware, and `undefined` outside a hosted turn. Concurrent turns on one container
+  each see their own context; the stores that persist per-user state keep taking their partition
+  key as an explicit argument. There is deliberately no per-request tenant field: the platform's
+  trust boundary injects only the user id and call id, and a hosted container is deployed per
+  agent inside one tenant.
+- **[BREAKING] `@polymind-inc/agent-framework-agentserver`** — `HandlerContext` gains two required
+  fields: `agentReference` (the resolved agent this turn targets, always with a non-empty name)
+  and `agentSessionId` (the resolved sandbox session id, as returned on `x-agent-session-id`).
+  Handlers only read the context and are unaffected; code that *constructs* `HandlerContext`
+  values — test doubles, custom protocol frontends — must now supply both.
 - **[BREAKING] `@polymind-inc/agent-framework-core`** — the function-calling loop no longer
   hardcodes OpenAI's `conv_` prefix when deciding whether a conversation id advances between tool
   rounds. Which ids are stable service-side anchors is now the provider's declaration:

--- a/packages/agentserver/src/server.test.ts
+++ b/packages/agentserver/src/server.test.ts
@@ -1430,6 +1430,44 @@ describe('input_items paging', () => {
   });
 });
 
+describe('handler context identity', () => {
+  it('hands the handler the resolved agent reference and sandbox session id', async () => {
+    let seen: HandlerContext | undefined;
+    const server = makeServer(async function* (_request: CreateResponseRequest, context: HandlerContext) {
+      seen = context;
+      yield { type: 'response.created', response: context.response };
+      yield { type: 'response.in_progress', response: { ...context.response, status: 'in_progress' } };
+      yield { type: 'response.completed', response: { ...context.response, status: 'completed' } };
+    });
+
+    const response = await server.handle(post({ input: 'hi' }));
+    expect(response.status).toBe(200);
+
+    const context = must(seen);
+    // The same resolution the response resource and the `x-agent-session-id` header carry — the
+    // handler no longer has to re-derive either.
+    expect(context.agentReference).toEqual(((await response.json()) as ResponseObject).agent_reference);
+    expect(context.agentReference.name).not.toBe('');
+    expect(context.agentSessionId).toBe(must(response.headers.get(HEADERS.sessionId)));
+  });
+
+  it('resolves the agent reference the request named', async () => {
+    let seen: HandlerContext | undefined;
+    const server = makeServer(async function* (_request: CreateResponseRequest, context: HandlerContext) {
+      seen = context;
+      yield { type: 'response.created', response: context.response };
+      yield { type: 'response.in_progress', response: { ...context.response, status: 'in_progress' } };
+      yield { type: 'response.completed', response: { ...context.response, status: 'completed' } };
+    });
+
+    await server.handle(
+      post({ input: 'hi', agent_reference: { type: 'agent_reference', name: 'triage', version: '3' } }),
+    );
+
+    expect(must(seen).agentReference).toMatchObject({ name: 'triage', version: '3' });
+  });
+});
+
 describe('draining', () => {
   let server: ResponsesServer;
 

--- a/packages/agentserver/src/server.ts
+++ b/packages/agentserver/src/server.ts
@@ -45,6 +45,7 @@ import {
 } from './validation.js';
 import { raceTimeout } from './wait.js';
 import type {
+  AgentReference,
   ApiError,
   CreateResponseRequest,
   DeletedResponse,
@@ -63,6 +64,18 @@ export interface HandlerContext {
   readonly conversationId: string | undefined;
   /** The platform request context: user id, call id, correlation id. */
   readonly request: RequestContext;
+  /**
+   * Which agent this turn resolved to. Always carries a non-empty name — the same resolution
+   * stamped on the response resource, so a handler routing between agents reads it here instead
+   * of re-deriving it from the request.
+   */
+  readonly agentReference: AgentReference;
+  /**
+   * The sandbox session this turn runs in, as returned on `x-agent-session-id`. Container-scoped,
+   * not conversation-scoped: one value serves every conversation and user this container hosts,
+   * so it must never key per-conversation or per-user state.
+   */
+  readonly agentSessionId: string;
   /** The transcript so far, prefetched from the store. Empty for a new conversation. */
   readonly history: readonly OutputItem[];
   /** Aborted when the client disconnects or the container is shutting down. */
@@ -952,6 +965,9 @@ export class ResponsesServer {
     // Resolved per request rather than per response: it names the sandbox the turn runs in, and
     // every turn of one conversation has to come back to the same one.
     const sessionId = await resolveAgentSessionId(created);
+    // Which agent produced this response. Always resolved to a non-empty name: a service-side
+    // store validates its presence on every write, and rejects one without it opaquely.
+    const agentReference = resolveAgentReference(created.agent_reference);
 
     const initial: ResponseObject = {
       id: responseId,
@@ -959,9 +975,7 @@ export class ResponsesServer {
       created_at: Math.floor(Date.now() / 1000),
       status: 'queued',
       output: [],
-      // Which agent produced this response. Always resolved to a non-empty name: a service-side
-      // store validates its presence on every write, and rejects one without it opaquely.
-      agent_reference: resolveAgentReference(created.agent_reference),
+      agent_reference: agentReference,
       // Persisted on the resource because the replay and cancel routes decide their answers by
       // it long after the run itself is gone.
       ...(background ? { background: true } : {}),
@@ -1001,6 +1015,8 @@ export class ResponsesServer {
       responseId,
       conversationId,
       request: context,
+      agentReference,
+      agentSessionId: sessionId,
       history,
       signal: abort.signal,
       response: initial,

--- a/packages/foundry/src/hosting.ts
+++ b/packages/foundry/src/hosting.ts
@@ -52,6 +52,10 @@ export { FileSystemAgentSessionStore, InMemoryAgentSessionStore } from './hostin
 
 export type { FoundryHandlerConfig } from './hosting/handler.js';
 export { createFoundryHandler, defaultApprovalStorage, defaultSessionStore } from './hosting/handler.js';
+export type { HostedAgentContext } from './hosting/hosted-context.js';
+// The builder (hostedAgentContextOf) and the iteration wrapper stay internal: the handler is the
+// only writer, which is what keeps the ambient read-only for everything below it.
+export { getHostedAgentContext } from './hosting/hosted-context.js';
 
 export type { ResponsesHostServerConfig } from './hosting/server.js';
 export { defaultStore, ResponsesHostServer } from './hosting/server.js';

--- a/packages/foundry/src/hosting/handler.ts
+++ b/packages/foundry/src/hosting/handler.ts
@@ -31,6 +31,7 @@ import {
   requestToChatOptions,
   usageToResponseUsage,
 } from './converters.js';
+import { hostedAgentContextOf, withHostedAgentContext } from './hosted-context.js';
 import { OutputBuilder } from './output.js';
 import type { AgentSessionStore } from './session-store.js';
 import {
@@ -376,6 +377,7 @@ export function createFoundryHandler(options: FoundryHandlerConfig): ResponseHan
     yield { type: 'response.in_progress', response: { ...context.response, status: 'in_progress' } };
 
     const consentChannel = createConsentChannel();
+    const hostedContext = hostedAgentContextOf(context);
 
     try {
       const stream = agent.run(messages, {
@@ -393,7 +395,10 @@ export function createFoundryHandler(options: FoundryHandlerConfig): ResponseHan
       // text is attacker-reachable, so it is never read as protocol (see `consent-channel.ts`).
       const consentRequests: ToolboxConsentRequest[] = [];
 
-      for await (const update of withConsentChannel(consentChannel, stream)) {
+      for await (const update of withHostedAgentContext(
+        hostedContext,
+        withConsentChannel(consentChannel, stream),
+      )) {
         for (const content of update.contents) {
           if (content.type === 'usage') {
             usage = addUsage(usage, content.usageDetails);

--- a/packages/foundry/src/hosting/hosted-context.test.ts
+++ b/packages/foundry/src/hosting/hosted-context.test.ts
@@ -1,0 +1,63 @@
+import type { HandlerContext } from '@polymind-inc/agent-framework-agentserver';
+import { createRequestContext } from '@polymind-inc/agent-framework-agentserver';
+import { describe, expect, it } from 'vitest';
+import { getHostedAgentContext, hostedAgentContextOf, withHostedAgentContext } from './hosted-context.js';
+
+function makeHandlerContext(): HandlerContext {
+  const responseId = 'caresp_test';
+  return {
+    responseId,
+    conversationId: undefined,
+    request: createRequestContext(new Headers({ 'x-agent-user-id': 'alice' })),
+    agentReference: { type: 'agent_reference', name: 'test-agent' },
+    agentSessionId: 'session-test',
+    history: [],
+    signal: new AbortController().signal,
+    response: { id: responseId, object: 'response', created_at: 0, status: 'queued', output: [] },
+  };
+}
+
+describe('withHostedAgentContext', () => {
+  it('keeps the context installed while the stream is torn down early', async () => {
+    const context = hostedAgentContextOf(makeHandlerContext());
+    // 'unread' rather than undefined, so a finally that never ran cannot pass the assertion.
+    let seenInFinally: unknown = 'unread';
+    async function* source(): AsyncGenerator<number> {
+      try {
+        yield 1;
+        yield 2;
+      } finally {
+        // Where the agent saves its session, tears its tools down and runs afterRun hooks when
+        // the consumer stops early — a consent break, a disconnect, a shutdown all arrive here.
+        seenInFinally = getHostedAgentContext();
+      }
+    }
+
+    for await (const value of withHostedAgentContext(context, source())) {
+      void value;
+      break;
+    }
+
+    expect(seenInFinally).toBe(context);
+  });
+});
+
+describe('hostedAgentContextOf', () => {
+  it('freezes the agent reference as a copy, apart from the protocol resource', () => {
+    const handlerContext = makeHandlerContext();
+    const context = hostedAgentContextOf(handlerContext);
+
+    expect(Object.isFrozen(context)).toBe(true);
+    expect(Object.isFrozen(context.agent)).toBe(true);
+    expect(context.agent).toEqual(handlerContext.agentReference);
+    // A copy, not the shared instance: the protocol layer persists its own object, and freezing
+    // or mutating through this view must not reach it.
+    expect(context.agent).not.toBe(handlerContext.agentReference);
+    expect(Object.isFrozen(handlerContext.agentReference)).toBe(false);
+
+    expect(() => {
+      (context.agent as { name: string }).name = 'mutated';
+    }).toThrow(TypeError);
+    expect(handlerContext.agentReference.name).toBe('test-agent');
+  });
+});

--- a/packages/foundry/src/hosting/hosted-context.ts
+++ b/packages/foundry/src/hosting/hosted-context.ts
@@ -1,0 +1,117 @@
+/**
+ * The typed execution context of one hosted turn, for code that runs *inside* the agent.
+ *
+ * The hosting handler receives everything about the turn as explicit arguments, and the stores it
+ * writes to take the user id as a required parameter — a partition key that lives in a signature
+ * is one the compiler enforces. But tools, context providers and middleware are wired into the
+ * agent by the application, not by the handler, so there is no argument the handler could hand
+ * down to them. For those, this module carries the turn's context ambiently, the same split the
+ * .NET implementation reaches with explicit `RunCoreAsync` parameters plus an `AsyncLocal`
+ * accessor, and Python with a `ContextVar` the endpoint sets per turn.
+ *
+ * ## What is deliberately not here
+ *
+ * - **A tenant.** The platform's trust boundary injects exactly two identifiers per request: the
+ *   end-user id and the call id. A hosted container is deployed per agent, inside one tenant, so
+ *   tenant isolation is container isolation; inventing a per-request tenant field would claim an
+ *   identity the platform never supplies.
+ * - **Trace context.** OpenTelemetry's own ambient context is the source of truth for the active
+ *   trace; a copy here would drift from it the moment a span starts or ends.
+ *
+ * ## Scope
+ *
+ * The context is installed around the agent-run stream by re-entering the `AsyncLocalStorage`
+ * scope on every pull (the consent channel does the same, and for the same reason): an async
+ * generator resumes in its consumer's context, so wrapping the whole loop once would leave the
+ * propagation to wherever the loop happened to be suspended. Outside a hosted turn — including
+ * after it ends — {@link getHostedAgentContext} returns `undefined`.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { AgentReference, HandlerContext } from '@polymind-inc/agent-framework-agentserver';
+
+/** What one hosted turn knows about itself. One frozen instance per turn. */
+export interface HostedAgentContext {
+  /**
+   * The end user this turn serves, injected by the platform. The partition key for per-user
+   * state, and `undefined` outside a hosted environment (local runs share one anonymous
+   * partition). Never forward it on an outbound call: it is a global, cross-agent identifier.
+   */
+  readonly userId: string | undefined;
+  /**
+   * The platform's opaque per-request call id, when protocol v2.0.0 is in play. Foundry
+   * first-party services require it on outbound calls; `platformHeaders()` already forwards it.
+   */
+  readonly callId: string | undefined;
+  /** The correlation id, echoed on the response as `x-request-id`. */
+  readonly requestId: string;
+  /** The id this turn's response is stored under. */
+  readonly responseId: string;
+  /** The conversation this turn belongs to, when the request named one. */
+  readonly conversationId: string | undefined;
+  /** Which agent this turn resolved to. Always carries a non-empty name. */
+  readonly agent: AgentReference;
+  /**
+   * The sandbox session this turn runs in. Container-scoped, not conversation-scoped: one value
+   * serves every conversation and user this container hosts, so it must never key per-user or
+   * per-conversation state.
+   */
+  readonly agentSessionId: string;
+  /** Aborted when the client disconnects or the container is shutting down. */
+  readonly signal: AbortSignal;
+}
+
+const storage = new AsyncLocalStorage<HostedAgentContext>();
+
+/** The turn's context, narrowed from what the protocol layer hands the handler. */
+export function hostedAgentContextOf(context: HandlerContext): HostedAgentContext {
+  return Object.freeze({
+    userId: context.request.userId,
+    callId: context.request.foundryCallId,
+    requestId: context.request.requestId,
+    responseId: context.responseId,
+    conversationId: context.conversationId,
+    agent: context.agentReference,
+    agentSessionId: context.agentSessionId,
+    signal: context.signal,
+  });
+}
+
+/**
+ * The context of the hosted turn in flight, or `undefined` outside one.
+ *
+ * Read-only by construction: the instance is frozen, and nothing here can widen a tool's or
+ * provider's authority — the stores that persist per-user state take their partition key as an
+ * explicit argument and never read it from this ambient.
+ */
+export function getHostedAgentContext(): HostedAgentContext | undefined {
+  return storage.getStore();
+}
+
+/**
+ * Drives `stream` with `context` installed as the ambient hosted context.
+ *
+ * Each `next()` is invoked inside `AsyncLocalStorage.run`, which is where the agent runs the
+ * round — the model call, the tools, the context providers — so a read from any of them lands on
+ * this turn's context and nowhere else, including while another turn is interleaved on the same
+ * container.
+ */
+export async function* withHostedAgentContext<T>(
+  context: HostedAgentContext,
+  stream: AsyncIterable<T>,
+): AsyncGenerator<T, void, undefined> {
+  const iterator = stream[Symbol.asyncIterator]();
+  try {
+    for (;;) {
+      const next = await storage.run(context, () => iterator.next());
+      if (next.done === true) {
+        return;
+      }
+      yield next.value;
+    }
+  } finally {
+    // `break` in the consumer has to reach the agent's own cleanup (session save, tool teardown)
+    // exactly as it would without this wrapper.
+    await iterator.return?.();
+  }
+}

--- a/packages/foundry/src/hosting/hosted-context.ts
+++ b/packages/foundry/src/hosting/hosted-context.ts
@@ -71,7 +71,10 @@ export function hostedAgentContextOf(context: HandlerContext): HostedAgentContex
     requestId: context.request.requestId,
     responseId: context.responseId,
     conversationId: context.conversationId,
-    agent: context.agentReference,
+    // A frozen copy, not the shared instance: the protocol layer persists its own reference on
+    // the response resource, so a mutation through this view — or freezing an object this module
+    // does not own — must not reach it.
+    agent: Object.freeze({ ...context.agentReference }),
     agentSessionId: context.agentSessionId,
     signal: context.signal,
   });
@@ -110,8 +113,9 @@ export async function* withHostedAgentContext<T>(
       yield next.value;
     }
   } finally {
-    // `break` in the consumer has to reach the agent's own cleanup (session save, tool teardown)
-    // exactly as it would without this wrapper.
-    await iterator.return?.();
+    // `break` in the consumer has to reach the agent's own cleanup (session save, tool teardown,
+    // afterRun hooks) exactly as it would without this wrapper — and that cleanup runs *inside*
+    // the context, because an early end is still part of the turn it ends.
+    await storage.run(context, () => iterator.return?.());
   }
 }

--- a/packages/foundry/src/hosting/hosting.test.ts
+++ b/packages/foundry/src/hosting/hosting.test.ts
@@ -15,7 +15,11 @@ import {
   newId,
   ResponsesServer,
 } from '@polymind-inc/agent-framework-agentserver';
-import type { Content, FunctionApprovalRequestContent } from '@polymind-inc/agent-framework-core';
+import type {
+  Content,
+  ContextProvider,
+  FunctionApprovalRequestContent,
+} from '@polymind-inc/agent-framework-core';
 import {
   Agent,
   InMemoryHistoryProvider,
@@ -38,6 +42,8 @@ import {
   usageToResponseUsage,
 } from './converters.js';
 import { createFoundryHandler, defaultApprovalStorage, defaultSessionStore } from './handler.js';
+import type { HostedAgentContext } from './hosted-context.js';
+import { getHostedAgentContext } from './hosted-context.js';
 import { OutputBuilder } from './output.js';
 import { FoundryResponseStore } from './response-store.js';
 import { FileSystemAgentSessionStore, InMemoryAgentSessionStore } from './session-store.js';
@@ -668,6 +674,8 @@ describe('tool approval over the protocol', () => {
       responseId,
       conversationId: undefined,
       request: createRequestContext(new Headers({ [HEADERS.userId]: 'alice' })),
+      agentReference: { type: 'agent_reference', name: 'test-agent' },
+      agentSessionId: 'session-test',
       history: [],
       signal: new AbortController().signal,
       response: { id: responseId, object: 'response', created_at: 0, status: 'queued', output: [] },
@@ -1437,6 +1445,8 @@ describe('stored-history replay', () => {
       responseId,
       conversationId: undefined,
       request: createRequestContext(new Headers()),
+      agentReference: { type: 'agent_reference', name: 'test-agent' },
+      agentSessionId: 'session-test',
       history: [
         {
           type: 'web_search_call',
@@ -2244,5 +2254,133 @@ describe('file approval storage concurrency', () => {
 
     expect(await storage.load('alice', 'mcpr_a')).toBeDefined();
     expect(await storage.load('alice', 'mcpr_b')).toBeDefined();
+  });
+});
+
+describe('hosted agent context', () => {
+  function captureThen(text: string): MockTurn[] {
+    return [
+      {
+        contents: [{ type: 'function_call', callId: 'cap1', name: 'capture', arguments: '{}' }],
+        finishReason: 'tool_calls',
+      },
+      say(text),
+    ];
+  }
+
+  it('is undefined outside a turn', () => {
+    expect(getHostedAgentContext()).toBeUndefined();
+  });
+
+  it('hands tools and context providers one context for the whole turn', async () => {
+    const seenByTool: Array<HostedAgentContext | undefined> = [];
+    const capture = tool({
+      name: 'capture',
+      description: 'Capture the ambient context',
+      parameters: { type: 'object', properties: {} },
+      execute: async () => {
+        seenByTool.push(getHostedAgentContext());
+        return 'ok';
+      },
+    });
+    let seenByProvider: HostedAgentContext | undefined;
+    const provider: ContextProvider = {
+      sourceId: 'context-capture',
+      beforeRun: () => {
+        seenByProvider = getHostedAgentContext();
+      },
+    };
+    const agent = new Agent({
+      client: new MockChatClient(captureThen('done')),
+      tools: [capture],
+      contextProviders: [provider],
+    });
+    const app = new ResponsesServer({
+      handler: createFoundryHandler({
+        agent,
+        sessionStore: new InMemoryAgentSessionStore(),
+        approvalStorage: new InMemoryApprovalStorage(),
+        hosted: false,
+      }),
+      store: new InMemoryResponseProvider(),
+    });
+
+    const response = (await (
+      await app.handle(
+        post({ input: 'go' }, { [HEADERS.userId]: 'alice', [HEADERS.foundryCallId]: 'call-77' }),
+      )
+    ).json()) as ResponseObject;
+    expect(response.status).toBe('completed');
+
+    const context = must(seenByTool[0]);
+    expect(context.userId).toBe('alice');
+    expect(context.callId).toBe('call-77');
+    expect(context.responseId).toBe(response.id);
+    expect(context.conversationId).toBeUndefined();
+    expect(context.agent.name).not.toBe('');
+    expect(context.agentSessionId).not.toBe('');
+    expect(context.requestId).not.toBe('');
+    expect(context.signal.aborted).toBe(false);
+    // One instance per turn: the provider saw the very same object the tool did.
+    expect(seenByProvider).toBe(context);
+    // The scope ended with the turn.
+    expect(getHostedAgentContext()).toBeUndefined();
+  });
+
+  it('keeps the contexts of concurrent turns apart', async () => {
+    // Both turns must be inside their tool call at the same time: a context that leaked across
+    // requests would be visible here, where sequential runs would mask it.
+    let inFlight = 0;
+    let release: () => void = () => {};
+    const bothIn = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const whoami = tool({
+      name: 'capture',
+      description: 'Report the ambient user',
+      parameters: { type: 'object', properties: {} },
+      execute: async () => {
+        inFlight += 1;
+        if (inFlight === 2) release();
+        await bothIn;
+        return getHostedAgentContext()?.userId ?? 'nobody';
+      },
+    });
+    const callCapture: MockTurn = {
+      contents: [{ type: 'function_call', callId: 'cap1', name: 'capture', arguments: '{}' }],
+      finishReason: 'tool_calls',
+    };
+    const agent = new Agent({
+      // Both tool-call turns first, then both completions: the barrier holds each turn inside its
+      // tool until the other arrives, so the runs are interleaved rather than sequential.
+      client: new MockChatClient([callCapture, callCapture, say('done'), say('done')]),
+      tools: [whoami],
+    });
+    const app = new ResponsesServer({
+      handler: createFoundryHandler({
+        agent,
+        sessionStore: new InMemoryAgentSessionStore(),
+        approvalStorage: new InMemoryApprovalStorage(),
+        hosted: false,
+      }),
+      store: new InMemoryResponseProvider(),
+    });
+
+    const [alice, bob] = await Promise.all([
+      app
+        .handle(post({ input: 'who am I' }, { [HEADERS.userId]: 'alice' }))
+        .then(async (r) => (await r.json()) as ResponseObject),
+      app
+        .handle(post({ input: 'who am I' }, { [HEADERS.userId]: 'bob' }))
+        .then(async (r) => (await r.json()) as ResponseObject),
+    ]);
+
+    expect(alice.status).toBe('completed');
+    expect(bob.status).toBe('completed');
+    // Each turn's tool answered with that turn's user — captured while the other turn was live.
+    expect(textOf(alice)).toContain('alice');
+    expect(textOf(alice)).not.toContain('bob');
+    expect(textOf(bob)).toContain('bob');
+    expect(textOf(bob)).not.toContain('alice');
   });
 });


### PR DESCRIPTION
Closes #23.

## What

Code wired into the agent by the application — tools, context providers, middleware — had no way to see which hosted turn it was serving: the platform user id died at the hosting handler, and the resolved agent reference and sandbox session id never left the protocol layer.

- **agentserver**: `HandlerContext` now carries the resolved `agentReference` (always a non-empty name; the same resolution stamped on the response resource) and `agentSessionId` (as returned on `x-agent-session-id`) as explicit fields.
- **foundry/hosting**: new `getHostedAgentContext()` (exported from `/hosting`) returns one frozen `HostedAgentContext` per turn — `userId`, `callId`, `requestId`, `responseId`, `conversationId`, `agent`, `agentSessionId`, `signal` — from anywhere inside the run, and `undefined` outside one. The handler installs it by re-entering an `AsyncLocalStorage` scope on every pull of the agent-run stream (the same mechanism the consent channel uses), so concurrent turns on one container each see their own context.

## Design decisions

- **No per-request tenant field.** The platform's trust boundary injects exactly two identifiers per request (`x-agent-user-id`, `x-agent-foundry-call-id`); a hosted container is deployed per agent inside one tenant, so tenant isolation is container isolation. Inventing a per-request tenant would claim an identity the platform never supplies — the same reasoning the .NET implementation applied when it dropped the chat isolation key.
- **The ambient is read-only and never the authority.** The stores that persist per-user state keep taking their partition key as a required explicit argument; the .NET implementation rejected ambient identity for stores because an async iterator's `AsyncLocal` writes revert across `yield`, and a partition key that lives in a signature is one the compiler enforces.
- **No session-stamped identity check.** The session and approval stores are partitioned by user id in their keys and paths, so a cross-user load is structurally impossible; a second copy of the identity inside the session would be a second source of truth to keep consistent.
- **Core is untouched.** The core stays runtime-agnostic (no `node:async_hooks`); the ambient lives in the Node-only hosting layer, mirroring how the reference implementations keep hosted identity out of their portable run-context types.

## Breaking change

`HandlerContext` gains two required fields. Handlers only *read* the context and are unaffected; code that *constructs* `HandlerContext` values — test doubles, custom protocol frontends — must now supply `agentReference` and `agentSessionId`.

## Tests

- The resolved agent reference and session id reach the handler (default and request-named agents).
- One context instance per turn, seen identically by a tool and a context provider, with the scope ending at the turn boundary.
- Two concurrent turns held inside their tool calls by a barrier each observe their own user id, with no cross-talk.
- Negative control: temporarily reverting the wiring makes the new tests fail on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)