### PR TITLE
Add the Foundry Invocations protocol server and hosting adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **`@polymind-inc/agent-framework-agentserver`** — new `InvocationsServer`: the Foundry
+  Invocations protocol ([#29](https://github.com/polymind-inc/agent-framework-js/issues/29)),
+  served alongside the existing Responses protocol. The protocol prescribes no payload — the
+  request body reaches the `InvocationHandler` unread, and the handler's `Response` is what the
+  caller gets — while the server owns the routes (`POST /invocations`, `GET /invocations/{id}`,
+  `POST /invocations/{id}/cancel`, `/readiness`), invocation and session id resolution
+  (`x-agent-invocation-id`; `agent_session_id` query → `FOUNDRY_AGENT_SESSION_ID` → generated),
+  their echo on every response including errors, cancellation via `InvocationContext.signal`,
+  opaque `upstream`-classified handler failures, SSE keep-alive injection for
+  `text/event-stream` bodies, and W3C trace propagation with the
+  `azure.ai.agentserver.invocation_id` / `.session_id` baggage. `serve` (on `/agentserver/node`)
+  now accepts any `{ fetch, drain }` protocol server — a widening, existing callers are
+  unaffected.
+- **`@polymind-inc/agent-framework-foundry`** — new `InvocationsHostServer` (on `/hosting`):
+  publishes an `Agent` over the Invocations protocol with the same wire contract as the Python
+  adapter — request `{ "message": string, "stream"?: boolean }`, plain-text responses, raw text
+  chunks under `text/event-stream` when streaming. Conversations are held in process, partitioned
+  per session id and — hosted — per platform user; callers continue a conversation by pinning the
+  `agent_session_id` query parameter to the previous response's `x-agent-session-id` header.
+  Hosted requests without the protocol-2.0.0 call id fail closed with 501, without a user id with
+  400, as the Responses adapter does.
 - **`@polymind-inc/agent-framework-foundry`** — the hosting layer now exposes the turn's typed
   execution context to code running inside the agent
   ([#23](https://github.com/polymind-inc/agent-framework-js/issues/23)). `getHostedAgentContext()`

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ bundler tree-shakes whatever you do not import.
 | `@polymind-inc/agent-framework/mcp`               | Model Context Protocol client integration — MCP server tools as framework tools                                                      |
 | `@polymind-inc/agent-framework/a2a`               | Agent2Agent (A2A) protocol client — a remote A2A agent used as an agent                                                              |
 | `@polymind-inc/agent-framework/foundry`           | Microsoft Foundry chat client, with the Hosted Agent adapter under `/foundry/hosting`                                                |
-| `@polymind-inc/agent-framework/agentserver`       | Foundry Responses container protocol v2.0.0 server, with `/agentserver/node` and `/agentserver/observability` companions             |
+| `@polymind-inc/agent-framework/agentserver`       | Foundry container protocol servers (Responses v2.0.0 and Invocations), with `/agentserver/node` and `/agentserver/observability` companions |
 | `@polymind-inc/agent-framework/testing`           | `MockChatClient` and friends for testing agents without a live provider                                                              |
 
 Under the hood the framework is developed and published as a family of
@@ -173,7 +173,7 @@ Deliberate divergences, and the reason for each:
 | Agent, sessions, tools, middleware, streaming                     | Implemented                                                      |
 | Function-calling loop, tool approval, continuation tokens          | Implemented                                                      |
 | OpenAI / Azure OpenAI, Anthropic and Microsoft Foundry providers   | Implemented                                                      |
-| Microsoft Foundry Hosted Agent hosting                            | Implemented                                                      |
+| Microsoft Foundry Hosted Agent hosting (Responses and Invocations protocols) | Implemented                                           |
 | `ContextProvider` / `HistoryProvider`                             | Implemented                                                      |
 | OpenTelemetry GenAI instrumentation                               | Implemented                                                      |
 | MCP client (tools)                                                | Implemented                                                      |

--- a/examples/02-foundry/05-invocations-agent/Dockerfile
+++ b/examples/02-foundry/05-invocations-agent/Dockerfile
@@ -1,0 +1,13 @@
+# The container contract: listen on 0.0.0.0:${PORT:-8088} and answer GET /readiness.
+FROM node:24-slim
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Build the self-contained ESM bundle before building this image.
+COPY dist/main.mjs ./main.mjs
+COPY dist/main.mjs.map ./main.mjs.map
+
+# Foundry probes this port; binding elsewhere makes every invocation fail with session_not_ready.
+EXPOSE 8088
+
+CMD ["node", "main.mjs"]

--- a/examples/02-foundry/05-invocations-agent/README.md
+++ b/examples/02-foundry/05-invocations-agent/README.md
@@ -1,0 +1,84 @@
+# Hosted Agent over the Invocations protocol (Microsoft Foundry)
+
+An agent built with `agent-framework-js`, published over the **Invocations protocol** and
+deployable to Microsoft Foundry. Use this protocol when your callers cannot speak the Responses
+request shape — a webhook, a custom client, non-conversational processing. For the
+OpenAI-compatible `/responses` endpoint, see [`../02-hosted-agent`](../02-hosted-agent).
+
+| File                  | What it is                                                                     |
+| --------------------- | ------------------------------------------------------------------------------ |
+| `main.ts`             | The agent, and the server that publishes it                                    |
+| `agent.yaml`          | The Foundry agent definition (`kind: hosted`, protocol declaration, resources) |
+| `agent.manifest.yaml` | The `azd` manifest: the model deployment this agent needs                      |
+| `Dockerfile`          | Copies the prebuilt bundle into `node:24-slim` and exposes port 8088           |
+| `tsdown.config.ts`    | Bundles the TypeScript host and all runtime dependencies into `dist/main.mjs`  |
+
+## Run it locally
+
+From the repository root:
+
+```bash
+pnpm install && pnpm -r build
+```
+
+With `az login` done and the project endpoint set, start the bundle:
+
+```bash
+FOUNDRY_PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project> AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini pnpm --filter example-02-foundry invocations
+```
+
+For source-level development without rebuilding the bundle after every edit, use
+`invocations:dev`. The server binds `0.0.0.0:8088` (override with `PORT`).
+
+### Check it
+
+Readiness — the probe the platform waits on before sending any traffic:
+
+```bash
+curl localhost:8088/readiness
+```
+
+A first turn — the request shape is `{ "message": string, "stream"?: boolean }`, and the answer
+comes back as plain text:
+
+```bash
+curl -sS -X POST localhost:8088/invocations -H 'content-type: application/json' -d '{"message": "My name is Alice."}'
+```
+
+The platform stores no conversation history for this protocol. To continue the conversation,
+take the `x-agent-session-id` response header and pass it back as the `agent_session_id` query
+parameter — hosted, that routes the turn to the same sandbox, whose memory holds the transcript:
+
+```bash
+curl -sS -X POST 'localhost:8088/invocations?agent_session_id=REPLACE_ME' -H 'content-type: application/json' -d '{"message": "What is my name?"}'
+```
+
+Stream instead of waiting:
+
+```bash
+curl -sS -N -X POST localhost:8088/invocations -H 'content-type: application/json' -d '{"message": "Hi", "stream": true}'
+```
+
+## Deploy it to Foundry
+
+The flow is the same as the Responses sample's — the manifest and CLI are protocol-agnostic. From
+this directory:
+
+```bash
+azd ext install azure.ai.agents
+azd ai agent init -m agent.manifest.yaml
+azd provision
+```
+
+Build the framework packages and the bundle from the repository root, then run locally against
+the provisioned project or deploy:
+
+```bash
+pnpm install --frozen-lockfile && pnpm -r build
+azd ai agent run   # local container, real credentials
+azd deploy
+```
+
+See [`../02-hosted-agent/README.md`](../02-hosted-agent/README.md) for the notes on deploying
+against an existing project — everything there applies, with `--protocol invocations` in place of
+`--protocol responses`.

--- a/examples/02-foundry/05-invocations-agent/agent.manifest.yaml
+++ b/examples/02-foundry/05-invocations-agent/agent.manifest.yaml
@@ -1,0 +1,9 @@
+# azd manifest: the resources `azd ai agent init` provisions for this agent.
+name: invocations-agent
+models:
+  - name: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}
+    format: OpenAI
+    version: '2024-07-18'
+    sku:
+      name: GlobalStandard
+      capacity: 30

--- a/examples/02-foundry/05-invocations-agent/agent.yaml
+++ b/examples/02-foundry/05-invocations-agent/agent.yaml
@@ -1,0 +1,21 @@
+# Foundry Hosted Agent definition.
+# Schema: microsoft/AgentSchema ContainerAgent.yaml
+kind: hosted
+name: invocations-agent
+description: An assistant built with agent-framework-js, served over the Invocations protocol.
+
+protocols:
+  # The container speaks Invocations container protocol 2.0.0 and nothing else. There is no
+  # version negotiation: this declaration is what makes the platform send
+  # `x-agent-foundry-call-id`, and the container fails closed with 501 if it ever arrives
+  # without one.
+  - protocol: invocations
+    version: 2.0.0
+
+resources:
+  cpu: '0.25'
+  memory: 0.5Gi
+
+environment_variables:
+  - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+    value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}

--- a/examples/02-foundry/05-invocations-agent/main.ts
+++ b/examples/02-foundry/05-invocations-agent/main.ts
@@ -1,0 +1,42 @@
+/**
+ * A Microsoft Foundry Hosted Agent on the Invocations protocol.
+ *
+ * `InvocationsHostServer` publishes the agent over `POST /invocations` — the protocol for callers
+ * that cannot speak the Responses request shape — and `serve` binds `0.0.0.0:${PORT:-8088}`, the
+ * address the platform's readiness probe expects.
+ *
+ * Locally:
+ *   pnpm --filter example-02-foundry build
+ *   pnpm --filter example-02-foundry invocations
+ *   curl -X POST localhost:8088/invocations -H 'content-type: application/json' -d '{"message":"Hi"}'
+ *
+ * On Foundry: see README.md.
+ */
+
+import { Agent } from '@polymind-inc/agent-framework';
+import { serve } from '@polymind-inc/agent-framework/agentserver/node';
+import { FoundryChatClient } from '@polymind-inc/agent-framework/foundry';
+import { InvocationsHostServer } from '@polymind-inc/agent-framework/foundry/hosting';
+
+const projectEndpoint = process.env.FOUNDRY_PROJECT_ENDPOINT;
+if (projectEndpoint === undefined) {
+  throw new Error('Set FOUNDRY_PROJECT_ENDPOINT to your Foundry project endpoint.');
+}
+
+const agent = new Agent({
+  client: new FoundryChatClient({
+    projectEndpoint,
+    target: { modelDeployment: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini' },
+  }),
+  name: 'invocations-agent',
+  instructions: 'You are a friendly assistant. Keep your answers brief.',
+});
+
+// The platform stores no conversation history for this protocol: the conversation lives in this
+// process, keyed by the session id. Callers keep a conversation going by pinning the
+// `agent_session_id` query parameter to the value the previous response's `x-agent-session-id`
+// header reported.
+const server = new InvocationsHostServer({ agent });
+
+const { port } = await serve(server);
+console.log(`listening on 0.0.0.0:${port}`);

--- a/examples/02-foundry/05-invocations-agent/tsdown.config.ts
+++ b/examples/02-foundry/05-invocations-agent/tsdown.config.ts
@@ -1,0 +1,23 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'tsdown';
+
+const sampleRoot = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  cwd: sampleRoot,
+  entry: ['main.ts'],
+  outDir: 'dist',
+  format: ['esm'],
+  platform: 'node',
+  target: 'es2024',
+  clean: true,
+  treeshake: true,
+  sourcemap: true,
+  dts: false,
+  outputOptions: { codeSplitting: false },
+  // This is an application bundle, not a library package. Include every dependency so the
+  // runtime image only needs the generated artifact and does not depend on the workspace tree.
+  deps: { alwaysBundle: [/.*/], onlyBundle: false },
+  outExtensions: () => ({ js: '.mjs' }),
+});

--- a/examples/02-foundry/package.json
+++ b/examples/02-foundry/package.json
@@ -7,12 +7,14 @@
     "node": ">=24"
   },
   "scripts": {
-    "build": "tsdown --config 02-hosted-agent/tsdown.config.ts",
+    "build": "tsdown --config 02-hosted-agent/tsdown.config.ts && tsdown --config 05-invocations-agent/tsdown.config.ts",
     "chat": "tsx 01-foundry-chat.ts",
     "host": "node 02-hosted-agent/dist/main.mjs",
     "host:dev": "tsx 02-hosted-agent/main.ts",
     "approval": "tsx 03-tool-approval.ts",
     "toolbox": "tsx 04-toolbox.ts",
+    "invocations": "node 05-invocations-agent/dist/main.mjs",
+    "invocations:dev": "tsx 05-invocations-agent/main.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,6 +33,7 @@ Foundry chat examples use Azure credentials from `DefaultAzureCredential`. Set
 | --- | --- | --- |
 | Foundry chat | Calling a model deployment through a Foundry project | `pnpm --filter example-02-foundry chat` |
 | Hosted Agent | Building and serving the Responses container protocol | `pnpm --filter example-02-foundry build`, then `pnpm --filter example-02-foundry host` |
+| Invocations Hosted Agent | Serving the same agent over the Invocations protocol | `pnpm --filter example-02-foundry build`, then `pnpm --filter example-02-foundry invocations` |
 | Tool approval | Pausing, persisting, approving, denying, and resuming locally | `pnpm --filter example-02-foundry approval` |
 | Foundry Toolbox | Calling tools exposed by a Foundry Toolbox MCP endpoint | `pnpm --filter example-02-foundry toolbox` |
 

--- a/packages/agentserver/README.md
+++ b/packages/agentserver/README.md
@@ -7,11 +7,21 @@
 > version. Installing this package directly works and resolves to the same modules, but examples
 > and documentation import through the main package.
 
-The Microsoft Foundry Responses container protocol v2.0.0, as a server. Independent of the
-Agent Framework: routing, SSE framing and sequence numbers, the lifecycle contract, id
-generation, the header contract, storage abstractions, and error shapes, exposed as a
-Web-standard fetch handler with a Node adapter on the `./node` subpath. The Agent Framework
-adapter lives in `@polymind-inc/agent-framework-foundry/hosting`.
+The Microsoft Foundry hosted-agent container protocols, as servers. Independent of the
+Agent Framework; the Agent Framework adapters live in
+`@polymind-inc/agent-framework-foundry/hosting`. Both are exposed as Web-standard fetch handlers
+with a Node adapter on the `./node` subpath:
+
+- **`ResponsesServer`** — the Responses container protocol v2.0.0: routing, SSE framing and
+  sequence numbers, the lifecycle contract, id generation, the header contract, storage
+  abstractions, and error shapes.
+- **`InvocationsServer`** — the Invocations protocol, for callers that cannot speak the Responses
+  request shape. The payload is deliberately unprescribed: the request body reaches the handler
+  unread, and the handler's `Response` — its body, status and content type — is what the caller
+  gets. This layer owns the routes (`POST /invocations`, `GET /invocations/{id}`,
+  `POST /invocations/{id}/cancel`, `/readiness`), invocation and session id resolution and their
+  response headers, cancellation, error classification, SSE keep-alive injection, and trace
+  propagation.
 
 ```sh
 npm install @polymind-inc/agent-framework-agentserver

--- a/packages/agentserver/package.json
+++ b/packages/agentserver/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polymind-inc/agent-framework-agentserver",
   "version": "0.2.2",
-  "description": "Microsoft Foundry Responses container protocol v2.0.0 server. Independent of the Agent Framework.",
+  "description": "Microsoft Foundry hosted-agent container protocol servers (Responses v2.0.0 and Invocations). Independent of the Agent Framework.",
   "keywords": [
     "agent",
     "ai",

--- a/packages/agentserver/src/config.ts
+++ b/packages/agentserver/src/config.ts
@@ -123,8 +123,8 @@ export function stateRoot(): string {
 export const PACKAGE_VERSION = '0.2.2';
 
 /** The `x-platform-server` value: which SDK, which protocol, which runtime. */
-export function serverIdentity(): string {
-  return `agent-framework-js/${PACKAGE_VERSION} protocol/responses-2.0.0 node/${process.versions.node}`;
+export function serverIdentity(protocol: string = 'responses-2.0.0'): string {
+  return `agent-framework-js/${PACKAGE_VERSION} protocol/${protocol} node/${process.versions.node}`;
 }
 
 // --- Telemetry (consumed by ./observability) ---

--- a/packages/agentserver/src/http.ts
+++ b/packages/agentserver/src/http.ts
@@ -1,0 +1,114 @@
+/**
+ * HTTP plumbing shared by every protocol server in this package.
+ *
+ * The Responses and Invocations servers answer different routes with different payloads, but the
+ * container contract they sit behind is one contract: the same correlation headers on every
+ * response, the same error envelope, the same prefix handling. Keeping the implementations here —
+ * rather than one copy per server — is what keeps the two protocols from drifting apart on the
+ * parts that must not differ.
+ */
+
+import { agentSessionId } from './config.js';
+import type { RequestContext } from './context.js';
+import { HEADERS } from './context.js';
+import type { ProtocolError } from './errors.js';
+import { badRequest, toHeaderValue } from './errors.js';
+
+/** A JSON body with the right content type. */
+export function jsonResponse(body: unknown, status: number, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+}
+
+/**
+ * Percent-decodes one path segment.
+ *
+ * A lone `%` makes `decodeURIComponent` throw a `URIError`, which would surface as an opaque 500
+ * for what is plainly a malformed request.
+ */
+export function decodeSegment(segment: string, param: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    throw badRequest('Malformed identifier.', { code: 'invalid_parameters', param });
+  }
+}
+
+/**
+ * Drops trailing `/` characters, scanning once from the end.
+ *
+ * Deliberately not `/\/+$/`: that pattern retries the run from every start position, so a request
+ * path made of slashes that does not end in one costs time quadratic in its length. The path comes
+ * off the wire, which makes the difference a denial-of-service lever rather than a micro-optimization.
+ */
+export function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 0x2f) {
+    end -= 1;
+  }
+  return end === value.length ? value : value.slice(0, end);
+}
+
+/**
+ * The part of `path` under `prefix`, or `undefined` when `path` is outside it.
+ *
+ * `startsWith` alone is not a prefix match: with `prefix = '/api'` it would also claim
+ * `/apiary/responses`. Only the whole segment counts. An empty prefix claims everything.
+ */
+export function stripPrefix(path: string, prefix: string): string | undefined {
+  if (prefix === '') {
+    return path;
+  }
+  if (path === prefix) {
+    return '/';
+  }
+  return path.startsWith(`${prefix}/`) ? path.slice(prefix.length) : undefined;
+}
+
+/** Adds the headers the platform expects on every response. */
+export function withStandardHeaders(
+  response: Response,
+  context: RequestContext,
+  serverVersion: string,
+): Response {
+  response.headers.set(HEADERS.requestId, context.requestId);
+  response.headers.set(HEADERS.serverVersion, serverVersion);
+  // Routes that resolved no session of their own report the container's, when the platform
+  // assigned one (Python `_session_headers`).
+  const ambient = agentSessionId();
+  if (ambient !== undefined && !response.headers.has(HEADERS.sessionId)) {
+    response.headers.set(HEADERS.sessionId, ambient);
+  }
+  return response;
+}
+
+/** Renders a {@link ProtocolError} as the wire envelope, with diagnostics kept out of the body. */
+export function errorResponse(
+  error: ProtocolError,
+  context: RequestContext,
+  serverVersion: string,
+  extraHeaders: Record<string, string> = {},
+): Response {
+  const headers: Record<string, string> = {
+    [HEADERS.requestId]: context.requestId,
+    [HEADERS.serverVersion]: serverVersion,
+    [HEADERS.errorSource]: error.source,
+  };
+  // Only a `platform`-source error carries its diagnostics on the header — user and upstream
+  // failures are not the platform's to explain (Python `error_response`, .NET
+  // `ResponsesExceptionFilter` both gate the detail header the same way).
+  if (error.detail !== undefined && error.source === 'platform') {
+    headers[HEADERS.errorDetail] = toHeaderValue(error.detail);
+  }
+  if (error.allow !== undefined) {
+    headers.allow = error.allow;
+  }
+  const ambient = agentSessionId();
+  if (ambient !== undefined) {
+    headers[HEADERS.sessionId] = ambient;
+  }
+  Object.assign(headers, extraHeaders);
+  return jsonResponse(error.toResponse(context.requestId), error.status, headers);
+}

--- a/packages/agentserver/src/index.ts
+++ b/packages/agentserver/src/index.ts
@@ -36,6 +36,12 @@ export {
 } from './errors.js';
 export { ID_PREFIX, invalidIdReason, isValidId, newId, newResponseId, partitionKeyOf } from './ids.js';
 export type {
+  InvocationContext,
+  InvocationHandler,
+  InvocationsServerConfig,
+} from './invocations.js';
+export { INVOCATION_ID_HEADER, InvocationsServer } from './invocations.js';
+export type {
   AgentReference,
   ApiError,
   ApiErrorDetail,

--- a/packages/agentserver/src/invocations.test.ts
+++ b/packages/agentserver/src/invocations.test.ts
@@ -562,6 +562,67 @@ describe('SSE keep-alive', () => {
     }
   });
 
+  it('delivers the payload intact after many consecutive keep-alives', async () => {
+    // Hours of silence mean many intervals against one still-pending read; the wait must resolve
+    // through the read's single observer every time, and the eventual chunk must still arrive.
+    vi.stubEnv('SSE_KEEPALIVE_INTERVAL', '1');
+    vi.useFakeTimers();
+    try {
+      const gate = deferred<void>();
+      const server = makeServer({ handler: sseHandler(gate.promise) });
+      const response = await server.handle(invoke());
+      const reader = must(response.body).getReader();
+      const decoder = new TextDecoder();
+
+      expect(decoder.decode((await reader.read()).value)).toBe('data: first\n\n');
+
+      for (let interval = 0; interval < 5; interval += 1) {
+        const next = reader.read();
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(decoder.decode((await next).value), `interval ${interval}`).toBe(': keep-alive\n\n');
+      }
+
+      gate.resolve();
+      expect(decoder.decode((await reader.read()).value)).toBe('data: second\n\n');
+      expect((await reader.read()).done).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('propagates a stream failure that lands after keep-alives', async () => {
+    vi.stubEnv('SSE_KEEPALIVE_INTERVAL', '1');
+    vi.useFakeTimers();
+    try {
+      const gate = deferred<void>();
+      const server = makeServer({
+        handler: () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              async start(controller): Promise<void> {
+                controller.enqueue(new TextEncoder().encode('data: first\n\n'));
+                await gate.promise;
+                controller.error(new Error('source broke'));
+              },
+            }),
+            { headers: { 'content-type': 'text/event-stream' } },
+          ),
+      });
+      const response = await server.handle(invoke());
+      const reader = must(response.body).getReader();
+
+      await reader.read();
+      const next = reader.read();
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(new TextDecoder().decode((await next).value)).toBe(': keep-alive\n\n');
+
+      gate.resolve();
+      await expect(reader.read()).rejects.toThrow('source broke');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('never injects comments into a non-SSE stream', async () => {
     vi.stubEnv('SSE_KEEPALIVE_INTERVAL', '1');
     vi.useFakeTimers();

--- a/packages/agentserver/src/invocations.test.ts
+++ b/packages/agentserver/src/invocations.test.ts
@@ -1,0 +1,536 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRequestContext, HEADERS } from './context.js';
+import { badRequest, ProtocolError } from './errors.js';
+import type { InvocationHandler, InvocationsServerConfig } from './invocations.js';
+import { INVOCATION_ID_HEADER, InvocationsServer } from './invocations.js';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/** Echoes the raw request body back, with the invocation identity in a JSON envelope. */
+function echoHandler(): InvocationHandler {
+  return async (request, context) =>
+    new Response(
+      JSON.stringify({
+        invocationId: context.invocationId,
+        sessionId: context.sessionId,
+        body: await request.text(),
+      }),
+      { headers: { 'content-type': 'application/json' } },
+    );
+}
+
+function makeServer(overrides: Partial<InvocationsServerConfig> = {}): InvocationsServer {
+  return new InvocationsServer({ handler: echoHandler(), ...overrides });
+}
+
+function invoke(body: string | null = 'hello', headers: Record<string, string> = {}, query = ''): Request {
+  return new Request(`http://localhost:8088/invocations${query}`, {
+    method: 'POST',
+    headers,
+    ...(body === null ? {} : { body }),
+  });
+}
+
+async function json(response: Response): Promise<Record<string, unknown>> {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+function errorCodeOf(payload: Record<string, unknown>): string {
+  return (payload.error as { code: string }).code;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('routes', () => {
+  it('answers the readiness probe', async () => {
+    const response = await makeServer().handle(new Request('http://localhost:8088/readiness'));
+    expect(response.status).toBe(200);
+    expect(await json(response)).toEqual({ status: 'healthy' });
+  });
+
+  it('dispatches POST /invocations to the handler with the body unread', async () => {
+    // Not JSON on purpose: the protocol layer must pass the payload through unparsed.
+    const response = await makeServer().handle(
+      invoke('this is { not json', { 'content-type': 'text/plain' }),
+    );
+    expect(response.status).toBe(200);
+    expect((await json(response)).body).toBe('this is { not json');
+  });
+
+  it('preserves the handler-chosen status and content type', async () => {
+    const server = makeServer({
+      handler: () => new Response('accepted', { status: 202, headers: { 'content-type': 'text/plain' } }),
+    });
+    const response = await server.handle(invoke());
+    expect(response.status).toBe(202);
+    expect(response.headers.get('content-type')).toBe('text/plain');
+    expect(await response.text()).toBe('accepted');
+  });
+
+  it('passes a handler response with no body through', async () => {
+    const server = makeServer({ handler: () => new Response(null, { status: 204 }) });
+    const response = await server.handle(invoke());
+    expect(response.status).toBe(204);
+    expect(response.body).toBeNull();
+  });
+
+  it('answers 405 for a GET on the invoke route', async () => {
+    const response = await makeServer().handle(new Request('http://localhost:8088/invocations'));
+    expect(response.status).toBe(405);
+    expect(response.headers.get('allow')).toBe('POST');
+  });
+
+  it('answers 404 for the read route until a handler is registered', async () => {
+    const response = await makeServer().handle(new Request('http://localhost:8088/invocations/inv_1'));
+    expect(response.status).toBe(404);
+    expect(errorCodeOf(await json(response))).toBe('not_found');
+    // Application code is what is missing, not platform plumbing.
+    expect(response.headers.get(HEADERS.errorSource)).toBe('upstream');
+  });
+
+  it('answers 404 for the cancel route until a handler is registered', async () => {
+    const response = await makeServer().handle(
+      new Request('http://localhost:8088/invocations/inv_1/cancel', { method: 'POST' }),
+    );
+    expect(response.status).toBe(404);
+    expect(errorCodeOf(await json(response))).toBe('not_found');
+  });
+
+  it('dispatches the read route with the path id', async () => {
+    const server = makeServer({
+      getHandler: (_request, context) => new Response(JSON.stringify({ id: context.invocationId })),
+    });
+    const response = await server.handle(new Request('http://localhost:8088/invocations/inv_42'));
+    expect(response.status).toBe(200);
+    expect((await json(response)).id).toBe('inv_42');
+    expect(response.headers.get(INVOCATION_ID_HEADER)).toBe('inv_42');
+  });
+
+  it('dispatches the cancel route and refuses other verbs on it', async () => {
+    const server = makeServer({
+      cancelHandler: (_request, context) => new Response(JSON.stringify({ cancelled: context.invocationId })),
+    });
+    const ok = await server.handle(
+      new Request('http://localhost:8088/invocations/inv_9/cancel', { method: 'POST' }),
+    );
+    expect((await json(ok)).cancelled).toBe('inv_9');
+
+    const wrongVerb = await server.handle(new Request('http://localhost:8088/invocations/inv_9/cancel'));
+    expect(wrongVerb.status).toBe(405);
+    expect(wrongVerb.headers.get('allow')).toBe('POST');
+  });
+
+  it('refuses a GET id route reached with POST', async () => {
+    const response = await makeServer({ getHandler: echoHandler() }).handle(
+      new Request('http://localhost:8088/invocations/inv_1', { method: 'POST' }),
+    );
+    expect(response.status).toBe(405);
+    expect(response.headers.get('allow')).toBe('GET');
+  });
+
+  it('answers 404 for paths outside the protocol and below the known routes', async () => {
+    const server = makeServer({ cancelHandler: echoHandler() });
+    for (const path of ['/responses', '/invocations/inv_1/cancel/extra', '/invocations/inv_1/other']) {
+      const response = await server.handle(new Request(`http://localhost:8088${path}`, { method: 'POST' }));
+      expect(response.status, path).toBe(404);
+    }
+  });
+
+  it('mounts under a prefix without claiming sibling paths', async () => {
+    const server = makeServer({ prefix: '/api' });
+    const mounted = await server.handle(
+      new Request('http://localhost:8088/api/invocations', { method: 'POST', body: 'x' }),
+    );
+    expect(mounted.status).toBe(200);
+
+    const sibling = await server.handle(
+      new Request('http://localhost:8088/apiary/invocations', { method: 'POST', body: 'x' }),
+    );
+    expect(sibling.status).toBe(404);
+
+    const bare = await server.handle(new Request('http://localhost:8088/invocations', { method: 'POST' }));
+    expect(bare.status).toBe(404);
+  });
+});
+
+describe('invocation id', () => {
+  it('echoes a valid x-agent-invocation-id on the response and to the handler', async () => {
+    const response = await makeServer().handle(invoke('x', { [INVOCATION_ID_HEADER]: 'inv_abc.1:2' }));
+    expect(response.headers.get(INVOCATION_ID_HEADER)).toBe('inv_abc.1:2');
+    expect((await json(response)).invocationId).toBe('inv_abc.1:2');
+  });
+
+  it.each([
+    ['empty', ''],
+    ['illegal characters', 'inv id with spaces'],
+    ['overlong', 'a'.repeat(257)],
+  ])('replaces an invalid header (%s) with a generated UUID', async (_name, value) => {
+    const response = await makeServer().handle(invoke('x', { [INVOCATION_ID_HEADER]: value }));
+    expect(must(response.headers.get(INVOCATION_ID_HEADER))).toMatch(UUID);
+  });
+
+  it('generates a UUID when the header is absent', async () => {
+    const response = await makeServer().handle(invoke());
+    expect(must(response.headers.get(INVOCATION_ID_HEADER))).toMatch(UUID);
+  });
+
+  it('overrides an invocation id header the handler set itself', async () => {
+    const server = makeServer({
+      handler: () => new Response('x', { headers: { [INVOCATION_ID_HEADER]: 'handler-forged' } }),
+    });
+    const response = await server.handle(invoke('x', { [INVOCATION_ID_HEADER]: 'inv_real' }));
+    expect(response.headers.get(INVOCATION_ID_HEADER)).toBe('inv_real');
+  });
+});
+
+describe('session id', () => {
+  it('prefers the agent_session_id query parameter', async () => {
+    vi.stubEnv('FOUNDRY_AGENT_SESSION_ID', 'env-session');
+    const response = await makeServer().handle(invoke('x', {}, '?agent_session_id=query-session'));
+    expect(response.headers.get(HEADERS.sessionId)).toBe('query-session');
+    expect((await json(response)).sessionId).toBe('query-session');
+  });
+
+  it('falls back to FOUNDRY_AGENT_SESSION_ID', async () => {
+    vi.stubEnv('FOUNDRY_AGENT_SESSION_ID', 'env-session');
+    const response = await makeServer().handle(invoke());
+    expect(response.headers.get(HEADERS.sessionId)).toBe('env-session');
+  });
+
+  it('generates a UUID when neither the query nor the environment names one', async () => {
+    const response = await makeServer().handle(invoke());
+    expect(must(response.headers.get(HEADERS.sessionId))).toMatch(UUID);
+  });
+
+  it('ignores an invalid query value rather than propagating it', async () => {
+    vi.stubEnv('FOUNDRY_AGENT_SESSION_ID', 'env-session');
+    const response = await makeServer().handle(invoke('x', {}, `?agent_session_id=${'a'.repeat(300)}`));
+    expect(response.headers.get(HEADERS.sessionId)).toBe('env-session');
+  });
+
+  it('resolves the session for the read and cancel routes by the same rule', async () => {
+    const server = makeServer({
+      getHandler: (_request, context) => new Response(context.sessionId),
+    });
+    const response = await server.handle(
+      new Request('http://localhost:8088/invocations/inv_1?agent_session_id=pinned'),
+    );
+    expect(await response.text()).toBe('pinned');
+    expect(response.headers.get(HEADERS.sessionId)).toBe('pinned');
+  });
+});
+
+describe('header contract', () => {
+  it('echoes x-request-id and reports the invocations protocol on x-platform-server', async () => {
+    const response = await makeServer().handle(invoke('x', { [HEADERS.requestId]: 'req-1' }));
+    expect(response.headers.get(HEADERS.requestId)).toBe('req-1');
+    expect(must(response.headers.get(HEADERS.serverVersion))).toContain('protocol/invocations-2.0.0');
+  });
+
+  it('generates a request id when the caller sent none', async () => {
+    const response = await makeServer().handle(invoke());
+    expect(must(response.headers.get(HEADERS.requestId))).toMatch(UUID);
+  });
+
+  it('hands the platform identity to the handler through the request context', async () => {
+    const server = makeServer({
+      handler: (_request, context) =>
+        new Response(
+          JSON.stringify({
+            userId: context.request.userId,
+            callId: context.request.foundryCallId,
+            outbound: context.request.platformHeaders(),
+          }),
+        ),
+    });
+    const response = await server.handle(
+      invoke('x', { [HEADERS.userId]: 'user-1', [HEADERS.foundryCallId]: 'call-1' }),
+    );
+    const body = await json(response);
+    expect(body.userId).toBe('user-1');
+    expect(body.callId).toBe('call-1');
+    // The user id never appears among the outbound platform headers.
+    expect(body.outbound).toEqual({ [HEADERS.foundryCallId]: 'call-1' });
+  });
+
+  it('keeps the ambient request context available to the handler', async () => {
+    const server = makeServer({
+      handler: () => new Response(getRequestContext()?.foundryCallId ?? 'missing'),
+    });
+    const response = await server.handle(invoke('x', { [HEADERS.foundryCallId]: 'call-9' }));
+    expect(await response.text()).toBe('call-9');
+  });
+
+  it('keeps the request context across the pulls of a streamed body', async () => {
+    // The socket writer consumes the body long after the request scope closed. The first pull of
+    // the handler's stream runs eagerly inside that scope; the second is consumer-driven, so this
+    // pins the outcome — a late pull still sees the turn's platform headers — whichever layer
+    // (the wrapper's re-entry, or the stream's own creation-scope propagation) provides it.
+    let pulls = 0;
+    const server = makeServer({
+      handler: () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller): void {
+              pulls += 1;
+              controller.enqueue(
+                new TextEncoder().encode(`${pulls}:${getRequestContext()?.foundryCallId ?? 'missing'};`),
+              );
+              if (pulls === 2) {
+                controller.close();
+              }
+            },
+          }),
+        ),
+    });
+    const response = await server.handle(invoke('x', { [HEADERS.foundryCallId]: 'call-7' }));
+    expect(await response.text()).toBe('1:call-7;2:call-7;');
+  });
+});
+
+describe('errors', () => {
+  it('answers a handler exception with an opaque 500 classified upstream', async () => {
+    const server = makeServer({
+      handler: () => {
+        throw new Error('the connection string is secret-42');
+      },
+    });
+    const response = await server.handle(invoke());
+    expect(response.status).toBe(500);
+    const body = await json(response);
+    expect((body.error as { message: string }).message).toBe('internal server error');
+    expect(JSON.stringify(body)).not.toContain('secret-42');
+    expect(response.headers.get(HEADERS.errorSource)).toBe('upstream');
+    // Diagnostics stay off the wire for upstream failures.
+    expect(response.headers.get(HEADERS.errorDetail)).toBeNull();
+  });
+
+  it('answers a rejected handler promise the same way', async () => {
+    const server = makeServer({ handler: () => Promise.reject(new Error('boom')) });
+    const response = await server.handle(invoke());
+    expect(response.status).toBe(500);
+    expect(response.headers.get(HEADERS.errorSource)).toBe('upstream');
+  });
+
+  it('lets a handler-thrown ProtocolError shape the response', async () => {
+    const server = makeServer({
+      handler: () => {
+        throw badRequest('message is required', { param: 'message' });
+      },
+    });
+    const response = await server.handle(invoke());
+    expect(response.status).toBe(400);
+    expect(errorCodeOf(await json(response))).toBe('invalid_request');
+    expect(response.headers.get(HEADERS.errorSource)).toBe('user');
+  });
+
+  it('carries diagnostics on the detail header for platform-source errors only', async () => {
+    const server = makeServer({
+      handler: () => {
+        throw new ProtocolError(500, 'internal server error', {
+          code: 'server_error',
+          type: 'server_error',
+          source: 'platform',
+          detail: 'stage: session restore',
+        });
+      },
+    });
+    const response = await server.handle(invoke());
+    expect(response.headers.get(HEADERS.errorDetail)).toBe('stage: session restore');
+  });
+
+  it('stamps the resolved invocation identity on error responses too', async () => {
+    const server = makeServer({
+      handler: () => {
+        throw new Error('boom');
+      },
+    });
+    const response = await server.handle(
+      invoke('x', { [INVOCATION_ID_HEADER]: 'inv_fail' }, '?agent_session_id=sess_fail'),
+    );
+    expect(response.headers.get(INVOCATION_ID_HEADER)).toBe('inv_fail');
+    expect(response.headers.get(HEADERS.sessionId)).toBe('sess_fail');
+  });
+});
+
+describe('draining', () => {
+  it('refuses new invocations with 503 while the readiness probe keeps answering', async () => {
+    const server = makeServer();
+    await server.drain();
+
+    const refused = await server.handle(invoke());
+    expect(refused.status).toBe(503);
+
+    const probe = await server.handle(new Request('http://localhost:8088/readiness'));
+    expect(probe.status).toBe(200);
+  });
+});
+
+describe('cancellation', () => {
+  it('aborts the handler when the caller disconnects', async () => {
+    const aborted = deferred<void>();
+    const server = makeServer({
+      handler: async (_request, context) => {
+        if (context.signal.aborted) {
+          aborted.resolve();
+        } else {
+          context.signal.addEventListener('abort', () => aborted.resolve(), { once: true });
+        }
+        await aborted.promise;
+        return new Response('wound down');
+      },
+    });
+
+    const controller = new AbortController();
+    const pending = server.handle(
+      new Request('http://localhost:8088/invocations', {
+        method: 'POST',
+        body: 'x',
+        signal: controller.signal,
+      }),
+    );
+    controller.abort();
+    const response = await pending;
+    expect(await response.text()).toBe('wound down');
+  });
+
+  it('aborts in-flight handlers when the server drains', async () => {
+    const entered = deferred<void>();
+    const aborted = deferred<void>();
+    const server = makeServer({
+      handler: async (_request, context) => {
+        context.signal.addEventListener('abort', () => aborted.resolve(), { once: true });
+        entered.resolve();
+        await aborted.promise;
+        return new Response('stopped');
+      },
+    });
+
+    const pending = server.handle(invoke());
+    await entered.promise;
+    await server.drain();
+    expect(await (await pending).text()).toBe('stopped');
+  });
+
+  it('hands an already-aborted request signal to the handler as aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let observed: boolean | undefined;
+    const server = makeServer({
+      handler: (_request, context) => {
+        observed = context.signal.aborted;
+        return new Response('x');
+      },
+    });
+    await server.handle(
+      new Request('http://localhost:8088/invocations', {
+        method: 'POST',
+        body: 'x',
+        signal: controller.signal,
+      }),
+    );
+    expect(observed).toBe(true);
+  });
+});
+
+describe('SSE keep-alive', () => {
+  function sseHandler(gate: Promise<void>): InvocationHandler {
+    return () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          async start(controller): Promise<void> {
+            controller.enqueue(new TextEncoder().encode('data: first\n\n'));
+            await gate;
+            controller.enqueue(new TextEncoder().encode('data: second\n\n'));
+            controller.close();
+          },
+        }),
+        { headers: { 'content-type': 'text/event-stream' } },
+      );
+  }
+
+  it('stays silent by default', async () => {
+    const gate = deferred<void>();
+    const server = makeServer({ handler: sseHandler(gate.promise) });
+    const pending = server.handle(invoke());
+    setTimeout(() => gate.resolve(), 50);
+    const text = await (await pending).text();
+    expect(text).not.toContain(': keep-alive');
+  });
+
+  it('injects keep-alive comments into a silent text/event-stream body', async () => {
+    vi.stubEnv('SSE_KEEPALIVE_INTERVAL', '1');
+    vi.useFakeTimers();
+    try {
+      const gate = deferred<void>();
+      const server = makeServer({ handler: sseHandler(gate.promise) });
+      const response = await server.handle(invoke());
+      const reader = must(response.body).getReader();
+      const decoder = new TextDecoder();
+
+      expect(decoder.decode((await reader.read()).value)).toBe('data: first\n\n');
+
+      // One interval of silence: the wrapper speaks so the proxies stay convinced.
+      const second = reader.read();
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(decoder.decode((await second).value)).toBe(': keep-alive\n\n');
+
+      gate.resolve();
+      expect(decoder.decode((await reader.read()).value)).toBe('data: second\n\n');
+      expect((await reader.read()).done).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('never injects comments into a non-SSE stream', async () => {
+    vi.stubEnv('SSE_KEEPALIVE_INTERVAL', '1');
+    vi.useFakeTimers();
+    try {
+      const gate = deferred<void>();
+      const server = makeServer({
+        handler: () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              async start(controller): Promise<void> {
+                controller.enqueue(new TextEncoder().encode('{"part":1}\n'));
+                await gate.promise;
+                controller.enqueue(new TextEncoder().encode('{"part":2}\n'));
+                controller.close();
+              },
+            }),
+            { headers: { 'content-type': 'application/x-ndjson' } },
+          ),
+      });
+      const response = await server.handle(invoke());
+      const reader = must(response.body).getReader();
+      const decoder = new TextDecoder();
+
+      expect(decoder.decode((await reader.read()).value)).toBe('{"part":1}\n');
+      const second = reader.read();
+      await vi.advanceTimersByTimeAsync(5000);
+      gate.resolve();
+      // The next chunk is the payload itself — no comment was interleaved during the silence.
+      expect(decoder.decode((await second).value)).toBe('{"part":2}\n');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+/** A promise with its `resolve` in hand. */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void } {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/** Narrows away null/undefined; a missing value fails the test with a clear error. */
+function must<T>(value: T | null | undefined): T {
+  if (value == null) throw new Error('expected a value');
+  return value;
+}

--- a/packages/agentserver/src/invocations.test.ts
+++ b/packages/agentserver/src/invocations.test.ts
@@ -138,6 +138,57 @@ describe('routes', () => {
     }
   });
 
+  it('rejects lookalike paths that only share the prefix', async () => {
+    // `/invocationsfoo` must never alias `/invocations/foo`: with handlers registered on every
+    // route, each of these still falls outside the protocol.
+    const server = makeServer({ getHandler: echoHandler(), cancelHandler: echoHandler() });
+    const cases: Array<[string, string]> = [
+      ['GET', '/invocationsfoo'],
+      ['POST', '/invocationsfoo'],
+      ['POST', '/invocationsfoo/cancel'],
+    ];
+    for (const [method, path] of cases) {
+      const response = await server.handle(
+        new Request(`http://localhost:8088${path}`, {
+          method,
+          ...(method === 'POST' ? { body: 'x' } : {}),
+        }),
+      );
+      expect(response.status, `${method} ${path}`).toBe(404);
+    }
+  });
+
+  it('answers a unicode path id without crashing, degrading only the header echo', async () => {
+    const server = makeServer({ getHandler: (_request, context) => new Response(context.invocationId) });
+    const response = await server.handle(new Request('http://localhost:8088/invocations/%E2%98%83'));
+    expect(response.status).toBe(200);
+    // The handler still sees the id as the caller sent it; only the header echo degrades to a
+    // representable approximation instead of crashing the response.
+    expect(await response.text()).toBe('☃');
+    expect(response.headers.get(INVOCATION_ID_HEADER)).toBe('?');
+  });
+
+  it.each([
+    ['read', 'GET', ''],
+    ['cancel', 'POST', '/cancel'],
+  ])(
+    'stamps the resolved identity on the 404 for an unregistered %s route',
+    async (_name, method, suffix) => {
+      const response = await makeServer().handle(
+        new Request(`http://localhost:8088/invocations/inv_404${suffix}?agent_session_id=pin`, { method }),
+      );
+      expect(response.status).toBe(404);
+      expect(response.headers.get(INVOCATION_ID_HEADER)).toBe('inv_404');
+      expect(response.headers.get(HEADERS.sessionId)).toBe('pin');
+    },
+  );
+
+  it('generates the session id echoed on an unregistered-route 404 when nothing names one', async () => {
+    const response = await makeServer().handle(new Request('http://localhost:8088/invocations/inv_404'));
+    expect(response.status).toBe(404);
+    expect(must(response.headers.get(HEADERS.sessionId))).toMatch(UUID);
+  });
+
   it('mounts under a prefix without claiming sibling paths', async () => {
     const server = makeServer({ prefix: '/api' });
     const mounted = await server.handle(
@@ -287,6 +338,32 @@ describe('header contract', () => {
     });
     const response = await server.handle(invoke('x', { [HEADERS.foundryCallId]: 'call-7' }));
     expect(await response.text()).toBe('1:call-7;2:call-7;');
+  });
+});
+
+describe('body cancellation', () => {
+  it('keeps the request context for the upstream cancel when the caller abandons the body', async () => {
+    // A consumer cancels the body from outside every ambient scope; the handler's own stream
+    // teardown must still see the turn's request context.
+    let observed: string | undefined | null = null;
+    const server = makeServer({
+      handler: () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller): void {
+              controller.enqueue(new TextEncoder().encode('first'));
+            },
+            cancel(): void {
+              observed = getRequestContext()?.requestId;
+            },
+          }),
+        ),
+    });
+    const response = await server.handle(invoke('x', { [HEADERS.requestId]: 'req-cancel' }));
+    const reader = must(response.body).getReader();
+    await reader.read();
+    await reader.cancel('abandoned');
+    expect(observed).toBe('req-cancel');
   });
 });
 

--- a/packages/agentserver/src/invocations.ts
+++ b/packages/agentserver/src/invocations.ts
@@ -1,0 +1,462 @@
+import { context as otelContext } from '@opentelemetry/api';
+import { agentSessionId, serverIdentity, sseKeepAliveSeconds } from './config.js';
+import type { RequestContext } from './context.js';
+import { createRequestContext, HEADERS, runWithRequestContext } from './context.js';
+import {
+  methodNotAllowed,
+  ProtocolError,
+  routeNotFound,
+  toHeaderValue,
+  toProtocolError,
+  unavailable,
+  upstreamError,
+} from './errors.js';
+import {
+  decodeSegment,
+  errorResponse,
+  jsonResponse,
+  stripPrefix,
+  trimTrailingSlashes,
+  withStandardHeaders,
+} from './http.js';
+import { flushTelemetry } from './observability/flush.js';
+import { extractTraceContext, withInvocationBaggage } from './observability/trace-context.js';
+import { SSE_KEEPALIVE } from './sse.js';
+
+/**
+ * The header carrying the caller's invocation id, echoed back on every response.
+ *
+ * Local to this protocol rather than part of {@link HEADERS}: the shared table is the container
+ * contract every protocol answers, and this header exists only for `/invocations` (both
+ * references keep the constant inside their Invocations package for the same reason).
+ */
+export const INVOCATION_ID_HEADER = 'x-agent-invocation-id';
+
+/** The protocol identifier reported on `x-platform-server`. */
+const PROTOCOL = 'invocations-2.0.0';
+
+/** One chunk read from a handler's body stream. */
+type ReadResult = Awaited<ReturnType<ReadableStreamDefaultReader<Uint8Array>['read']>>;
+
+/**
+ * The bound the references sanitize ids against: at most 256 characters of `[A-Za-z0-9._:-]`.
+ *
+ * A value that fails is replaced, not rejected — the id is diagnostic, and refusing the request
+ * over it would turn a cosmetic problem into an outage (Python `_sanitize_id`).
+ */
+const MAX_ID_LENGTH = 256;
+const VALID_ID = /^[A-Za-z0-9._:-]+$/;
+
+function sanitizeId(value: string | null): string | undefined {
+  if (value === null || value === '' || value.length > MAX_ID_LENGTH || !VALID_ID.test(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * The session id for one invocation: the `agent_session_id` query parameter, then the
+ * platform-assigned `FOUNDRY_AGENT_SESSION_ID`, then a fresh UUID.
+ *
+ * The query parameter is caller-supplied and sanitized; the environment variable is
+ * platform-injected and trusted as-is, like every other platform header. The references disagree
+ * on the read routes — .NET ignores the query there where Python honours it — and this
+ * implementation applies one rule everywhere: a caller that pins its session on the create is
+ * answered consistently when it pins the same session on a read.
+ */
+function resolveInvocationSessionId(url: URL): string {
+  return sanitizeId(url.searchParams.get('agent_session_id')) ?? agentSessionId() ?? crypto.randomUUID();
+}
+
+/** What the server resolved for the turn, echoed on the response — including an error response. */
+interface TurnIdentity {
+  invocationId?: string;
+  sessionId?: string;
+  /** Whether the turn's body was wrapped, making the wrapper the one that flushes telemetry. */
+  streamed?: boolean;
+}
+
+function turnHeaders(turn: TurnIdentity): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (turn.invocationId !== undefined) {
+    // `toHeaderValue` because a GET's invocation id comes straight off the path: the references
+    // echo it unvalidated, and a value `Headers.set` cannot represent must degrade to a readable
+    // approximation rather than crash the response that reports it.
+    headers[INVOCATION_ID_HEADER] = toHeaderValue(turn.invocationId);
+  }
+  if (turn.sessionId !== undefined) {
+    headers[HEADERS.sessionId] = toHeaderValue(turn.sessionId);
+  }
+  return headers;
+}
+
+/** What an {@link InvocationHandler} is told about the request it is answering. */
+export interface InvocationContext {
+  /**
+   * The invocation's id.
+   *
+   * On `POST /invocations`: the sanitized `x-agent-invocation-id` header, or a generated UUID.
+   * On the read and cancel routes: the id from the path, as the caller sent it.
+   */
+  readonly invocationId: string;
+  /** The resolved session id; see the resolution order on {@link InvocationsServer}. */
+  readonly sessionId: string;
+  /** The platform identity and correlation headers, also ambient via `getRequestContext()`. */
+  readonly request: RequestContext;
+  /**
+   * Aborted when the caller disconnects or the container starts shutting down.
+   *
+   * The only cancellation this layer wires up: there is no request timeout (the reference removed
+   * one deliberately), and the cancel route runs the registered handler rather than aborting
+   * anything itself.
+   */
+  readonly signal: AbortSignal;
+}
+
+/**
+ * Answers one invocation. The request body, the response body, its status and its content type
+ * are all the handler's to choose — the protocol prescribes none of them.
+ */
+export type InvocationHandler = (
+  request: Request,
+  context: InvocationContext,
+) => Response | Promise<Response>;
+
+/** Construction options for {@link InvocationsServer}. */
+export interface InvocationsServerConfig {
+  /** Answers `POST /invocations`. Required — a server with nothing to invoke serves nothing. */
+  handler: InvocationHandler;
+  /** Answers `GET /invocations/{id}`. Absent, the route is a 404, as in the references. */
+  getHandler?: InvocationHandler;
+  /** Answers `POST /invocations/{id}/cancel`. Absent, the route is a 404, as in the references. */
+  cancelHandler?: InvocationHandler;
+  /** Mounts the routes under a path prefix. Defaults to none, the hosted layout. */
+  prefix?: string;
+}
+
+/**
+ * A Foundry Invocations protocol server.
+ *
+ * The counterpart of {@link ResponsesServer} for the `/invocations` contract: where Responses
+ * prescribes the payload, the execution modes and the event stream, Invocations prescribes only
+ * the routes and the headers. The body is passed to the handler unread, and whatever `Response`
+ * the handler returns is what the caller gets — this layer adds the platform's correlation
+ * headers, propagates cancellation and trace context, and injects SSE keep-alives when the
+ * handler streams `text/event-stream` and `SSE_KEEPALIVE_INTERVAL` asks for them.
+ *
+ * Routes: `POST /invocations`, `GET /invocations/{id}`, `POST /invocations/{id}/cancel`, and
+ * `GET /readiness`. The read and cancel routes answer 404 until their handlers are registered;
+ * the platform does not require them.
+ *
+ * ## Security considerations
+ *
+ * - **Inbound requests are not authenticated here.** The Foundry gateway is the authorization
+ *   boundary, exactly as for {@link ResponsesServer}.
+ * - **Handler exceptions are opaque to the caller.** A 500 body says only `internal server
+ *   error`, classified `upstream` on `x-platform-error-source`.
+ * - **`x-agent-user-id` never leaves.** See {@link RequestContext.platformHeaders}.
+ */
+export class InvocationsServer {
+  readonly #handler: InvocationHandler;
+  readonly #getHandler: InvocationHandler | undefined;
+  readonly #cancelHandler: InvocationHandler | undefined;
+  readonly #prefix: string;
+  readonly #shutdown = new AbortController();
+  #draining = false;
+
+  constructor(options: InvocationsServerConfig) {
+    this.#handler = options.handler;
+    this.#getHandler = options.getHandler;
+    this.#cancelHandler = options.cancelHandler;
+    this.#prefix = trimTrailingSlashes(options.prefix ?? '');
+  }
+
+  /**
+   * Refuses new work and aborts the signal every in-flight handler holds.
+   *
+   * Resolved immediately: an invocation has no detached execution — every turn lives inside its
+   * HTTP request, and the Node adapter's shutdown already waits for open connections to finish.
+   */
+  drain(): Promise<void> {
+    this.#draining = true;
+    this.#shutdown.abort();
+    return Promise.resolve();
+  }
+
+  /** The `fetch` handler. */
+  get fetch(): (request: Request) => Promise<Response> {
+    return (request) => this.handle(request);
+  }
+
+  /** Routes and answers one request. */
+  async handle(request: Request): Promise<Response> {
+    const context = createRequestContext(request.headers);
+    const turn: TurnIdentity = {};
+    try {
+      // The caller's W3C trace context becomes the ambient OTel context for the turn, so the
+      // handler's spans parent under the calling service's trace. No server span — the
+      // references dropped theirs deliberately.
+      const response = await otelContext.with(extractTraceContext(request.headers), () =>
+        runWithRequestContext(context, async () => this.#route(request, context, turn)),
+      );
+      return withStandardHeaders(response, context, serverIdentity(PROTOCOL));
+    } catch (error) {
+      return errorResponse(toProtocolError(error), context, serverIdentity(PROTOCOL), turnHeaders(turn));
+    } finally {
+      // A wrapped body outlives this scope, and its turn's spans with it; the stream wrapper
+      // flushes when the body ends instead (the same split Responses makes for SSE).
+      if (turn.streamed !== true) {
+        await flushTelemetry();
+      }
+    }
+  }
+
+  async #route(request: Request, context: RequestContext, turn: TurnIdentity): Promise<Response> {
+    const url = new URL(request.url);
+    const path = trimTrailingSlashes(url.pathname) || '/';
+
+    if (path === '/readiness') {
+      // Answered even while draining, so the platform can watch the container leave rotation.
+      return jsonResponse({ status: 'healthy' }, 200);
+    }
+
+    const relative = stripPrefix(path, this.#prefix);
+    if (relative === undefined || !relative.startsWith('/invocations')) {
+      throw routeNotFound();
+    }
+
+    if (this.#draining) {
+      throw unavailable('the container is shutting down');
+    }
+
+    const rest = relative.slice('/invocations'.length);
+    if (rest === '' || rest === '/') {
+      if (request.method !== 'POST') {
+        throw methodNotAllowed('POST');
+      }
+      const invocationId = sanitizeId(request.headers.get(INVOCATION_ID_HEADER)) ?? crypto.randomUUID();
+      return this.#dispatch(this.#handler, request, url, context, turn, invocationId);
+    }
+
+    const segments = rest.split('/').filter((segment) => segment !== '');
+    if (segments.length > 2) {
+      throw routeNotFound();
+    }
+    // Passed through as the caller sent it, like the references: this layer never uses the id as
+    // a key, so there is nothing a malformed one could corrupt — the handler that does use it is
+    // the place to validate it.
+    const id = decodeSegment(segments[0] ?? '', 'invocation_id');
+    const action = segments[1];
+
+    if (action === 'cancel') {
+      if (request.method !== 'POST') throw methodNotAllowed('POST');
+      return this.#dispatchOptional(
+        this.#cancelHandler,
+        'cancel_invocation',
+        request,
+        url,
+        context,
+        turn,
+        id,
+      );
+    }
+    if (action !== undefined) {
+      throw routeNotFound();
+    }
+    if (request.method !== 'GET') throw methodNotAllowed('GET');
+    return this.#dispatchOptional(this.#getHandler, 'get_invocation', request, url, context, turn, id);
+  }
+
+  /** The read and cancel routes: registered handlers answer, unregistered ones are a 404. */
+  #dispatchOptional(
+    handler: InvocationHandler | undefined,
+    name: string,
+    request: Request,
+    url: URL,
+    context: RequestContext,
+    turn: TurnIdentity,
+    invocationId: string,
+  ): Promise<Response> {
+    if (handler === undefined) {
+      // 404 rather than 405: the route is defined by the protocol but not offered by this
+      // container. `upstream` because what is missing is application code, not platform plumbing
+      // (Python answers the same way).
+      throw new ProtocolError(404, `${name} is not implemented by this container`, {
+        code: 'not_found',
+        type: 'not_found',
+        source: 'upstream',
+      });
+    }
+    return this.#dispatch(handler, request, url, context, turn, invocationId);
+  }
+
+  async #dispatch(
+    handler: InvocationHandler,
+    request: Request,
+    url: URL,
+    context: RequestContext,
+    turn: TurnIdentity,
+    invocationId: string,
+  ): Promise<Response> {
+    const sessionId = resolveInvocationSessionId(url);
+    // Recorded before the handler runs, so the error path reports the resolved identity too —
+    // the caller correlating a failure needs these more than anyone.
+    turn.invocationId = invocationId;
+    turn.sessionId = sessionId;
+
+    const abort = new AbortController();
+    const onShutdown = (): void => abort.abort();
+    this.#shutdown.signal.addEventListener('abort', onShutdown, { once: true });
+    request.signal.addEventListener('abort', onShutdown, { once: true });
+    const releaseSignals = (): void => {
+      this.#shutdown.signal.removeEventListener('abort', onShutdown);
+      request.signal.removeEventListener('abort', onShutdown);
+    };
+    // `addEventListener` is not a subscription to *state*: a signal that aborted before the
+    // listener existed never fires it. Re-read after registration so neither the edge nor the
+    // state can be missed.
+    if (this.#shutdown.signal.aborted || request.signal.aborted) {
+      onShutdown();
+    }
+
+    const invocationContext: InvocationContext = {
+      invocationId,
+      sessionId,
+      request: context,
+      signal: abort.signal,
+    };
+
+    // The server's own baggage stamp, on top of whatever the caller propagated — what ties the
+    // handler's spans to this invocation whether or not the caller speaks W3C baggage.
+    const turnContext = withInvocationBaggage(otelContext.active(), { invocationId, sessionId });
+
+    let response: Response;
+    try {
+      response = await otelContext.with(turnContext, () => handler(request, invocationContext));
+    } catch (error) {
+      releaseSignals();
+      throw error instanceof ProtocolError ? error : upstreamError(error);
+    }
+
+    // Rebuilt rather than mutated: a handler may return a `Response` whose headers are immutable
+    // (one obtained from `fetch`, for instance), and the identity headers must win over anything
+    // the handler set — the server's resolution is the one the platform routed by.
+    const headers = new Headers(response.headers);
+    headers.set(INVOCATION_ID_HEADER, invocationId);
+    headers.set(HEADERS.sessionId, toHeaderValue(sessionId));
+
+    if (response.body === null) {
+      releaseSignals();
+      return new Response(null, { status: response.status, statusText: response.statusText, headers });
+    }
+    turn.streamed = true;
+    return new Response(this.#wrapBody(response, turnContext, context, releaseSignals), {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+
+  /**
+   * Wraps a handler's body stream for the life it leads after this request scope closes.
+   *
+   * Every pull re-enters the turn's OTel context and request context — a stream is consumed by
+   * the socket writer, and work the handler still does while it drains must keep its trace and
+   * its platform headers. When the handler declared `text/event-stream` and
+   * `SSE_KEEPALIVE_INTERVAL` is set, a keep-alive comment goes out after each interval of
+   * silence; the wrapper reads at most one chunk ahead, so a slow consumer still exerts
+   * backpressure on the handler (the reference's one-item lookahead). Any other content type is
+   * passed through untouched — a comment injected into an NDJSON stream would corrupt it.
+   */
+  #wrapBody(
+    response: Response,
+    turnContext: ReturnType<typeof otelContext.active>,
+    context: RequestContext,
+    releaseSignals: () => void,
+  ): ReadableStream<Uint8Array> {
+    const contentType = response.headers.get('content-type') ?? '';
+    const keepAliveMs = contentType.toLowerCase().startsWith('text/event-stream')
+      ? sseKeepAliveSeconds() * 1000
+      : 0;
+    // biome-ignore lint/style/noNonNullAssertion: callers checked `body !== null`.
+    const reader = response.body!.getReader();
+    const keepAliveBytes = new TextEncoder().encode(SSE_KEEPALIVE);
+
+    let pending: Promise<ReadResult> | undefined;
+    let finished = false;
+    const finish = async (): Promise<void> => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      releaseSignals();
+      // The turn's spans leave with the body, not with a batch timer that may never fire in a
+      // sandbox frozen right after the last byte.
+      await flushTelemetry();
+    };
+
+    return new ReadableStream<Uint8Array>({
+      pull: async (controller): Promise<void> => {
+        // The read starts inside the turn's scopes; `AsyncLocalStorage` and the OTel context
+        // follow the async flow from here into the handler's own pull callback.
+        pending ??= otelContext.with(turnContext, () => runWithRequestContext(context, () => reader.read()));
+        let result: ReadResult;
+        try {
+          if (keepAliveMs > 0) {
+            const raced = await raceRead(pending, keepAliveMs);
+            if (raced === undefined) {
+              // Silence, not the end: comfort the proxies and keep waiting on the same read.
+              controller.enqueue(keepAliveBytes);
+              return;
+            }
+            result = raced;
+          } else {
+            result = await pending;
+          }
+        } catch (error) {
+          pending = undefined;
+          await finish();
+          throw error;
+        }
+        pending = undefined;
+        if (result.done) {
+          controller.close();
+          await finish();
+          return;
+        }
+        controller.enqueue(result.value);
+      },
+      cancel: async (reason: unknown): Promise<void> => {
+        // The client hung up: stop the handler rather than let it stream to nobody.
+        try {
+          await reader.cancel(reason);
+        } finally {
+          await finish();
+        }
+      },
+    });
+  }
+}
+
+/**
+ * `read`, or `undefined` when it has not settled within `ms`.
+ *
+ * Losing the race abandons the wait, not the read: the caller keeps the same promise and waits
+ * again, which is what makes the keep-alive loop read only one chunk ahead.
+ */
+function raceRead<T>(read: Promise<T>, ms: number): Promise<T | undefined> {
+  return new Promise<T | undefined>((resolve, reject) => {
+    const timer = setTimeout(() => resolve(undefined), ms);
+    timer.unref?.();
+    read.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}

--- a/packages/agentserver/src/invocations.ts
+++ b/packages/agentserver/src/invocations.ts
@@ -221,7 +221,8 @@ export class InvocationsServer {
     }
 
     const relative = stripPrefix(path, this.#prefix);
-    if (relative === undefined || !relative.startsWith('/invocations')) {
+    // Whole-segment match only: `/invocationsfoo` shares the prefix but is not this protocol.
+    if (relative === undefined || (relative !== '/invocations' && !relative.startsWith('/invocations/'))) {
       throw routeNotFound();
     }
 
@@ -235,7 +236,8 @@ export class InvocationsServer {
         throw methodNotAllowed('POST');
       }
       const invocationId = sanitizeId(request.headers.get(INVOCATION_ID_HEADER)) ?? crypto.randomUUID();
-      return this.#dispatch(this.#handler, request, url, context, turn, invocationId);
+      const sessionId = this.#resolveTurn(url, turn, invocationId);
+      return this.#dispatch(this.#handler, request, context, turn, invocationId, sessionId);
     }
 
     const segments = rest.split('/').filter((segment) => segment !== '');
@@ -267,6 +269,19 @@ export class InvocationsServer {
     return this.#dispatchOptional(this.#getHandler, 'get_invocation', request, url, context, turn, id);
   }
 
+  /**
+   * Resolves the turn's identity and records it for the response — including an error response.
+   *
+   * Resolved exactly once per turn: the session fallback is a generated UUID, so a second
+   * resolution would echo a different id than the one the handler saw.
+   */
+  #resolveTurn(url: URL, turn: TurnIdentity, invocationId: string): string {
+    const sessionId = resolveInvocationSessionId(url);
+    turn.invocationId = invocationId;
+    turn.sessionId = sessionId;
+    return sessionId;
+  }
+
   /** The read and cancel routes: registered handlers answer, unregistered ones are a 404. */
   #dispatchOptional(
     handler: InvocationHandler | undefined,
@@ -277,6 +292,9 @@ export class InvocationsServer {
     turn: TurnIdentity,
     invocationId: string,
   ): Promise<Response> {
+    // Resolved before the not-implemented check: the 404 carries the same identity headers as
+    // every other answer on these routes — the caller correlating a failure needs them most.
+    const sessionId = this.#resolveTurn(url, turn, invocationId);
     if (handler === undefined) {
       // 404 rather than 405: the route is defined by the protocol but not offered by this
       // container. `upstream` because what is missing is application code, not platform plumbing
@@ -287,23 +305,17 @@ export class InvocationsServer {
         source: 'upstream',
       });
     }
-    return this.#dispatch(handler, request, url, context, turn, invocationId);
+    return this.#dispatch(handler, request, context, turn, invocationId, sessionId);
   }
 
   async #dispatch(
     handler: InvocationHandler,
     request: Request,
-    url: URL,
     context: RequestContext,
     turn: TurnIdentity,
     invocationId: string,
+    sessionId: string,
   ): Promise<Response> {
-    const sessionId = resolveInvocationSessionId(url);
-    // Recorded before the handler runs, so the error path reports the resolved identity too —
-    // the caller correlating a failure needs these more than anyone.
-    turn.invocationId = invocationId;
-    turn.sessionId = sessionId;
-
     const abort = new AbortController();
     const onShutdown = (): void => abort.abort();
     this.#shutdown.signal.addEventListener('abort', onShutdown, { once: true });
@@ -342,7 +354,9 @@ export class InvocationsServer {
     // (one obtained from `fetch`, for instance), and the identity headers must win over anything
     // the handler set — the server's resolution is the one the platform routed by.
     const headers = new Headers(response.headers);
-    headers.set(INVOCATION_ID_HEADER, invocationId);
+    // `toHeaderValue` because a read route's id comes straight off the path: a value `Headers.set`
+    // cannot represent must degrade to a readable approximation rather than crash the response.
+    headers.set(INVOCATION_ID_HEADER, toHeaderValue(invocationId));
     headers.set(HEADERS.sessionId, toHeaderValue(sessionId));
 
     if (response.body === null) {
@@ -427,9 +441,13 @@ export class InvocationsServer {
         controller.enqueue(result.value);
       },
       cancel: async (reason: unknown): Promise<void> => {
-        // The client hung up: stop the handler rather than let it stream to nobody.
+        // The client hung up: stop the handler rather than let it stream to nobody. The cancel
+        // re-enters the turn's scopes for the same reason the pulls do — the handler's stream
+        // teardown runs from here, and it must still see the turn's trace and request context.
         try {
-          await reader.cancel(reason);
+          await otelContext.with(turnContext, () =>
+            runWithRequestContext(context, () => reader.cancel(reason)),
+          );
         } finally {
           await finish();
         }

--- a/packages/agentserver/src/invocations.ts
+++ b/packages/agentserver/src/invocations.ts
@@ -396,7 +396,7 @@ export class InvocationsServer {
     const reader = response.body!.getReader();
     const keepAliveBytes = new TextEncoder().encode(SSE_KEEPALIVE);
 
-    let pending: Promise<ReadResult> | undefined;
+    let pending: PendingRead | undefined;
     let finished = false;
     const finish = async (): Promise<void> => {
       if (finished) {
@@ -409,36 +409,52 @@ export class InvocationsServer {
       await flushTelemetry();
     };
 
+    // Exactly one settlement observer per read. A keep-alive wait that simply raced the same
+    // promise again would register a fresh reaction every interval, and on a stream that stays
+    // silent for hours those reactions accumulate unboundedly — a promise offers no way to
+    // unsubscribe. So the read is observed once, into `state`, and each wait subscribes to the
+    // single `wake` slot instead (safe because the stream serializes pulls: at most one wait
+    // exists at a time).
+    const startRead = (): PendingRead => {
+      const state: PendingRead = {};
+      // The read starts inside the turn's scopes; `AsyncLocalStorage` and the OTel context
+      // follow the async flow from here into the handler's own pull callback.
+      otelContext
+        .with(turnContext, () => runWithRequestContext(context, () => reader.read()))
+        .then(
+          (result) => {
+            state.outcome = { ok: true, result };
+            state.wake?.();
+          },
+          (error: unknown) => {
+            state.outcome = { ok: false, error };
+            state.wake?.();
+          },
+        );
+      return state;
+    };
+
     return new ReadableStream<Uint8Array>({
       pull: async (controller): Promise<void> => {
-        // The read starts inside the turn's scopes; `AsyncLocalStorage` and the OTel context
-        // follow the async flow from here into the handler's own pull callback.
-        pending ??= otelContext.with(turnContext, () => runWithRequestContext(context, () => reader.read()));
-        let result: ReadResult;
-        try {
-          if (keepAliveMs > 0) {
-            const raced = await raceRead(pending, keepAliveMs);
-            if (raced === undefined) {
-              // Silence, not the end: comfort the proxies and keep waiting on the same read.
-              controller.enqueue(keepAliveBytes);
-              return;
-            }
-            result = raced;
-          } else {
-            result = await pending;
-          }
-        } catch (error) {
-          pending = undefined;
-          await finish();
-          throw error;
+        pending ??= startRead();
+        // Silence past the deadline is not the end: comfort the proxies and keep waiting on the
+        // same read next pull.
+        if (!(await settles(pending, keepAliveMs))) {
+          controller.enqueue(keepAliveBytes);
+          return;
         }
+        const outcome = pending.outcome;
         pending = undefined;
-        if (result.done) {
+        if (outcome === undefined || !outcome.ok) {
+          await finish();
+          throw outcome === undefined ? new Error('read settled without an outcome') : outcome.error;
+        }
+        if (outcome.result.done) {
           controller.close();
           await finish();
           return;
         }
-        controller.enqueue(result.value);
+        controller.enqueue(outcome.result.value);
       },
       cancel: async (reason: unknown): Promise<void> => {
         // The client hung up: stop the handler rather than let it stream to nobody. The cancel
@@ -456,25 +472,40 @@ export class InvocationsServer {
   }
 }
 
+/** One in-flight read, observed exactly once; waits go through the single `wake` slot. */
+interface PendingRead {
+  /** Set when the read settles; absent while it is in flight. */
+  outcome?: { ok: true; result: ReadResult } | { ok: false; error: unknown };
+  /** Wakes the wait in progress, if any. At most one exists at a time. */
+  wake?: (() => void) | undefined;
+}
+
 /**
- * `read`, or `undefined` when it has not settled within `ms`.
+ * Whether `state` settles within `timeoutMs` (`0` waits without a deadline).
  *
- * Losing the race abandons the wait, not the read: the caller keeps the same promise and waits
- * again, which is what makes the keep-alive loop read only one chunk ahead.
+ * A timeout abandons only the wait, never the read — the caller keeps the same `PendingRead` and
+ * waits again, which is what makes the keep-alive loop read only one chunk ahead. Each wait is a
+ * fresh short-lived promise resolved by the read's single observer, so a stream that stays
+ * silent across many keep-alive intervals accumulates nothing.
  */
-function raceRead<T>(read: Promise<T>, ms: number): Promise<T | undefined> {
-  return new Promise<T | undefined>((resolve, reject) => {
-    const timer = setTimeout(() => resolve(undefined), ms);
-    timer.unref?.();
-    read.then(
-      (value) => {
-        clearTimeout(timer);
-        resolve(value);
-      },
-      (error: unknown) => {
-        clearTimeout(timer);
-        reject(error instanceof Error ? error : new Error(String(error)));
-      },
-    );
+function settles(state: PendingRead, timeoutMs: number): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    if (state.outcome !== undefined) {
+      resolve(true);
+      return;
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    if (timeoutMs > 0) {
+      timer = setTimeout(() => {
+        state.wake = undefined;
+        resolve(false);
+      }, timeoutMs);
+      timer.unref?.();
+    }
+    state.wake = (): void => {
+      clearTimeout(timer);
+      state.wake = undefined;
+      resolve(true);
+    };
   });
 }

--- a/packages/agentserver/src/node.test.ts
+++ b/packages/agentserver/src/node.test.ts
@@ -106,6 +106,34 @@ describe('node adapter', () => {
     expect(response.headers.get('x-platform-error-source')).toBe('user');
   });
 
+  it('keeps a method-style fetch bound to its server instance', async () => {
+    // `ProtocolServer` is structural: a server whose `fetch` is an ordinary class method reading
+    // instance state qualifies, and must keep its receiver when the adapter calls it.
+    class MethodServer {
+      readonly #answer = 'bound';
+      fetch(request: Request): Promise<Response> {
+        void request;
+        return Promise.resolve(new Response(this.#answer));
+      }
+      drain(): Promise<void> {
+        return Promise.resolve();
+      }
+    }
+    const bound = await serve(new MethodServer(), {
+      port: 0,
+      host: '127.0.0.1',
+      handleSignals: false,
+      observability: false,
+    });
+    try {
+      const response = await fetch(`http://127.0.0.1:${bound.port}/anything`);
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe('bound');
+    } finally {
+      await bound.close();
+    }
+  });
+
   it('serves an InvocationsServer over the same adapter', async () => {
     const invocations = await serve(
       new InvocationsServer({

--- a/packages/agentserver/src/node.test.ts
+++ b/packages/agentserver/src/node.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events';
 import type { ServerResponse } from 'node:http';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { InvocationsServer } from './invocations.js';
 import type { RunningServer } from './node.js';
 import { serve } from './node.js';
 import { writeWebResponse } from './node-internals.js';
@@ -103,6 +104,35 @@ describe('node adapter', () => {
       error: { code: 'unsupported_parameter', param: 'background' },
     });
     expect(response.headers.get('x-platform-error-source')).toBe('user');
+  });
+
+  it('serves an InvocationsServer over the same adapter', async () => {
+    const invocations = await serve(
+      new InvocationsServer({
+        handler: async (request, context) =>
+          new Response(`echo:${await request.text()}:${context.invocationId}`, {
+            headers: { 'content-type': 'text/plain' },
+          }),
+      }),
+      { port: 0, host: '127.0.0.1', handleSignals: false, observability: false },
+    );
+    try {
+      const probe = await fetch(`http://127.0.0.1:${invocations.port}/readiness`);
+      expect(await probe.json()).toEqual({ status: 'healthy' });
+
+      // curl -X POST :PORT/invocations -d '{"message": "Hi"}'
+      const response = await fetch(`http://127.0.0.1:${invocations.port}/invocations`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-agent-invocation-id': 'inv_smoke' },
+        body: '{"message": "Hi"}',
+      });
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe('echo:{"message": "Hi"}:inv_smoke');
+      expect(response.headers.get('x-agent-invocation-id')).toBe('inv_smoke');
+      expect(response.headers.get('x-agent-session-id')).toBeTruthy();
+    } finally {
+      await invocations.close();
+    }
   });
 
   it('removes its process signal handlers when closed', async () => {

--- a/packages/agentserver/src/node.ts
+++ b/packages/agentserver/src/node.ts
@@ -5,8 +5,16 @@ import { port as configuredPort, gracefulShutdownSeconds, UnsupportedOtlpProtoco
 import { writeWebResponse } from './node-internals.js';
 import { flushTelemetry } from './observability/flush.js';
 import type { HostObservabilityOptions } from './observability/setup.js';
-import type { ResponsesServer } from './server.js';
 import { raceTimeout } from './wait.js';
+
+/**
+ * What {@link serve} needs from a protocol server: a `fetch` handler to answer requests, and a
+ * `drain` to call on shutdown. `ResponsesServer` and `InvocationsServer` both qualify.
+ */
+export interface ProtocolServer {
+  readonly fetch: (request: Request) => Promise<Response>;
+  drain(): Promise<void>;
+}
 
 /** Options for {@link serve}. */
 export interface ServeOptions {
@@ -62,13 +70,13 @@ function toWebRequest(req: IncomingMessage, host: string, signal: AbortSignal): 
 }
 
 /**
- * Serves a {@link ResponsesServer} over `node:http`.
+ * Serves a {@link ProtocolServer} over `node:http`.
  *
  * Binds `0.0.0.0:${PORT:-8088}` — the container contract's requirement. Observability is
  * configured first, so the very first turn's spans have somewhere to go; see
  * {@link ServeOptions.observability}.
  */
-export async function serve(app: ResponsesServer, options: ServeOptions = {}): Promise<RunningServer> {
+export async function serve(app: ProtocolServer, options: ServeOptions = {}): Promise<RunningServer> {
   if (options.observability !== false) {
     try {
       // Imported here, not at the top: a `serve` that opted out never loads the SDK packages.

--- a/packages/agentserver/src/node.ts
+++ b/packages/agentserver/src/node.ts
@@ -96,7 +96,6 @@ export async function serve(app: ProtocolServer, options: ServeOptions = {}): Pr
 
   const host = options.host ?? '0.0.0.0';
   const port = options.port ?? configuredPort();
-  const handler = app.fetch;
 
   const server = createServer((req, res) => {
     void (async (): Promise<void> => {
@@ -104,7 +103,9 @@ export async function serve(app: ProtocolServer, options: ServeOptions = {}): Pr
       const abort = new AbortController();
       res.on('close', () => abort.abort());
       try {
-        await writeWebResponse(await handler(toWebRequest(req, host, abort.signal)), res);
+        // Called through `app`, never detached: `ProtocolServer` is structural, and a server
+        // implementing `fetch` as an ordinary method would lose its instance state otherwise.
+        await writeWebResponse(await app.fetch(toWebRequest(req, host, abort.signal)), res);
       } catch {
         // The protocol layer answers its own errors; reaching here means the socket itself broke.
         if (!res.headersSent) {

--- a/packages/agentserver/src/observability/trace-context.ts
+++ b/packages/agentserver/src/observability/trace-context.ts
@@ -100,6 +100,34 @@ export function withResponseBaggage(context: Context, turn: ResponseBaggage): Co
 }
 
 /**
+ * The baggage entries the Invocations server stamps on every request it dispatches, worded as
+ * both references word them (Python `_invocation.py`, .NET `InvocationsActivitySource`).
+ *
+ * Self-stamped for the same reason as {@link RESPONSE_BAGGAGE}: the calling service is not
+ * required to send anything, and these are what correlate the handler's spans with the
+ * invocation that caused them. No server span carries them — neither reference creates one.
+ */
+export const INVOCATION_BAGGAGE = {
+  invocationId: 'azure.ai.agentserver.invocation_id',
+  sessionId: 'azure.ai.agentserver.session_id',
+} as const;
+
+/** One invocation's identity, as the dispatch knows it. */
+export interface InvocationBaggage {
+  invocationId: string;
+  sessionId: string;
+}
+
+/** Adds the invocation baggage to `context`, keeping whatever the caller sent. */
+export function withInvocationBaggage(context: Context, turn: InvocationBaggage): Context {
+  let bag = propagation.getBaggage(context) ?? propagation.createBaggage();
+  bag = bag
+    .setEntry(INVOCATION_BAGGAGE.invocationId, { value: turn.invocationId })
+    .setEntry(INVOCATION_BAGGAGE.sessionId, { value: turn.sessionId });
+  return propagation.setBaggage(context, bag);
+}
+
+/**
  * Runs every pull of `iterable` through `run`, which re-enters whatever ambient scopes the turn
  * needs — the OTel context, the request's `AsyncLocalStorage`, or both composed.
  *

--- a/packages/agentserver/src/server.ts
+++ b/packages/agentserver/src/server.ts
@@ -1,6 +1,5 @@
 import { context as otelContext } from '@opentelemetry/api';
 import {
-  agentSessionId,
   cancelGraceMs,
   isHosted,
   maxBodyBytes,
@@ -20,11 +19,18 @@ import {
   ProtocolError,
   requestTooLarge,
   routeNotFound,
-  toHeaderValue,
   toProtocolError,
   unavailable,
   upstreamError,
 } from './errors.js';
+import {
+  decodeSegment,
+  errorResponse,
+  jsonResponse,
+  stripPrefix,
+  trimTrailingSlashes,
+  withStandardHeaders,
+} from './http.js';
 import { ID_PREFIX, itemIdPrefix, newId, newResponseId } from './ids.js';
 import type { LifecycleViolation } from './lifecycle.js';
 import { applyCancelledTerminal, enforceLifecycle, ResponseTracker } from './lifecycle.js';
@@ -496,41 +502,9 @@ function cancelledTerminal(tracker: ResponseTracker): ResponseEvent {
   return { type: 'response.failed', response };
 }
 
-function jsonResponse(body: unknown, status: number, headers: Record<string, string> = {}): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'content-type': 'application/json', ...headers },
-  });
-}
-
-/**
- * Percent-decodes one path segment.
- *
- * A lone `%` makes `decodeURIComponent` throw a `URIError`, which would surface as an opaque 500
- * for what is plainly a malformed request.
- */
-function decodeSegment(segment: string): string {
-  try {
-    return decodeURIComponent(segment);
-  } catch {
-    throw badRequest('Malformed identifier.', { code: 'invalid_parameters', param: 'response_id' });
-  }
-}
-
-/**
- * Drops trailing `/` characters, scanning once from the end.
- *
- * Deliberately not `/\/+$/`: that pattern retries the run from every start position, so a request
- * path made of slashes that does not end in one costs time quadratic in its length. The path comes
- * off the wire, which makes the difference a denial-of-service lever rather than a micro-optimization.
- */
-function trimTrailingSlashes(value: string): string {
-  let end = value.length;
-  while (end > 0 && value.charCodeAt(end - 1) === 0x2f) {
-    end -= 1;
-  }
-  return end === value.length ? value : value.slice(0, end);
-}
+// jsonResponse, decodeSegment, trimTrailingSlashes and the prefix/header/error plumbing live in
+// http.ts, shared with the Invocations server: the container contract is one contract, and the
+// parts of it every protocol answers identically must have one implementation.
 
 /**
  * A Foundry Responses container protocol v2.0.0 server.
@@ -676,16 +650,7 @@ export class ResponsesServer {
       return jsonResponse({ status: 'healthy' }, 200);
     }
 
-    // `startsWith` alone is not a prefix match: with `prefix = '/api'` it would also claim
-    // `/apiary/responses`. Only the whole segment counts.
-    const relative =
-      this.#prefix === ''
-        ? path
-        : path === this.#prefix
-          ? '/'
-          : path.startsWith(`${this.#prefix}/`)
-            ? path.slice(this.#prefix.length)
-            : undefined;
+    const relative = stripPrefix(path, this.#prefix);
     if (relative === undefined || !relative.startsWith('/responses')) {
       throw routeNotFound();
     }
@@ -708,7 +673,7 @@ export class ResponsesServer {
       // unknown paths silently alias known ones.
       throw routeNotFound();
     }
-    const id = decodeSegment(segments[0] ?? '');
+    const id = decodeSegment(segments[0] ?? '', 'response_id');
     // The id is about to become a storage key — with a file-backed store, a file name. Rejecting a
     // malformed one here keeps behaviour identical across store implementations (the file store
     // would otherwise throw an opaque 500 where the in-memory store answers 404) and makes the id
@@ -1672,37 +1637,11 @@ export class ResponsesServer {
 
   /** Adds the headers the platform expects on every response. */
   #withStandardHeaders(response: Response, context: RequestContext): Response {
-    response.headers.set(HEADERS.requestId, context.requestId);
-    response.headers.set(HEADERS.serverVersion, serverIdentity());
-    // Routes other than `POST /responses` have no request to derive a session from, so they report
-    // the container's own, when the platform assigned one (Python `_session_headers`).
-    const ambient = agentSessionId();
-    if (ambient !== undefined && !response.headers.has(HEADERS.sessionId)) {
-      response.headers.set(HEADERS.sessionId, ambient);
-    }
-    return response;
+    return withStandardHeaders(response, context, serverIdentity());
   }
 
   /** Renders a {@link ProtocolError} as the wire envelope, with diagnostics kept out of the body. */
   #errorResponse(error: ProtocolError, context: RequestContext): Response {
-    const headers: Record<string, string> = {
-      [HEADERS.requestId]: context.requestId,
-      [HEADERS.serverVersion]: serverIdentity(),
-      [HEADERS.errorSource]: error.source,
-    };
-    // Only a `platform`-source error carries its diagnostics on the header — user and upstream
-    // failures are not the platform's to explain (Python `error_response`, .NET
-    // `ResponsesExceptionFilter` both gate the detail header the same way).
-    if (error.detail !== undefined && error.source === 'platform') {
-      headers[HEADERS.errorDetail] = toHeaderValue(error.detail);
-    }
-    if (error.allow !== undefined) {
-      headers.allow = error.allow;
-    }
-    const ambient = agentSessionId();
-    if (ambient !== undefined) {
-      headers[HEADERS.sessionId] = ambient;
-    }
-    return jsonResponse(error.toResponse(context.requestId), error.status, headers);
+    return errorResponse(error, context, serverIdentity());
   }
 }

--- a/packages/foundry/README.md
+++ b/packages/foundry/README.md
@@ -9,8 +9,10 @@
 
 Microsoft Foundry provider for the Agent Framework: `FoundryChatClient` talks to a Foundry
 project (model deployments or server agents) with Microsoft Entra authentication, and the
-`@polymind-inc/agent-framework-foundry/hosting` subpath publishes an `Agent` as a Foundry Hosted Agent over
-the Responses container protocol implemented by `@polymind-inc/agent-framework-agentserver`.
+`@polymind-inc/agent-framework-foundry/hosting` subpath publishes an `Agent` as a Foundry Hosted
+Agent — `ResponsesHostServer` over the Responses container protocol, `InvocationsHostServer` over
+the Invocations protocol — on the servers implemented by
+`@polymind-inc/agent-framework-agentserver`.
 
 ```sh
 npm install @polymind-inc/agent-framework-core @polymind-inc/agent-framework-foundry

--- a/packages/foundry/src/hosting.ts
+++ b/packages/foundry/src/hosting.ts
@@ -57,6 +57,8 @@ export type { HostedAgentContext } from './hosting/hosted-context.js';
 // only writer, which is what keeps the ambient read-only for everything below it.
 export { getHostedAgentContext } from './hosting/hosted-context.js';
 
+export type { InvocationsHostServerConfig } from './hosting/invocations.js';
+export { InvocationsHostServer } from './hosting/invocations.js';
 export type { ResponsesHostServerConfig } from './hosting/server.js';
 export { defaultStore, ResponsesHostServer } from './hosting/server.js';
 

--- a/packages/foundry/src/hosting/invocations.test.ts
+++ b/packages/foundry/src/hosting/invocations.test.ts
@@ -206,6 +206,33 @@ describe('InvocationsHostServer', () => {
     expect(JSON.stringify(client.calls[1]?.messages)).not.toContain('first secret');
   });
 
+  it('gives colliding partition spellings distinct session identities', async () => {
+    // Distinct session *objects* are not enough: `AgentSession.sessionId` is the conversation's
+    // stable identifier, and an external store keyed by it would merge the two users' histories
+    // if both sessions answered to the same 'S:v:u'.
+    const created: Array<string | undefined> = [];
+    const agent = new Agent({ client: new MockChatClient([say('one'), say('two')]), instructions: 'x' });
+    const app = new InvocationsHostServer({ agent: recording(agent, created), hosted: true });
+
+    await app.handle(
+      invoke(
+        { message: 'a' },
+        { [HEADERS.userId]: 'u', [HEADERS.foundryCallId]: 'c1' },
+        '?agent_session_id=S:v',
+      ),
+    );
+    await app.handle(
+      invoke(
+        { message: 'b' },
+        { [HEADERS.userId]: 'v:u', [HEADERS.foundryCallId]: 'c2' },
+        '?agent_session_id=S',
+      ),
+    );
+
+    expect(created).toHaveLength(2);
+    expect(created[0]).not.toBe(created[1]);
+  });
+
   it('streams only the non-empty update text', async () => {
     // Tool rounds surface as updates with no text; the body must carry the text and nothing else.
     const client = new MockChatClient([

--- a/packages/foundry/src/hosting/invocations.test.ts
+++ b/packages/foundry/src/hosting/invocations.test.ts
@@ -1,0 +1,157 @@
+import { HEADERS, INVOCATION_ID_HEADER } from '@polymind-inc/agent-framework-agentserver';
+import { Agent, textContent } from '@polymind-inc/agent-framework-core';
+import type { MockTurn } from '@polymind-inc/agent-framework-core/testing';
+import { MockChatClient } from '@polymind-inc/agent-framework-core/testing';
+import { describe, expect, it } from 'vitest';
+import { InvocationsHostServer } from './invocations.js';
+
+function say(text: string): MockTurn {
+  return { contents: [textContent(text)], finishReason: 'stop' };
+}
+
+function server(client: MockChatClient, hosted = false): InvocationsHostServer {
+  return new InvocationsHostServer({
+    agent: new Agent({ client, instructions: 'Be helpful.' }),
+    hosted,
+  });
+}
+
+function invoke(body: unknown, headers: Record<string, string> = {}, query = ''): Request {
+  return new Request(`http://localhost:8088/invocations${query}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+function errorCodeOf(payload: unknown): string {
+  return (payload as { error: { code: string } }).error.code;
+}
+
+const HOSTED_HEADERS = { [HEADERS.userId]: 'user-1', [HEADERS.foundryCallId]: 'call-1' };
+
+describe('InvocationsHostServer', () => {
+  it('answers a non-streaming turn as plain text', async () => {
+    const app = server(new MockChatClient([say('Hello there')]));
+    const response = await app.handle(invoke({ message: 'Hi' }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('text/plain; charset=utf-8');
+    expect(await response.text()).toBe('Hello there');
+    expect(response.headers.get(INVOCATION_ID_HEADER)).toBeTruthy();
+    expect(response.headers.get(HEADERS.sessionId)).toBeTruthy();
+  });
+
+  it('streams the update text under text/event-stream when asked to', async () => {
+    const app = server(new MockChatClient([say('streamed reply')]));
+    const response = await app.handle(invoke({ message: 'Hi', stream: true }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('text/event-stream');
+    expect(response.headers.get('cache-control')).toBe('no-cache');
+    expect(await response.text()).toBe('streamed reply');
+  });
+
+  it.each([
+    ['a missing message', {}],
+    ['an empty message', { message: '' }],
+    ['a non-string message', { message: 42 }],
+  ])('answers 400 for %s', async (_name, body) => {
+    const app = server(new MockChatClient([say('unused')]));
+    const response = await app.handle(invoke(body));
+    expect(response.status).toBe(400);
+    expect(errorCodeOf(await response.json())).toBe('invalid_request');
+    expect(response.headers.get(HEADERS.errorSource)).toBe('user');
+  });
+
+  it.each([
+    ['unparseable', 'this is { not json'],
+    ['a JSON array', [1, 2]],
+    ['a JSON string', '"just text"'],
+  ])('answers 400 for a body that is %s', async (_name, body) => {
+    const app = server(new MockChatClient([say('unused')]));
+    const response = await app.handle(invoke(body));
+    expect(response.status).toBe(400);
+  });
+
+  it('continues the conversation when the caller pins the session id', async () => {
+    const client = new MockChatClient([say('first answer'), say('second answer')]);
+    const app = server(client);
+
+    const first = await app.handle(invoke({ message: 'my name is Alice' }));
+    const sessionId = first.headers.get(HEADERS.sessionId);
+    expect(sessionId).toBeTruthy();
+
+    const second = await app.handle(
+      invoke({ message: 'what is my name?' }, {}, `?agent_session_id=${sessionId}`),
+    );
+    expect(await second.text()).toBe('second answer');
+
+    // The second model call replays the first turn: same session, same transcript.
+    const replayed = JSON.stringify(client.calls[1]?.messages);
+    expect(replayed).toContain('my name is Alice');
+    expect(replayed).toContain('first answer');
+  });
+
+  it('starts a fresh conversation for a different session id', async () => {
+    const client = new MockChatClient([say('one'), say('two')]);
+    const app = server(client);
+
+    await app.handle(invoke({ message: 'first conversation' }, {}, '?agent_session_id=sess-a'));
+    await app.handle(invoke({ message: 'second conversation' }, {}, '?agent_session_id=sess-b'));
+
+    expect(JSON.stringify(client.calls[1]?.messages)).not.toContain('first conversation');
+  });
+
+  it('fails closed when hosted without the platform call id', async () => {
+    const app = server(new MockChatClient([say('unused')]), true);
+    const response = await app.handle(invoke({ message: 'Hi' }, { [HEADERS.userId]: 'user-1' }));
+
+    expect(response.status).toBe(501);
+    expect(errorCodeOf(await response.json())).toBe('unsupported_container_protocol_version');
+  });
+
+  it.each([
+    ['missing', {}],
+    ['empty', { [HEADERS.userId]: '' }],
+  ])('refuses a hosted request whose user id is %s', async (_name, extra) => {
+    const app = server(new MockChatClient([say('unused')]), true);
+    const response = await app.handle(
+      invoke({ message: 'Hi' }, { [HEADERS.foundryCallId]: 'call-1', ...extra }),
+    );
+    expect(response.status).toBe(400);
+    expect(errorCodeOf(await response.json())).toBe('missing_user_id');
+  });
+
+  it('answers a hosted request that carries the full platform identity', async () => {
+    const app = server(new MockChatClient([say('hosted reply')]), true);
+    const response = await app.handle(invoke({ message: 'Hi' }, HOSTED_HEADERS));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('hosted reply');
+  });
+
+  it('partitions hosted conversations per user within one session', async () => {
+    const client = new MockChatClient([say('for user 1'), say('for user 2')]);
+    const app = server(client, true);
+    const query = '?agent_session_id=shared-sandbox';
+
+    await app.handle(invoke({ message: 'user one secret' }, HOSTED_HEADERS, query));
+    await app.handle(
+      invoke({ message: 'hello' }, { [HEADERS.userId]: 'user-2', [HEADERS.foundryCallId]: 'call-2' }, query),
+    );
+
+    // The second user's turn must not replay the first user's transcript.
+    expect(JSON.stringify(client.calls[1]?.messages)).not.toContain('user one secret');
+  });
+
+  it('keeps one hosted user’s conversation flowing across turns', async () => {
+    const client = new MockChatClient([say('first'), say('second')]);
+    const app = server(client, true);
+    const query = '?agent_session_id=shared-sandbox';
+
+    await app.handle(invoke({ message: 'remember me' }, HOSTED_HEADERS, query));
+    await app.handle(invoke({ message: 'again' }, HOSTED_HEADERS, query));
+
+    expect(JSON.stringify(client.calls[1]?.messages)).toContain('remember me');
+  });
+});

--- a/packages/foundry/src/hosting/invocations.test.ts
+++ b/packages/foundry/src/hosting/invocations.test.ts
@@ -182,6 +182,40 @@ describe('InvocationsHostServer', () => {
     expect(created).toEqual(['sess-a']);
   });
 
+  it('keeps colliding partition spellings apart', async () => {
+    // `S:v` × user `u` and `S` × user `v:u` both read `S:v:u` when naively joined with a colon;
+    // the partition must tell them apart or one caller reads another's conversation.
+    const client = new MockChatClient([say('one'), say('two')]);
+    const app = server(client, true);
+
+    await app.handle(
+      invoke(
+        { message: 'first secret' },
+        { [HEADERS.userId]: 'u', [HEADERS.foundryCallId]: 'c1' },
+        '?agent_session_id=S:v',
+      ),
+    );
+    await app.handle(
+      invoke(
+        { message: 'hello' },
+        { [HEADERS.userId]: 'v:u', [HEADERS.foundryCallId]: 'c2' },
+        '?agent_session_id=S',
+      ),
+    );
+
+    expect(JSON.stringify(client.calls[1]?.messages)).not.toContain('first secret');
+  });
+
+  it('streams only the non-empty update text', async () => {
+    // Tool rounds surface as updates with no text; the body must carry the text and nothing else.
+    const client = new MockChatClient([
+      { contents: [textContent(''), textContent('streamed'), textContent('')], finishReason: 'stop' },
+    ]);
+    const app = server(client);
+    const response = await app.handle(invoke({ message: 'Hi', stream: true }));
+    expect(await response.text()).toBe('streamed');
+  });
+
   it('creates the hosted session under the user-partitioned key', async () => {
     const created: Array<string | undefined> = [];
     const agent = new Agent({ client: new MockChatClient([say('ok')]), instructions: 'x' });

--- a/packages/foundry/src/hosting/invocations.test.ts
+++ b/packages/foundry/src/hosting/invocations.test.ts
@@ -1,4 +1,5 @@
 import { HEADERS, INVOCATION_ID_HEADER } from '@polymind-inc/agent-framework-agentserver';
+import type { AgentLike } from '@polymind-inc/agent-framework-core';
 import { Agent, textContent } from '@polymind-inc/agent-framework-core';
 import type { MockTurn } from '@polymind-inc/agent-framework-core/testing';
 import { MockChatClient } from '@polymind-inc/agent-framework-core/testing';
@@ -153,5 +154,41 @@ describe('InvocationsHostServer', () => {
     await app.handle(invoke({ message: 'again' }, HOSTED_HEADERS, query));
 
     expect(JSON.stringify(client.calls[1]?.messages)).toContain('remember me');
+  });
+
+  // The reference adapter constructs `AgentSession(session_id=partition_key)`, so tools,
+  // middleware and custom agents observe the conversation's real identity rather than a
+  // throwaway UUID.
+  function recording(agent: Agent, created: Array<string | undefined>): AgentLike {
+    return {
+      id: agent.id,
+      run: agent.run.bind(agent),
+      createSession: (options) => {
+        created.push(options?.sessionId);
+        return agent.createSession(options);
+      },
+      deserializeSession: agent.deserializeSession.bind(agent),
+      asTool: agent.asTool.bind(agent),
+    };
+  }
+
+  it('creates the local session under the resolved session id', async () => {
+    const created: Array<string | undefined> = [];
+    const agent = new Agent({ client: new MockChatClient([say('ok')]), instructions: 'x' });
+    const app = new InvocationsHostServer({ agent: recording(agent, created), hosted: false });
+
+    await app.handle(invoke({ message: 'hi' }, {}, '?agent_session_id=sess-a'));
+
+    expect(created).toEqual(['sess-a']);
+  });
+
+  it('creates the hosted session under the user-partitioned key', async () => {
+    const created: Array<string | undefined> = [];
+    const agent = new Agent({ client: new MockChatClient([say('ok')]), instructions: 'x' });
+    const app = new InvocationsHostServer({ agent: recording(agent, created), hosted: true });
+
+    await app.handle(invoke({ message: 'hi' }, HOSTED_HEADERS, '?agent_session_id=shared-sandbox'));
+
+    expect(created).toEqual(['shared-sandbox:user-1']);
   });
 });

--- a/packages/foundry/src/hosting/invocations.ts
+++ b/packages/foundry/src/hosting/invocations.ts
@@ -20,36 +20,22 @@ export interface InvocationsHostServerConfig extends Pick<InvocationsServerConfi
   hosted?: boolean;
 }
 
-/** The session partition for one invocation: the map key, and the identity the session carries. */
-interface SessionPartition {
-  /**
-   * The key conversations are stored under.
-   *
-   * An injective encoding of the (session, user) pair, not a delimiter join: the session id is
-   * caller-supplied and may itself contain `:`, so `S:v` × user `u` and `S` × user `v:u` would
-   * otherwise collapse into one partition and hand one user another's conversation (the same
-   * delimiter-collision defect the Responses session store fixed).
-   */
-  readonly key: string;
-  /**
-   * What the session reports as its id — the reference's human-readable `sessionId:userId`
-   * spelling, kept so tools and middleware observe the same identity they would under the
-   * Python adapter.
-   */
-  readonly sessionId: string;
-}
-
 /**
- * The session partition for one invocation.
+ * The session partition key for one invocation — the map key *and* the session's own id.
  *
  * Hosted, the partition is per session *and* user: one container session serves several end
  * users under container protocol 2.0.0, so the session id alone would hand one user another's
  * conversation. Locally there is no platform to inject a user, and the session id is the whole
  * partition.
+ *
+ * One value serves both roles on purpose. `AgentSession.sessionId` is the conversation's stable
+ * identifier — an external store keyed by it partitions exactly as well as the id distinguishes,
+ * so a colliding spelling there would reopen the cross-user mix-up even with a distinct session
+ * object per pair.
  */
-function partitionKey(context: InvocationContext, hosted: boolean): SessionPartition {
+function partitionKey(context: InvocationContext, hosted: boolean): string {
   if (!hosted) {
-    return { key: context.sessionId, sessionId: context.sessionId };
+    return context.sessionId;
   }
   // The only runtime signal of the protocol version is whether the call id header is present.
   // Serving a v1.0.0 caller would run without the per-user partition this handler depends on,
@@ -72,10 +58,13 @@ function partitionKey(context: InvocationContext, hosted: boolean): SessionParti
       { code: 'missing_user_id', source: 'platform' },
     );
   }
-  return {
-    key: JSON.stringify([context.sessionId, userId]),
-    sessionId: `${context.sessionId}:${userId}`,
-  };
+  // The reference spells this `sessionId:userId`, but a bare join is not injective: the session
+  // id is caller-supplied and may itself contain `:`, so `S:v` × user `u` and `S` × user `v:u`
+  // would collapse into one identity (the same delimiter-collision defect the Responses session
+  // store fixed). URI-escaping the components keeps the join injective — the separator can never
+  // appear inside either side — and leaves ids without reserved characters spelled exactly as
+  // the reference spells them.
+  return `${encodeURIComponent(context.sessionId)}:${encodeURIComponent(userId)}`;
 }
 
 /** What a well-formed invocation body carries. */
@@ -100,7 +89,7 @@ function invocationHandler(agent: AgentLike, hosted: boolean): InvocationHandler
   const sessions = new Map<string, AgentSession>();
 
   return async (request: Request, context: InvocationContext): Promise<Response> => {
-    const partition = partitionKey(context, hosted);
+    const key = partitionKey(context, hosted);
 
     let payload: unknown;
     try {
@@ -110,13 +99,13 @@ function invocationHandler(agent: AgentLike, hosted: boolean): InvocationHandler
     }
     const { message, stream } = parseInvocation(payload);
 
-    let session = sessions.get(partition.key);
+    let session = sessions.get(key);
     if (session === undefined) {
-      // Under the partition's identity on purpose (the reference constructs
+      // Under the partition key on purpose (the reference constructs
       // `AgentSession(session_id=partition_key)`): tools, middleware and custom agents observe
       // the conversation's real identity through the session, not a throwaway UUID.
-      session = agent.createSession({ sessionId: partition.sessionId });
-      sessions.set(partition.key, session);
+      session = agent.createSession({ sessionId: key });
+      sessions.set(key, session);
     }
 
     if (!stream) {

--- a/packages/foundry/src/hosting/invocations.ts
+++ b/packages/foundry/src/hosting/invocations.ts
@@ -20,16 +20,36 @@ export interface InvocationsHostServerConfig extends Pick<InvocationsServerConfi
   hosted?: boolean;
 }
 
+/** The session partition for one invocation: the map key, and the identity the session carries. */
+interface SessionPartition {
+  /**
+   * The key conversations are stored under.
+   *
+   * An injective encoding of the (session, user) pair, not a delimiter join: the session id is
+   * caller-supplied and may itself contain `:`, so `S:v` × user `u` and `S` × user `v:u` would
+   * otherwise collapse into one partition and hand one user another's conversation (the same
+   * delimiter-collision defect the Responses session store fixed).
+   */
+  readonly key: string;
+  /**
+   * What the session reports as its id — the reference's human-readable `sessionId:userId`
+   * spelling, kept so tools and middleware observe the same identity they would under the
+   * Python adapter.
+   */
+  readonly sessionId: string;
+}
+
 /**
- * The session partition key for one invocation.
+ * The session partition for one invocation.
  *
- * Hosted, the key is `sessionId:userId`: one container session serves several end users under
- * container protocol 2.0.0, so the session id alone would hand one user another's conversation.
- * Locally there is no platform to inject a user, and the session id is the whole key.
+ * Hosted, the partition is per session *and* user: one container session serves several end
+ * users under container protocol 2.0.0, so the session id alone would hand one user another's
+ * conversation. Locally there is no platform to inject a user, and the session id is the whole
+ * partition.
  */
-function partitionKey(context: InvocationContext, hosted: boolean): string {
+function partitionKey(context: InvocationContext, hosted: boolean): SessionPartition {
   if (!hosted) {
-    return context.sessionId;
+    return { key: context.sessionId, sessionId: context.sessionId };
   }
   // The only runtime signal of the protocol version is whether the call id header is present.
   // Serving a v1.0.0 caller would run without the per-user partition this handler depends on,
@@ -52,7 +72,10 @@ function partitionKey(context: InvocationContext, hosted: boolean): string {
       { code: 'missing_user_id', source: 'platform' },
     );
   }
-  return `${context.sessionId}:${userId}`;
+  return {
+    key: JSON.stringify([context.sessionId, userId]),
+    sessionId: `${context.sessionId}:${userId}`,
+  };
 }
 
 /** What a well-formed invocation body carries. */
@@ -77,7 +100,7 @@ function invocationHandler(agent: AgentLike, hosted: boolean): InvocationHandler
   const sessions = new Map<string, AgentSession>();
 
   return async (request: Request, context: InvocationContext): Promise<Response> => {
-    const key = partitionKey(context, hosted);
+    const partition = partitionKey(context, hosted);
 
     let payload: unknown;
     try {
@@ -87,13 +110,13 @@ function invocationHandler(agent: AgentLike, hosted: boolean): InvocationHandler
     }
     const { message, stream } = parseInvocation(payload);
 
-    let session = sessions.get(key);
+    let session = sessions.get(partition.key);
     if (session === undefined) {
-      // Under the partition key on purpose (the reference constructs
+      // Under the partition's identity on purpose (the reference constructs
       // `AgentSession(session_id=partition_key)`): tools, middleware and custom agents observe
       // the conversation's real identity through the session, not a throwaway UUID.
-      session = agent.createSession({ sessionId: key });
-      sessions.set(key, session);
+      session = agent.createSession({ sessionId: partition.sessionId });
+      sessions.set(partition.key, session);
     }
 
     if (!stream) {
@@ -112,13 +135,19 @@ function invocationHandler(agent: AgentLike, hosted: boolean): InvocationHandler
     return new Response(
       new ReadableStream<Uint8Array>({
         async pull(controller): Promise<void> {
-          const { done, value } = await iterator.next();
-          if (done === true) {
-            controller.close();
-            return;
-          }
-          if (value.text !== '') {
-            controller.enqueue(encoder.encode(value.text));
+          // Until something is enqueued or the run ends: a tool round surfaces as updates with
+          // no text, and returning empty-handed would just make the stream machinery re-enter
+          // immediately — the loop is the same consumption, without the churn.
+          for (;;) {
+            const { done, value } = await iterator.next();
+            if (done === true) {
+              controller.close();
+              return;
+            }
+            if (value.text !== '') {
+              controller.enqueue(encoder.encode(value.text));
+              return;
+            }
           }
         },
         async cancel(): Promise<void> {

--- a/packages/foundry/src/hosting/invocations.ts
+++ b/packages/foundry/src/hosting/invocations.ts
@@ -89,7 +89,10 @@ function invocationHandler(agent: AgentLike, hosted: boolean): InvocationHandler
 
     let session = sessions.get(key);
     if (session === undefined) {
-      session = agent.createSession();
+      // Under the partition key on purpose (the reference constructs
+      // `AgentSession(session_id=partition_key)`): tools, middleware and custom agents observe
+      // the conversation's real identity through the session, not a throwaway UUID.
+      session = agent.createSession({ sessionId: key });
       sessions.set(key, session);
     }
 

--- a/packages/foundry/src/hosting/invocations.ts
+++ b/packages/foundry/src/hosting/invocations.ts
@@ -1,0 +1,166 @@
+import type {
+  InvocationContext,
+  InvocationHandler,
+  InvocationsServerConfig,
+} from '@polymind-inc/agent-framework-agentserver';
+import {
+  badRequest,
+  InvocationsServer,
+  isHosted,
+  notImplemented,
+  ProtocolError,
+} from '@polymind-inc/agent-framework-agentserver';
+import type { AgentLike, AgentSession } from '@polymind-inc/agent-framework-core';
+
+/** Construction options for {@link InvocationsHostServer}. */
+export interface InvocationsHostServerConfig extends Pick<InvocationsServerConfig, 'prefix'> {
+  /** The agent every invocation runs. */
+  agent: AgentLike;
+  /** Overrides `FOUNDRY_HOSTING_ENVIRONMENT` detection. */
+  hosted?: boolean;
+}
+
+/**
+ * The session partition key for one invocation.
+ *
+ * Hosted, the key is `sessionId:userId`: one container session serves several end users under
+ * container protocol 2.0.0, so the session id alone would hand one user another's conversation.
+ * Locally there is no platform to inject a user, and the session id is the whole key.
+ */
+function partitionKey(context: InvocationContext, hosted: boolean): string {
+  if (!hosted) {
+    return context.sessionId;
+  }
+  // The only runtime signal of the protocol version is whether the call id header is present.
+  // Serving a v1.0.0 caller would run without the per-user partition this handler depends on,
+  // so it refuses, exactly as the Responses handler does.
+  if (context.request.foundryCallId === undefined) {
+    throw notImplemented(
+      'This container implements Invocations container protocol 2.0.0, which requires the ' +
+        'x-agent-foundry-call-id header. The request did not carry one.',
+      'unsupported_container_protocol_version',
+    );
+  }
+  const userId = context.request.userId;
+  // An *empty* header is rejected the same as a missing one: it would silently fall through to
+  // an anonymous partition every caller of a misconfigured gateway would share.
+  if (userId === undefined || userId === '') {
+    throw new ProtocolError(
+      400,
+      'The hosted environment is missing the platform user id. The request did not come from a ' +
+        'Foundry platform service.',
+      { code: 'missing_user_id', source: 'platform' },
+    );
+  }
+  return `${context.sessionId}:${userId}`;
+}
+
+/** What a well-formed invocation body carries. */
+function parseInvocation(payload: unknown): { message: string; stream: boolean } {
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    throw badRequest('The request body must be a JSON object.');
+  }
+  const { message, stream } = payload as { message?: unknown; stream?: unknown };
+  if (typeof message !== 'string' || message === '') {
+    throw badRequest("The request body must carry a non-empty 'message' string.", {
+      param: 'message',
+    });
+  }
+  return { message, stream: stream === true };
+}
+
+function invocationHandler(agent: AgentLike, hosted: boolean): InvocationHandler {
+  // In memory on purpose: the platform stores no conversation history for the Invocations
+  // protocol — the `agent_session_id` the caller pins routes it back to the same sandbox, and
+  // the sandbox's own memory is where the conversation lives (the Python adapter keeps the same
+  // dict). A recycled sandbox starts the conversation over.
+  const sessions = new Map<string, AgentSession>();
+
+  return async (request: Request, context: InvocationContext): Promise<Response> => {
+    const key = partitionKey(context, hosted);
+
+    let payload: unknown;
+    try {
+      payload = await request.json();
+    } catch (error) {
+      throw badRequest('The request body must be a JSON object.', { cause: error });
+    }
+    const { message, stream } = parseInvocation(payload);
+
+    let session = sessions.get(key);
+    if (session === undefined) {
+      session = agent.createSession();
+      sessions.set(key, session);
+    }
+
+    if (!stream) {
+      const response = await agent.run(message, { session, signal: context.signal });
+      return new Response(response.text, {
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }
+
+    // The chunks are the updates' text, verbatim — the shape the Python adapter streams. The
+    // content type asks the protocol layer for SSE keep-alives; the framing of the payload
+    // itself is this adapter's wire contract, not the SSE spec's.
+    const updates = agent.run(message, { session, signal: context.signal });
+    const iterator = updates[Symbol.asyncIterator]();
+    const encoder = new TextEncoder();
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        async pull(controller): Promise<void> {
+          const { done, value } = await iterator.next();
+          if (done === true) {
+            controller.close();
+            return;
+          }
+          if (value.text !== '') {
+            controller.enqueue(encoder.encode(value.text));
+          }
+        },
+        async cancel(): Promise<void> {
+          await iterator.return?.();
+        },
+      }),
+      {
+        headers: {
+          'content-type': 'text/event-stream',
+          'cache-control': 'no-cache',
+          connection: 'keep-alive',
+        },
+      },
+    );
+  };
+}
+
+/**
+ * Publishes an agent as a Foundry Hosted Agent over the Invocations protocol.
+ *
+ * The counterpart of {@link ResponsesHostServer} for callers that cannot speak the Responses
+ * request shape. The wire contract is the adapter's own, matching the Python
+ * `InvocationsHostServer`: the request body is `{ "message": string, "stream"?: boolean }`;
+ * a non-streaming turn answers the agent's text as `text/plain`, a streaming one answers the
+ * update text chunks under `text/event-stream`.
+ *
+ * Conversation state lives in this process, partitioned per session — and per user when hosted.
+ * The platform stores no history for this protocol: for a multi-turn conversation the caller
+ * pins the `agent_session_id` query parameter to the value the previous response's
+ * `x-agent-session-id` header reported, which routes the turn back to the same sandbox.
+ *
+ * ```ts
+ * const agent = new Agent({
+ *   client: new FoundryChatClient({ projectEndpoint, target: { modelDeployment } }),
+ *   instructions: 'You are a helpful assistant.',
+ * });
+ *
+ * await serve(new InvocationsHostServer({ agent }));
+ * ```
+ */
+export class InvocationsHostServer extends InvocationsServer {
+  constructor(options: InvocationsHostServerConfig) {
+    super({
+      handler: invocationHandler(options.agent, options.hosted ?? isHosted()),
+      ...(options.prefix === undefined ? {} : { prefix: options.prefix }),
+    });
+  }
+}


### PR DESCRIPTION
Closes #29.

Adds the Foundry Hosted Agent **HTTP Invocations protocol** alongside the existing Responses container protocol, in the same two-layer shape.

## Protocol layer — `InvocationsServer` (agentserver)

- Routes: `POST /invocations`, `GET /invocations/{id}`, `POST /invocations/{id}/cancel`, `GET /readiness`. The read and cancel routes answer 404 until their optional handlers are registered, matching both reference SDKs; the invoke handler is required by the constructor.
- **The payload is deliberately unprescribed** (as in `Azure.AI.AgentServer.Invocations` and `azure-ai-agentserver-invocations`): the request body reaches the handler unread, and the handler's `Response` — body, status, content type — is what the caller gets.
- Invocation id: `x-agent-invocation-id`, sanitized (≤256 chars of `[A-Za-z0-9._:-]`), replaced with a generated UUID rather than rejected. Session id: `agent_session_id` query → `FOUNDRY_AGENT_SESSION_ID` → generated UUID, one rule for all three routes. Both ids are echoed on every response, including errors.
- Handler exceptions are opaque 500s classified `upstream` on `x-platform-error-source`; `ProtocolError` throws pass through with their own status, code and source. `x-platform-server` reports `protocol/invocations-2.0.0`.
- Cancellation: caller disconnect and container drain compose into `InvocationContext.signal`. No request timeout, matching the reference (which removed one deliberately). The cancel route's semantics stay handler-owned; the server keeps no invocation registry.
- SSE keep-alive comments are injected only when the handler declares `text/event-stream` and `SSE_KEEPALIVE_INTERVAL` is set, reading at most one chunk ahead so backpressure is preserved. No server span; `azure.ai.agentserver.invocation_id` / `.session_id` baggage, same keys as both references.
- Shared HTTP plumbing (error envelope, standard headers, prefix handling) is extracted to one module used by both protocol servers, and `serve()` on `/agentserver/node` now accepts any `{ fetch, drain }` protocol server (a non-breaking widening).

## Hosting adapter — `InvocationsHostServer` (foundry/hosting)

Publishes an `Agent` over the protocol with the wire contract of the Python `InvocationsHostServer`, the only reference adapter (.NET Foundry.Hosting is Responses-only):

- Request `{ "message": string, "stream"?: boolean }`; missing or non-string `message` is a 400. Non-streaming turns answer `text/plain`; streaming turns send the update text chunks under `text/event-stream`.
- Conversations live in process, keyed per session — and per platform user when hosted — since the platform stores no history for this protocol; callers continue by pinning `agent_session_id` to the previous response's `x-agent-session-id` header.
- Container protocol 2.0.0 fail-close: hosted without `x-agent-foundry-call-id` → 501 `unsupported_container_protocol_version`; hosted without a user id → 400 `missing_user_id`.
- Three defects observed in the reference adapter are deliberately not reproduced: internal error text leaking to the client, 400s returned as one-character streaming responses, and inconsistent run-argument shapes between the stream and non-stream paths.

## Tests, example, docs

- 40 protocol conformance tests (routes, ids, header contract, error classification, draining, cancellation, SSE keep-alive, streamed-body context) + 16 adapter tests (wire contract, session continuity, per-user partitioning, fail-close) + a real-socket smoke through `serve`. Load-bearing behaviors were mutation-checked: breaking the error-header stamping, the keep-alive gate and the user partition each fails its test.
- New runnable example `examples/02-foundry/05-invocations-agent` with `agent.yaml` (`protocol: invocations`, `version: 2.0.0`), Dockerfile, azd manifest and a README covering local runs, multi-turn via `agent_session_id`, streaming and deployment.
- Existing Responses endpoints are untouched by behavior: all pre-existing tests pass unchanged (`pnpm check` green end to end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)