### PR TITLE
Align Dependabot pull request titles with the commit subject convention

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    commit-message:
-      prefix: 'ci'
 
   - package-ecosystem: npm
     directory: /
@@ -25,5 +23,3 @@ updates:
         dependency-type: production
       development-dependencies:
         dependency-type: development
-    commit-message:
-      prefix: 'deps'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,9 +81,9 @@ also carries an explicit **"Security considerations"** note, as the .NET impleme
 - One concern per pull request.
 - Commit subjects and pull request titles are plain English imperative sentences with no
   `type:` prefix — "Add the umbrella package", not "feat: add umbrella package". Pull requests
-  are squash-merged, so the title becomes the commit subject on the default branch. The
-  conventional-commit prefixes configured in `dependabot.yml` apply only to Dependabot's own
-  commits. Prefix a backward-incompatible change with `[BREAKING]`; automation keeps the
+  are squash-merged, so the title becomes the commit subject on the default branch.
+  Dependabot's default "Bump …" titles already follow this form.
+  Prefix a backward-incompatible change with `[BREAKING]`; automation keeps the
   `breaking change` label synchronized with the title and pull request template.
 - `pnpm check` passes.
 - Behaviour changes come with a test that fails without the change.


### PR DESCRIPTION
## What this changes

Removes the `commit-message.prefix` settings (`ci` / `deps`) from `.github/dependabot.yml`. With a prefix configured, Dependabot titled its pull requests like `deps: bump @biomejs/biome from 2.5.6 to 2.5.7 …`, and because pull requests are squash-merged, those prefixed subjects landed on `master` — unlike every other commit, which uses a plain imperative sentence with no `type:` prefix. Without a prefix, Dependabot falls back to its default `Bump X from A to B` titles, which already match the convention. The carve-out note in CONTRIBUTING.md is updated accordingly.

Configuration only — no code or behaviour changes.

## Parity

- Reference checked: not applicable (repository tooling)
- Wire format affected: no
- Public API affected: no
- Breaking change: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)