### PR TITLE
Correct the pinned actions/labeler version comment

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This action reads the changed-file list through the API and never checks out PR code.
-      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v6
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What this changes

The `actions/labeler` step in `label-pr.yml` is pinned to SHA `bf12e9b`, which is v7.0.0, but the
trailing comment still read `# v6` after the 6.1.0 to 7.0.0 bump. The comment is the only
human-readable record of what a pinned SHA resolves to, so a stale one makes the pin harder to
audit and invites a wrong conclusion about which major version the workflow actually runs.

Update the comment to `# v7.0.0`, matching the `vX.Y.Z` form used by every other pinned action.

Only the comment changes — the SHA, and therefore the version that runs, is untouched.

Every pinned action across the workflows was resolved through the GitHub API and checked against
its comment; this was the only mismatch:

| Workflow | Action | SHA resolves to | Comment |
| --- | --- | --- | --- |
| `ci.yml`, `release.yml` | `actions/checkout` | v7.0.1 | v7.0.1 |
| `ci.yml`, `release.yml` | `pnpm/action-setup` | v6.0.10 | v6.0.10 |
| `ci.yml`, `release.yml` | `actions/setup-node` | v7.0.0 | v7.0.0 |
| `label-issues.yml`, `label-pr.yml` | `actions/github-script` | v9.0.0 | v9.0.0 |
| `label-pr.yml` | `actions/labeler` | v7.0.0 | v6 → **v7.0.0** |

## Parity

- Reference checked: n/a — CI metadata only, no library behaviour
- Wire format affected: no
- Public API affected: no
- Breaking change: no

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change — n/a, comment-only
- [x] Public API changes are reflected in the package README and `CHANGELOG.md` — n/a
