### PR TITLE
Make encrypted reasoning an explicit opt-in on Foundry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,20 @@ contain breaking changes**; patch releases are fixes only.
   so their behavior is unchanged. **A custom `ChatClient` implementation that relied on the loop
   pinning `conv_…` ids must now declare the predicate on its `metadata`** — without it, every
   conversation id a round reports advances the chain, matching the .NET and Python loops.
+- **[BREAKING] `@polymind-inc/agent-framework-foundry`** — `FoundryChatClient` no longer asks for
+  `reasoning.encrypted_content` implicitly. Not every Foundry deployment supports encrypted
+  reasoning, and one that does not rejects a request that asks for it — which the client did on
+  every call without service-side storage, with no way to turn it off. **A caller whose deployment
+  does support encrypted reasoning, and who replays the transcript from their own side, must now
+  list `reasoning.encrypted_content` in `options.include`**; without it a reasoning model's
+  replayed transcript fails for missing reasoning content. Matches the upstream Python fix and the
+  function-calling loop specification, which make the request an explicit caller opt-in on
+  Foundry.
+- **`@polymind-inc/agent-framework-openai`** — new `includeReasoningEncryptedContent` construction
+  option (default `true`, so OpenAI and Azure OpenAI are unchanged). Setting it to `false`
+  suppresses the implicit `reasoning.encrypted_content` request for an endpoint that rejects it;
+  an entry the caller lists in `include` themselves is always sent either way. Mirrors the .NET
+  clients' option of the same name.
 
 ## 0.2.2
 

--- a/packages/foundry/src/chat-client.test.ts
+++ b/packages/foundry/src/chat-client.test.ts
@@ -188,6 +188,66 @@ describe('FoundryChatClient', () => {
     ]);
   });
 
+  // Foundry deployments do not all support encrypted reasoning, and one that does not rejects a
+  // request that asks for it. Asking implicitly would make those deployments unreachable.
+  it('does not request encrypted reasoning by default', () => {
+    const client = new FoundryChatClient({
+      projectEndpoint: PROJECT,
+      target: { modelDeployment: 'gpt-4o' },
+      client: { responses: { create: vi.fn() }, baseURL: PROJECT } as unknown as OpenAI,
+    });
+
+    const request = client.buildRequest([{ role: 'user', contents: [textContent('hi')] }]);
+
+    expect('include' in request).toBe(false);
+  });
+
+  it('preserves an explicit encrypted reasoning opt-in', () => {
+    const client = new FoundryChatClient({
+      projectEndpoint: PROJECT,
+      target: { modelDeployment: 'gpt-4o' },
+      client: { responses: { create: vi.fn() }, baseURL: PROJECT } as unknown as OpenAI,
+    });
+
+    const request = client.buildRequest([{ role: 'user', contents: [textContent('hi')] }], {
+      include: ['reasoning.encrypted_content'],
+    });
+
+    expect(request.include).toEqual(['reasoning.encrypted_content']);
+  });
+
+  // Nothing adds the entry back on Foundry, so an unrelated raw `include` — which replaces the
+  // typed list wholesale — would drop the opt-in and fail the stateless replay it was there for.
+  it('preserves an explicit opt-in that additionalProperties replaced', () => {
+    const client = new FoundryChatClient({
+      projectEndpoint: PROJECT,
+      target: { modelDeployment: 'gpt-4o' },
+      client: { responses: { create: vi.fn() }, baseURL: PROJECT } as unknown as OpenAI,
+    });
+
+    const request = client.buildRequest([{ role: 'user', contents: [textContent('hi')] }], {
+      include: ['reasoning.encrypted_content'],
+      additionalProperties: { include: ['file_search_call.results'] },
+    });
+
+    expect(request.include).toEqual(['file_search_call.results', 'reasoning.encrypted_content']);
+  });
+
+  it('does not request encrypted reasoning on the request it actually sends', async () => {
+    const completed = { id: 'resp_1', object: 'response', status: 'completed', output: [] };
+    const create = vi.fn().mockResolvedValue(completed);
+    const client = new FoundryChatClient({
+      projectEndpoint: PROJECT,
+      target: { modelDeployment: 'gpt-4o' },
+      client: { responses: { create }, baseURL: PROJECT } as unknown as OpenAI,
+    });
+
+    await client.getResponse([{ role: 'user', contents: [textContent('hi')] }]);
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create.mock.calls[0]?.[0]).not.toHaveProperty('include');
+  });
+
   it('sends the credential token as the bearer, to the target endpoint', async () => {
     const credential = fakeCredential();
     const seen: Array<{ url: string; authorization: string | null }> = [];

--- a/packages/foundry/src/chat-client.ts
+++ b/packages/foundry/src/chat-client.ts
@@ -104,9 +104,16 @@ export class FoundryChatClient
         ...(config.fetch === undefined ? {} : { fetch: config.fetch }),
       });
 
-    this.#inner = new OpenAIChatClient(
-      model === undefined ? { client, endpointProvidesModel: true } : { client, model },
-    );
+    this.#inner = new OpenAIChatClient({
+      client,
+      // Not every Foundry deployment supports encrypted reasoning, and one that does not rejects
+      // a request that asks for it — so asking implicitly would make those deployments
+      // unreachable. A caller whose deployment does support it opts in per request by listing
+      // `reasoning.encrypted_content` in `include`, which is what a replayed transcript of a
+      // reasoning model needs.
+      includeReasoningEncryptedContent: false,
+      ...(model === undefined ? { endpointProvidesModel: true as const } : { model }),
+    });
     this.metadata = {
       providerName: 'azure.ai.foundry',
       ...(model === undefined ? {} : { modelId: model }),

--- a/packages/openai/src/chat-client.test.ts
+++ b/packages/openai/src/chat-client.test.ts
@@ -432,6 +432,57 @@ describe('OpenAIChatClient request mapping', () => {
     expect(request.include).toEqual(['message.output_text.logprobs']);
   });
 
+  // Not every deployment behind a Responses endpoint supports encrypted reasoning, and a request
+  // that asks for it is rejected outright there. The flag turns off the *implicit* request only.
+  describe('with includeReasoningEncryptedContent: false', () => {
+    const optedOut = new OpenAIChatClient({
+      client: fakeClient(vi.fn()),
+      model: 'gpt-4o',
+      includeReasoningEncryptedContent: false,
+    });
+
+    it('leaves include off the request entirely', () => {
+      expect('include' in optedOut.buildRequest(HI)).toBe(false);
+    });
+
+    it('keeps an unrelated include list intact', () => {
+      expect(optedOut.buildRequest(HI, { include: ['file_search_call.results'] }).include).toEqual([
+        'file_search_call.results',
+      ]);
+    });
+
+    it('honours an explicit caller opt-in, through either include route', () => {
+      expect(optedOut.buildRequest(HI, { include: ['reasoning.encrypted_content'] }).include).toEqual([
+        'reasoning.encrypted_content',
+      ]);
+      expect(
+        optedOut.buildRequest(HI, {
+          additionalProperties: { include: ['reasoning.encrypted_content'] },
+        }).include,
+      ).toEqual(['reasoning.encrypted_content']);
+    });
+
+    // A raw `include` replaces the typed list wholesale, so with nothing adding the entry back an
+    // explicit opt-in would be dropped by an unrelated pass-through — silently disabling the
+    // replay of a reasoning model's transcript, which is what the opt-in exists for.
+    it('keeps an explicit opt-in that additionalProperties replaced', () => {
+      const request = optedOut.buildRequest(HI, {
+        include: ['reasoning.encrypted_content'],
+        additionalProperties: { include: ['file_search_call.results'] },
+      });
+      expect(request.include).toEqual(['file_search_call.results', 'reasoning.encrypted_content']);
+    });
+
+    it('keeps an explicit opt-in under service storage too', () => {
+      const request = optedOut.buildRequest(HI, {
+        conversationId: 'conv_1',
+        include: ['reasoning.encrypted_content'],
+        additionalProperties: { include: ['file_search_call.results'] },
+      });
+      expect(request.include).toEqual(['file_search_call.results', 'reasoning.encrypted_content']);
+    });
+  });
+
   it('passes additionalProperties through and lets rawRequestTransform have the last word', () => {
     const request = client.buildRequest(HI, {
       additionalProperties: { safety_identifier: 'abc' },

--- a/packages/openai/src/chat-client.ts
+++ b/packages/openai/src/chat-client.ts
@@ -68,6 +68,17 @@ export interface OpenAIChatClientOptions {
   apiKey?: string;
   /** Convenience for `new OpenAI({ baseURL })` when `client` is omitted. */
   baseURL?: string;
+  /**
+   * Whether to ask for `reasoning.encrypted_content` on requests whose transcript is replayed from
+   * this side. Defaults to `true`.
+   *
+   * A reasoning model needs its opaque reasoning payload back to accept a replayed transcript, so
+   * the request asks for it whenever there is no service-side storage to hold it. Set this to
+   * `false` for an endpoint whose deployments do not support encrypted reasoning and reject a
+   * request that asks for it. Only the implicit request is affected: an entry the caller puts in
+   * `include` themselves is always sent.
+   */
+  includeReasoningEncryptedContent?: boolean;
 }
 
 /**
@@ -212,6 +223,7 @@ export class OpenAIChatClient
   readonly metadata: ChatClientMetadata;
   readonly #client: OpenAI;
   readonly #model: string | undefined;
+  readonly #includeReasoningEncryptedContent: boolean;
   /**
    * Normalizes anything thrown around an SDK call into the value this client throws.
    *
@@ -261,6 +273,7 @@ export class OpenAIChatClient
         ...(config.baseURL === undefined ? {} : { baseURL: config.baseURL }),
       });
     this.#model = config.model;
+    this.#includeReasoningEncryptedContent = config.includeReasoningEncryptedContent ?? true;
     this.metadata = {
       providerName: detectProviderName(this.#client),
       ...(config.model === undefined ? {} : { modelId: config.model }),
@@ -383,10 +396,20 @@ export class OpenAIChatClient
     // supplied (`_prepare_options`), so the entry can never be lost; doing the merge here
     // reproduces that while leaving "additionalProperties wins" intact for the field itself and
     // for every other key.
+    //
+    // `includeReasoningEncryptedContent: false` suppresses only the *implicit* request, for an
+    // endpoint that rejects it. The caller's own entry is restored either way: with the implicit
+    // request off there is nothing else to add it back, so a raw `include` that replaced the typed
+    // list would drop an explicit opt-in — the one thing that reaches encrypted reasoning on such
+    // an endpoint — as silently as it would have disabled the implicit request.
     const passthroughInclude = request.include;
     if (passthroughInclude === undefined || Array.isArray(passthroughInclude)) {
       const include = [...((passthroughInclude as string[] | undefined) ?? options?.include ?? [])];
-      if (!usesServiceStorage && !include.includes('reasoning.encrypted_content')) {
+      const callerAskedForEncryptedReasoning =
+        options?.include?.includes('reasoning.encrypted_content') === true;
+      const wanted =
+        callerAskedForEncryptedReasoning || (this.#includeReasoningEncryptedContent && !usesServiceStorage);
+      if (wanted && !include.includes('reasoning.encrypted_content')) {
         include.push('reasoning.encrypted_content');
       }
       if (include.length > 0) {


### PR DESCRIPTION
## What this changes

A Responses request whose transcript is replayed from our side asks for `reasoning.encrypted_content` — a reasoning model needs its opaque payload back or it rejects the replay. Not every Foundry deployment supports encrypted reasoning, and one that does not rejects a request that merely *asks* for it.

`FoundryChatClient` asked on every call without service-side storage, and there was no way to turn it off: passing an empty `include`, or supplying one through `additionalProperties`, both still got the entry appended. Only `rawRequestTransform` could remove it, so those deployments were unreachable through the public API.

- **`@polymind-inc/agent-framework-openai`** — new `includeReasoningEncryptedContent` construction option, defaulting to `true`, so OpenAI and Azure OpenAI behave exactly as before.
- **`@polymind-inc/agent-framework-foundry`** — `FoundryChatClient` builds its inner client with the option off.

Only the *implicit* request is suppressed. An entry the caller lists in `include` themselves is always sent — through the typed option or through the raw `additionalProperties` pass-through that replaces the typed list wholesale. That second path matters here: with the implicit request off there is nothing else to add the entry back, so an unrelated raw `include` would otherwise drop the one thing that reaches encrypted reasoning on such an endpoint. The existing precedence is untouched: `additionalProperties.include` still replaces the typed list.

## Parity

Both reference implementations already treat this as opt-in, and they agree on the outcome from different directions:

- **.NET** — `AsIChatClientWithStoredOutputDisabled(..., bool includeReasoningEncryptedContent = true)` on both the OpenAI and the Foundry extensions; the implicit request has always been behind a caller flag.
- **Python** — the Foundry chat client now strips the entry unless the caller asked for it (the persistent agent client already did), and `docs/specs/004-python-function-calling-loop.md` states the rule: Foundry clients do not request `reasoning.encrypted_content` implicitly; callers may opt in explicitly when the deployment supports it.

This PR takes .NET's mechanism (a construction flag) and Python's semantics (the caller's own entry always wins), which land on the same observable behaviour as the Python fix. Python needs no equivalent of the second path because it has a single `include` channel; TypeScript has two, so "the caller asked" is read from the typed option independently.

- Reference checked: .NET `OpenAIResponseClientExtensions` / `ProjectResponsesClientExtensions`; Python `RawFoundryChatClient._prepare_options` and `docs/specs/004-python-function-calling-loop.md`
- Wire format affected: no
- Public API affected: yes
- Breaking change: yes

A caller whose deployment **does** support encrypted reasoning, and who replays the transcript from their own side, must now list `reasoning.encrypted_content` in `options.include`. Without it, a reasoning model's replayed transcript fails for missing reasoning content. This is the behaviour change upstream deliberately accepted; the changelog carries the migration.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`

Reproduction-first throughout, with the fix temporarily reverted afterwards to confirm each test fails again: Foundry omits the entry by default (on `buildRequest` and on the request actually sent); an explicit opt-in survives plain, and when `additionalProperties` replaces the include list, with and without service-side storage; the OpenAI default is unchanged, with the existing tests asserting the implicit request all still passing.
