### PR TITLE
Add the Foundry Memory context provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **`@polymind-inc/agent-framework-foundry`** — new `FoundryMemoryProvider`: a `ContextProvider`
+  backed by a Microsoft Foundry Memory Store
+  ([#25](https://github.com/polymind-inc/agent-framework-js/issues/25)). It searches the store
+  before each run — once per session for the user's profile memories, then per turn for memories
+  relevant to the input — injects what it finds as a single user message under a configurable
+  context prompt, and sends the completed turn back for extraction afterwards. A failed run is not
+  stored. Memories are partitioned by a **required** `scope`, given as a value or as a function of
+  the run and pinned to the session on first use, so one provider instance can serve every user of
+  a hosted container; `hostedUserScope()` (exported from `/hosting`) resolves it from the platform
+  user id of the turn. Service failures default to `failureMode: 'continue'` — the run proceeds
+  without the memories — and `'throw'` fails the run instead; `onFailure` observes both. The
+  provider also carries the store operations a caller needs around it:
+  `ensureMemoryStoreCreated`, `getMemoryStore`, `deleteStoredMemories` and `whenUpdatesCompleted`.
+  The transport is `fetch` against the preview memory-store routes (`Foundry-Features:
+  MemoryStores=V1Preview`) and is overridable, so tests need no live credentials.
 - **`@polymind-inc/agent-framework-agentserver`** — new `InvocationsServer`: the Foundry
   Invocations protocol ([#29](https://github.com/polymind-inc/agent-framework-js/issues/29)),
   served alongside the existing Responses protocol. The protocol prescribes no payload — the

--- a/examples/02-foundry/06-memory-agent/Dockerfile
+++ b/examples/02-foundry/06-memory-agent/Dockerfile
@@ -1,0 +1,13 @@
+# The container contract: listen on 0.0.0.0:${PORT:-8088} and answer GET /readiness.
+FROM node:24-slim
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Build the self-contained ESM bundle before building this image.
+COPY dist/main.mjs ./main.mjs
+COPY dist/main.mjs.map ./main.mjs.map
+
+# Foundry probes this port; binding elsewhere makes every invocation fail with session_not_ready.
+EXPOSE 8088
+
+CMD ["node", "main.mjs"]

--- a/examples/02-foundry/06-memory-agent/README.md
+++ b/examples/02-foundry/06-memory-agent/README.md
@@ -1,0 +1,101 @@
+# Hosted Agent with memory (Microsoft Foundry)
+
+A Hosted Agent that remembers what a user told it in an **earlier conversation**. The transcript
+already carries the current conversation; a
+[Foundry Memory Store](https://learn.microsoft.com/azure/ai-foundry/agents/concepts/agent-memory)
+is what survives it.
+
+| File                  | What it is                                                                     |
+| --------------------- | ------------------------------------------------------------------------------ |
+| `main.ts`             | The agent, its memory provider, and the server that publishes it               |
+| `provision.ts`        | Creates the memory store once, and can erase one user's memories               |
+| `agent.yaml`          | The Foundry agent definition (`kind: hosted`, protocol declaration, resources) |
+| `agent.manifest.yaml` | The `azd` manifest: the chat and embedding deployments this agent needs         |
+| `Dockerfile`          | Copies the prebuilt bundle into `node:24-slim` and exposes port 8088            |
+| `tsdown.config.ts`    | Bundles the TypeScript host and all runtime dependencies into `dist/main.mjs`  |
+
+## What the provider does
+
+`FoundryMemoryProvider` is a `ContextProvider`, so it sees every run twice:
+
+- **before the run** it searches the store — once per session for the user's profile memories, and
+  on every turn for memories relevant to what was just said — and injects what it finds as a single
+  user message under a `## Memories` heading;
+- **after the run** it sends the turn to the store, which extracts memories from it asynchronously.
+
+Memories are partitioned by **scope**. Here the scope is `hostedUserScope()`, which resolves to the
+end-user id the platform injects with each request, so one long-lived provider serves every user of
+the container without their memories ever meeting. Outside a hosted container there is no such
+identity — pass a scope of your own (a string, or a function of the run).
+
+## Set it up
+
+```bash
+export FOUNDRY_PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project>
+export AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini
+export AZURE_AI_EMBEDDING_MODEL_DEPLOYMENT_NAME=text-embedding-3-small
+export MEMORY_STORE_NAME=sample-memories
+```
+
+With `az login` done and **Azure AI User** on the project, create the store:
+
+```bash
+pnpm --filter example-02-foundry memory:provision
+```
+
+The store is configured with user-profile extraction on and chat summaries off, so it remembers
+durable preferences rather than the shape of each conversation. Re-running the script is safe.
+
+## Run it locally
+
+From the repository root:
+
+```bash
+pnpm install && pnpm -r build
+```
+
+Then start the bundle:
+
+```bash
+pnpm --filter example-02-foundry memory
+```
+
+For source-level development without rebuilding after every edit, use `memory:dev`.
+
+### See it remember
+
+The memory scope comes from the caller's identity, so send one — locally the container accepts the
+same header the platform sets:
+
+```bash
+curl -sS -X POST localhost:8088/responses -H 'content-type: application/json' -H 'x-agent-user-id: rin' -d '{"input": "I only drink black coffee, no sugar."}'
+```
+
+Extraction is asynchronous and takes a few seconds. Then start a **new** conversation — no
+`previous_response_id`, so nothing of the first exchange is in the transcript:
+
+```bash
+curl -sS -X POST localhost:8088/responses -H 'content-type: application/json' -H 'x-agent-user-id: rin' -d '{"input": "Order me a coffee."}'
+```
+
+The answer comes back without sugar. Ask as a different user (`x-agent-user-id: kai`) and it has
+nothing to go on — which is the isolation boundary doing its job.
+
+To start over:
+
+```bash
+pnpm --filter example-02-foundry memory:provision -- --reset rin
+```
+
+## Deploy it
+
+Same as the [Hosted Agent sample](../02-hosted-agent/README.md) — build the bundle, build the
+image, push it, and `azd ai agent deploy`. Two differences:
+
+- the agent's managed identity needs access to the memory store's project (**Azure AI User** on the
+  project scope is enough for both the model and the store);
+- `MEMORY_STORE_NAME` has to reach the container, which `agent.yaml` already declares.
+
+Provision the store **before** the first deployment: a missing store makes every search and update
+fail, and with the default `failureMode: 'continue'` that is a silent loss of memory rather than a
+visible error. The `onFailure` hook in `main.ts` is what makes it visible in the container log.

--- a/examples/02-foundry/06-memory-agent/agent.manifest.yaml
+++ b/examples/02-foundry/06-memory-agent/agent.manifest.yaml
@@ -1,0 +1,16 @@
+# azd manifest: the resources `azd ai agent init` provisions for this agent.
+name: memory-agent
+models:
+  - name: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}
+    format: OpenAI
+    version: '2024-07-18'
+    sku:
+      name: GlobalStandard
+      capacity: 30
+  # The memory store extracts with the chat model and searches with this one.
+  - name: ${AZURE_AI_EMBEDDING_MODEL_DEPLOYMENT_NAME}
+    format: OpenAI
+    version: '1'
+    sku:
+      name: GlobalStandard
+      capacity: 30

--- a/examples/02-foundry/06-memory-agent/agent.yaml
+++ b/examples/02-foundry/06-memory-agent/agent.yaml
@@ -1,0 +1,23 @@
+# Foundry Hosted Agent definition.
+# Schema: microsoft/AgentSchema ContainerAgent.yaml
+kind: hosted
+name: memory-agent
+description: An assistant with persistent memory, built with agent-framework-js.
+
+protocols:
+  # The container speaks Responses container protocol 2.0.0 and nothing else. There is no version
+  # negotiation: this declaration is what makes the platform send `x-agent-foundry-call-id`, and
+  # the container fails closed with 501 if it ever arrives without one.
+  - protocol: responses
+    version: 2.0.0
+
+resources:
+  cpu: '0.25'
+  memory: 0.5Gi
+
+environment_variables:
+  - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+    value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}
+  # The store is provisioned out of band by provision.ts; the agent only needs its name.
+  - name: MEMORY_STORE_NAME
+    value: ${MEMORY_STORE_NAME}

--- a/examples/02-foundry/06-memory-agent/main.ts
+++ b/examples/02-foundry/06-memory-agent/main.ts
@@ -1,0 +1,61 @@
+/**
+ * A Hosted Agent with persistent memory.
+ *
+ * `FoundryMemoryProvider` searches a Microsoft Foundry Memory Store before each turn and writes
+ * the turn back afterwards, so the agent recalls facts a user stated in an *earlier conversation*
+ * — not just earlier in this one, which the transcript already covers.
+ *
+ * The store is provisioned once, out of band:
+ *   pnpm --filter example-02-foundry memory:provision
+ *
+ * Locally:
+ *   pnpm --filter example-02-foundry build
+ *   pnpm --filter example-02-foundry memory
+ *
+ * On Foundry: see README.md.
+ */
+
+import { Agent } from '@polymind-inc/agent-framework';
+import { serve } from '@polymind-inc/agent-framework/agentserver/node';
+import { FoundryChatClient, FoundryMemoryProvider } from '@polymind-inc/agent-framework/foundry';
+import { hostedUserScope, ResponsesHostServer } from '@polymind-inc/agent-framework/foundry/hosting';
+
+const projectEndpoint = process.env.FOUNDRY_PROJECT_ENDPOINT;
+if (projectEndpoint === undefined) {
+  throw new Error('Set FOUNDRY_PROJECT_ENDPOINT to your Foundry project endpoint.');
+}
+const memoryStoreName = process.env.MEMORY_STORE_NAME;
+if (memoryStoreName === undefined) {
+  throw new Error('Set MEMORY_STORE_NAME to the memory store provisioned for this agent.');
+}
+
+const memory = new FoundryMemoryProvider({
+  projectEndpoint,
+  memoryStoreName,
+  // Every user of this container gets their own partition of the store. `hostedUserScope()` reads
+  // the end-user id the platform injects per request, so one provider instance serves all of them
+  // without ever mixing two users' memories; the scope is pinned to a session on first use.
+  scope: hostedUserScope(),
+  // A memory the service is having a bad minute with must not take the conversation down with it.
+  failureMode: 'continue',
+  onFailure: ({ operation, error }) => console.warn(`memory ${operation} failed:`, error),
+});
+
+const agent = new Agent({
+  client: new FoundryChatClient({
+    projectEndpoint,
+    target: { modelDeployment: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini' },
+  }),
+  name: 'memory-agent',
+  instructions:
+    'You are a helpful assistant that remembers what the user has told you in earlier ' +
+    'conversations. Relevant memories are supplied to you automatically. Use them, and say when ' +
+    'you are relying on something you remembered. Answer in one or two short sentences.',
+  contextProviders: [memory],
+  // The hosting infrastructure owns the transcript and replays it on each turn, so the provider
+  // must not also store it — otherwise every turn is sent twice.
+  defaultOptions: { store: false },
+});
+
+const { port } = await serve(new ResponsesHostServer({ agent }));
+console.log(`listening on 0.0.0.0:${port}`);

--- a/examples/02-foundry/06-memory-agent/provision.ts
+++ b/examples/02-foundry/06-memory-agent/provision.ts
@@ -1,0 +1,63 @@
+/**
+ * Provisions the memory store the agent in `main.ts` reads and writes.
+ *
+ * Safe to re-run: an existing store of the same name is left alone. Your identity needs
+ * **Azure AI User** on the Foundry project.
+ *
+ *   pnpm --filter example-02-foundry memory:provision
+ *
+ * Pass `--reset <user-id>` to also erase everything stored for one user, which is how you get a
+ * clean slate while trying the sample out.
+ */
+
+import { FoundryMemoryProvider } from '@polymind-inc/agent-framework/foundry';
+
+const projectEndpoint = process.env.FOUNDRY_PROJECT_ENDPOINT;
+if (projectEndpoint === undefined) {
+  throw new Error('Set FOUNDRY_PROJECT_ENDPOINT to your Foundry project endpoint.');
+}
+const memoryStoreName = process.env.MEMORY_STORE_NAME;
+if (memoryStoreName === undefined) {
+  throw new Error('Set MEMORY_STORE_NAME to the memory store to provision.');
+}
+
+// The scope is irrelevant to provisioning — no run happens here — but it is a required part of the
+// provider's contract, so the script names the user it may also be asked to reset.
+const resetUser = process.argv[process.argv.indexOf('--reset') + 1];
+const memory = new FoundryMemoryProvider({
+  projectEndpoint,
+  memoryStoreName,
+  scope: resetUser ?? 'provisioning',
+});
+
+const created = await memory.ensureMemoryStoreCreated(
+  {
+    kind: 'default',
+    chat_model: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini',
+    embedding_model: process.env.AZURE_AI_EMBEDDING_MODEL_DEPLOYMENT_NAME ?? 'text-embedding-3-small',
+    options: {
+      // Durable facts about the user are the point of this sample; per-conversation summaries are
+      // not, and the transcript already covers them.
+      user_profile_enabled: true,
+      user_profile_details:
+        'Preferences and stable facts only. Avoid sensitive data such as age, finances, precise ' +
+        'location and credentials.',
+      chat_summary_enabled: false,
+    },
+  },
+  { description: 'Memory store for the agent-framework-js hosted memory sample' },
+);
+
+console.log(
+  created
+    ? `Created memory store '${memoryStoreName}'.`
+    : `Memory store '${memoryStoreName}' already exists; left as-is.`,
+);
+
+if (process.argv.includes('--reset')) {
+  if (resetUser === undefined) {
+    throw new Error('--reset needs the user id whose memories should be erased.');
+  }
+  const erased = await memory.deleteStoredMemories(resetUser);
+  console.log(erased ? `Erased the memories of '${resetUser}'.` : `'${resetUser}' had no memories.`);
+}

--- a/examples/02-foundry/06-memory-agent/provision.ts
+++ b/examples/02-foundry/06-memory-agent/provision.ts
@@ -23,7 +23,8 @@ if (memoryStoreName === undefined) {
 
 // The scope is irrelevant to provisioning — no run happens here — but it is a required part of the
 // provider's contract, so the script names the user it may also be asked to reset.
-const resetUser = process.argv[process.argv.indexOf('--reset') + 1];
+const resetIndex = process.argv.indexOf('--reset');
+const resetUser = resetIndex === -1 ? undefined : process.argv[resetIndex + 1];
 const memory = new FoundryMemoryProvider({
   projectEndpoint,
   memoryStoreName,
@@ -54,7 +55,7 @@ console.log(
     : `Memory store '${memoryStoreName}' already exists; left as-is.`,
 );
 
-if (process.argv.includes('--reset')) {
+if (resetIndex !== -1) {
   if (resetUser === undefined) {
     throw new Error('--reset needs the user id whose memories should be erased.');
   }

--- a/examples/02-foundry/06-memory-agent/tsdown.config.ts
+++ b/examples/02-foundry/06-memory-agent/tsdown.config.ts
@@ -1,0 +1,23 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'tsdown';
+
+const sampleRoot = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  cwd: sampleRoot,
+  entry: ['main.ts'],
+  outDir: 'dist',
+  format: ['esm'],
+  platform: 'node',
+  target: 'es2024',
+  clean: true,
+  treeshake: true,
+  sourcemap: true,
+  dts: false,
+  outputOptions: { codeSplitting: false },
+  // This is an application bundle, not a library package. Include every dependency so the
+  // runtime image only needs the generated artifact and does not depend on the workspace tree.
+  deps: { alwaysBundle: [/.*/], onlyBundle: false },
+  outExtensions: () => ({ js: '.mjs' }),
+});

--- a/examples/02-foundry/package.json
+++ b/examples/02-foundry/package.json
@@ -7,7 +7,7 @@
     "node": ">=24"
   },
   "scripts": {
-    "build": "tsdown --config 02-hosted-agent/tsdown.config.ts && tsdown --config 05-invocations-agent/tsdown.config.ts",
+    "build": "tsdown --config 02-hosted-agent/tsdown.config.ts && tsdown --config 05-invocations-agent/tsdown.config.ts && tsdown --config 06-memory-agent/tsdown.config.ts",
     "chat": "tsx 01-foundry-chat.ts",
     "host": "node 02-hosted-agent/dist/main.mjs",
     "host:dev": "tsx 02-hosted-agent/main.ts",
@@ -15,6 +15,9 @@
     "toolbox": "tsx 04-toolbox.ts",
     "invocations": "node 05-invocations-agent/dist/main.mjs",
     "invocations:dev": "tsx 05-invocations-agent/main.ts",
+    "memory": "node 06-memory-agent/dist/main.mjs",
+    "memory:dev": "tsx 06-memory-agent/main.ts",
+    "memory:provision": "tsx 06-memory-agent/provision.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/examples/02-foundry/tsconfig.json
+++ b/examples/02-foundry/tsconfig.json
@@ -5,5 +5,5 @@
     "isolatedDeclarations": false,
     "noEmit": true
   },
-  "include": ["*.ts", "02-hosted-agent/*.ts"]
+  "include": ["*.ts", "*/*.ts"]
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,9 +36,12 @@ Foundry chat examples use Azure credentials from `DefaultAzureCredential`. Set
 | Invocations Hosted Agent | Serving the same agent over the Invocations protocol | `pnpm --filter example-02-foundry build`, then `pnpm --filter example-02-foundry invocations` |
 | Tool approval | Pausing, persisting, approving, denying, and resuming locally | `pnpm --filter example-02-foundry approval` |
 | Foundry Toolbox | Calling tools exposed by a Foundry Toolbox MCP endpoint | `pnpm --filter example-02-foundry toolbox` |
+| Memory | Recalling facts across conversations, scoped per user | `pnpm --filter example-02-foundry memory:provision`, then `build` and `pnpm --filter example-02-foundry memory` |
 
 See [`02-foundry/02-hosted-agent/README.md`](02-foundry/02-hosted-agent/README.md) for container
-build and deployment instructions.
+build and deployment instructions, and
+[`02-foundry/06-memory-agent/README.md`](02-foundry/06-memory-agent/README.md) for the memory
+store the memory sample needs.
 
 ## Extensibility and providers
 

--- a/packages/foundry/README.md
+++ b/packages/foundry/README.md
@@ -8,7 +8,8 @@
 > package.
 
 Microsoft Foundry provider for the Agent Framework: `FoundryChatClient` talks to a Foundry
-project (model deployments or server agents) with Microsoft Entra authentication, and the
+project (model deployments or server agents) with Microsoft Entra authentication,
+`FoundryMemoryProvider` gives an agent persistent memory backed by a Foundry Memory Store, and the
 `@polymind-inc/agent-framework-foundry/hosting` subpath publishes an `Agent` as a Foundry Hosted
 Agent — `ResponsesHostServer` over the Responses container protocol, `InvocationsHostServer` over
 the Invocations protocol — on the servers implemented by
@@ -26,6 +27,10 @@ needs it, so consumers using just `FoundryChatClient` can leave it uninstalled.
 
 Known limitations:
 
+- `FoundryMemoryProvider` targets the preview memory-store API (`Foundry-Features:
+  MemoryStores=V1Preview`) and implements the routes a context provider needs — search, update,
+  update-result polling, scope deletion, and store creation. Memory *items* have their own CRUD
+  routes, which are not covered.
 - `FoundryResponseStore` (the hosted default) keeps the response resource in the Foundry storage
   service and the background replay log beside the sandbox state — the storage service has no
   events API — so stream replay after a sandbox recycle fails closed rather than resuming.

--- a/packages/foundry/src/hosting.ts
+++ b/packages/foundry/src/hosting.ts
@@ -56,9 +56,9 @@ export type { HostedAgentContext } from './hosting/hosted-context.js';
 // The builder (hostedAgentContextOf) and the iteration wrapper stay internal: the handler is the
 // only writer, which is what keeps the ambient read-only for everything below it.
 export { getHostedAgentContext } from './hosting/hosted-context.js';
-
 export type { InvocationsHostServerConfig } from './hosting/invocations.js';
 export { InvocationsHostServer } from './hosting/invocations.js';
+export { hostedUserScope } from './hosting/memory-scope.js';
 export type { ResponsesHostServerConfig } from './hosting/server.js';
 export { defaultStore, ResponsesHostServer } from './hosting/server.js';
 

--- a/packages/foundry/src/hosting/memory-scope.test.ts
+++ b/packages/foundry/src/hosting/memory-scope.test.ts
@@ -1,0 +1,53 @@
+import type { HandlerContext } from '@polymind-inc/agent-framework-agentserver';
+import { createRequestContext } from '@polymind-inc/agent-framework-agentserver';
+import { ConfigurationError } from '@polymind-inc/agent-framework-core';
+import { describe, expect, it } from 'vitest';
+import { hostedAgentContextOf, withHostedAgentContext } from './hosted-context.js';
+import { hostedUserScope } from './memory-scope.js';
+
+function handlerContext(headers: Record<string, string>): HandlerContext {
+  const responseId = 'caresp_test';
+  return {
+    responseId,
+    conversationId: undefined,
+    request: createRequestContext(new Headers(headers)),
+    agentReference: { type: 'agent_reference', name: 'test-agent' },
+    agentSessionId: 'session-test',
+    history: [],
+    signal: new AbortController().signal,
+    response: { id: responseId, object: 'response', created_at: 0, status: 'queued', output: [] },
+  };
+}
+
+/** Reads `scope` from inside a hosted turn built on `headers`. */
+async function insideTurn(headers: Record<string, string>, scope: () => string): Promise<unknown> {
+  const context = hostedAgentContextOf(handlerContext(headers));
+  async function* source(): AsyncGenerator<unknown> {
+    try {
+      yield scope();
+    } catch (error) {
+      yield error;
+    }
+  }
+  for await (const value of withHostedAgentContext(context, source())) {
+    return value;
+  }
+  return undefined;
+}
+
+describe('hostedUserScope', () => {
+  it('scopes memories to the end user the platform injected', async () => {
+    expect(await insideTurn({ 'x-agent-user-id': 'alice' }, hostedUserScope())).toBe('alice');
+  });
+
+  it('refuses to fall back to a shared partition when the turn carries no user', async () => {
+    const result = await insideTurn({}, hostedUserScope());
+
+    expect(result).toBeInstanceOf(ConfigurationError);
+    expect((result as Error).message).toContain('no end-user id');
+  });
+
+  it('refuses to resolve outside a hosted turn', () => {
+    expect(() => hostedUserScope()()).toThrow(ConfigurationError);
+  });
+});

--- a/packages/foundry/src/hosting/memory-scope.ts
+++ b/packages/foundry/src/hosting/memory-scope.ts
@@ -1,0 +1,45 @@
+/**
+ * Memory scopes derived from the hosted turn's identity.
+ *
+ * The memory provider takes its scope as a value or a function; this is the function a hosted
+ * agent wants. It lives here, not beside the provider, because it reads the ambient hosted context
+ * — which only exists inside a hosting handler.
+ */
+
+import { ConfigurationError } from '@polymind-inc/agent-framework-core';
+import { getHostedAgentContext } from './hosted-context.js';
+
+/**
+ * Scopes memories to the end user of the hosted turn.
+ *
+ * ```ts
+ * new FoundryMemoryProvider({ memoryStoreName: 'assistant-memories', scope: hostedUserScope() });
+ * ```
+ *
+ * Throws outside a hosted turn, and when the platform supplied no user id, rather than falling
+ * back to a shared partition: a fallback here would quietly merge every user's memories into one
+ * scope, and that is a failure nobody notices until the memories of one user surface in another's
+ * conversation. Outside a hosted container, pass a scope of your own.
+ *
+ * There is no tenant equivalent. The platform injects exactly one identity per request — the end
+ * user — and a hosted container is deployed per agent inside one tenant, so the tenant boundary is
+ * the container's, not a partition inside the store.
+ */
+export function hostedUserScope(): () => string {
+  return () => {
+    const context = getHostedAgentContext();
+    if (context === undefined) {
+      throw new ConfigurationError(
+        'hostedUserScope() was called outside a hosted turn. It reads the identity the Foundry ' +
+          'hosting layer installs per request; outside a hosted container, pass an explicit scope.',
+      );
+    }
+    const userId = context.userId;
+    if (userId === undefined || userId.trim() === '') {
+      throw new ConfigurationError(
+        'The hosted turn carries no end-user id, so memories cannot be scoped to a user.',
+      );
+    }
+    return userId;
+  };
+}

--- a/packages/foundry/src/index.ts
+++ b/packages/foundry/src/index.ts
@@ -11,6 +11,16 @@ export type { OpenAIChatOptions } from '@polymind-inc/agent-framework-openai';
 export type { FoundryChatClientConfig } from './chat-client.js';
 export { FoundryChatClient } from './chat-client.js';
 export { tokenProvider } from './credential.js';
+// The memory-store client itself (memory/client.ts) is the provider's transport, not a public
+// surface; only the error it raises and the store definition a caller has to supply are exported.
+export type { MemoryOperation, MemoryStoreDefinition, MemoryStoreObject } from './memory/client.js';
+export { FoundryMemoryError } from './memory/client.js';
+export type {
+  FoundryMemoryFailure,
+  FoundryMemoryProviderConfig,
+  FoundryMemoryScope,
+} from './memory/provider.js';
+export { FoundryMemoryProvider } from './memory/provider.js';
 export type { FoundryEndpoint, FoundryTarget } from './target.js';
 export {
   FOUNDRY_API_VERSION,

--- a/packages/foundry/src/memory/client.test.ts
+++ b/packages/foundry/src/memory/client.test.ts
@@ -1,0 +1,219 @@
+import type { AccessToken, TokenCredential } from '@azure/identity';
+import { describe, expect, it } from 'vitest';
+import { FoundryMemoryError, MemoryStoreClient } from './client.js';
+
+const PROJECT = 'https://my-resource.services.ai.azure.com/api/projects/my-project';
+
+const credential: TokenCredential = {
+  async getToken(): Promise<AccessToken> {
+    return { token: 'mi-token', expiresOnTimestamp: Date.now() + 3_600_000 };
+  },
+};
+
+interface Call {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+/** A client whose every request is recorded, answered by the scripted replies in order. */
+function client(replies: Array<{ status?: number; body?: unknown; text?: string }> = [{}]): {
+  client: MemoryStoreClient;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  let index = 0;
+  const fetchStub = (async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const headers: Record<string, string> = {};
+    new Headers(init?.headers).forEach((value, name) => {
+      headers[name] = value;
+    });
+    calls.push({
+      method: init?.method ?? 'GET',
+      url: String(url),
+      headers,
+      body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+    });
+    const reply = replies[Math.min(index, replies.length - 1)] ?? {};
+    index++;
+    const payload = reply.text ?? (reply.body === undefined ? null : JSON.stringify(reply.body));
+    return new Response(payload, {
+      status: reply.status ?? 200,
+      ...(payload === null ? {} : { headers: { 'content-type': 'application/json' } }),
+    });
+  }) as typeof globalThis.fetch;
+
+  return {
+    client: new MemoryStoreClient({ projectEndpoint: PROJECT, credential, fetch: fetchStub }),
+    calls,
+  };
+}
+
+describe('MemoryStoreClient', () => {
+  it('searches with the store name in the path and the scope in the body', async () => {
+    const { client: memory, calls } = client([{ body: { search_id: 'srch_1', memories: [] } }]);
+
+    await memory.searchMemories({ name: 'my-store', scope: 'user-1', maxMemories: 3 });
+
+    expect(calls[0]?.method).toBe('POST');
+    expect(calls[0]?.url).toBe(`${PROJECT}/memory_stores/my-store:search_memories?api-version=v1`);
+    expect(calls[0]?.body).toEqual({ scope: 'user-1', options: { max_memories: 3 } });
+  });
+
+  it('sends the required preview opt-in and the bearer token on every call', async () => {
+    const { client: memory, calls } = client();
+
+    await memory.searchMemories({ name: 'my-store', scope: 'user-1' });
+
+    expect(calls[0]?.headers['foundry-features']).toBe('MemoryStores=V1Preview');
+    expect(calls[0]?.headers.authorization).toBe('Bearer mi-token');
+    expect(calls[0]?.headers['content-type']).toBe('application/json');
+  });
+
+  it('encodes the store name without swallowing the action separator', async () => {
+    const { client: memory, calls } = client();
+
+    await memory.searchMemories({ name: 'store/one two', scope: 'user-1' });
+
+    expect(calls[0]?.url).toBe(`${PROJECT}/memory_stores/store%2Fone%20two:search_memories?api-version=v1`);
+  });
+
+  it('carries the previous search id and the items when they are supplied', async () => {
+    const { client: memory, calls } = client();
+
+    await memory.searchMemories({
+      name: 'my-store',
+      scope: 'user-1',
+      items: [{ type: 'message', role: 'user', content: 'hello' }],
+      previousSearchId: 'srch_0',
+    });
+
+    expect(calls[0]?.body).toEqual({
+      scope: 'user-1',
+      items: [{ type: 'message', role: 'user', content: 'hello' }],
+      previous_search_id: 'srch_0',
+    });
+  });
+
+  it('updates memories with the delay and the previous update id', async () => {
+    const { client: memory, calls } = client([{ status: 202, body: { update_id: 'upd_1' } }]);
+
+    const result = await memory.updateMemories({
+      name: 'my-store',
+      scope: 'user-1',
+      items: [{ type: 'message', role: 'assistant', content: 'noted' }],
+      previousUpdateId: 'upd_0',
+      updateDelay: 0,
+    });
+
+    expect(calls[0]?.url).toBe(`${PROJECT}/memory_stores/my-store:update_memories?api-version=v1`);
+    expect(calls[0]?.body).toEqual({
+      scope: 'user-1',
+      items: [{ type: 'message', role: 'assistant', content: 'noted' }],
+      previous_update_id: 'upd_0',
+      update_delay: 0,
+    });
+    expect(result.update_id).toBe('upd_1');
+  });
+
+  it('reads an update result by id', async () => {
+    const { client: memory, calls } = client([{ body: { update_id: 'upd 1', status: 'completed' } }]);
+
+    const result = await memory.getUpdateResult('my-store', 'upd 1');
+
+    expect(calls[0]?.method).toBe('GET');
+    expect(calls[0]?.url).toBe(`${PROJECT}/memory_stores/my-store/updates/upd%201?api-version=v1`);
+    expect(result.status).toBe('completed');
+  });
+
+  it('reports a deleted scope, and reports an absent one as nothing to delete', async () => {
+    const { client: deleted } = client([{ status: 200, body: { deleted: true } }]);
+    expect(await deleted.deleteScope('my-store', 'user-1')).toBe(true);
+
+    const { client: missing, calls } = client([{ status: 404, body: { error: { code: 'not_found' } } }]);
+    expect(await missing.deleteScope('my-store', 'user-1')).toBe(false);
+    expect(calls[0]?.url).toBe(`${PROJECT}/memory_stores/my-store:delete_scope?api-version=v1`);
+    expect(calls[0]?.body).toEqual({ scope: 'user-1' });
+  });
+
+  it('answers an unknown store with undefined rather than an error', async () => {
+    const { client: memory } = client([{ status: 404, body: { error: { code: 'not_found' } } }]);
+
+    expect(await memory.getMemoryStore('my-store')).toBeUndefined();
+  });
+
+  it('creates a store with its definition', async () => {
+    const { client: memory, calls } = client([{ body: { name: 'my-store' } }]);
+
+    await memory.createMemoryStore({
+      name: 'my-store',
+      description: 'demo',
+      definition: { kind: 'default', chat_model: 'gpt-4o', embedding_model: 'text-embedding-3-small' },
+    });
+
+    expect(calls[0]?.url).toBe(`${PROJECT}/memory_stores?api-version=v1`);
+    expect(calls[0]?.body).toEqual({
+      name: 'my-store',
+      definition: { kind: 'default', chat_model: 'gpt-4o', embedding_model: 'text-embedding-3-small' },
+      description: 'demo',
+    });
+  });
+
+  it('raises a typed error naming the operation, the status and the service message', async () => {
+    const { client: memory } = client([{ status: 500, body: { error: { message: 'boom' } } }]);
+
+    const error = await memory.searchMemories({ name: 'my-store', scope: 'user-1' }).catch((e) => e);
+
+    expect(error).toBeInstanceOf(FoundryMemoryError);
+    expect((error as FoundryMemoryError).operation).toBe('search');
+    expect((error as FoundryMemoryError).status).toBe(500);
+    expect((error as FoundryMemoryError).message).toContain('boom');
+  });
+
+  it('raises the failure of the operation that made the call, not of the last route shape', async () => {
+    const { client: memory } = client([{ status: 403 }]);
+
+    const error = await memory.getUpdateResult('my-store', 'upd_1').catch((e) => e);
+
+    expect((error as FoundryMemoryError).operation).toBe('updateResult');
+  });
+
+  it('reads an accepted update that carries no body as an empty result', async () => {
+    const { client: memory } = client([{ status: 202 }]);
+
+    expect(
+      await memory.updateMemories({
+        name: 'my-store',
+        scope: 'user-1',
+        items: [{ type: 'message', role: 'user', content: 'hi' }],
+      }),
+    ).toEqual({});
+  });
+
+  it('raises when a successful call answers with something that is not JSON', async () => {
+    const { client: memory } = client([{ status: 200, text: '<html>gateway</html>' }]);
+
+    const error = await memory.searchMemories({ name: 'my-store', scope: 'user-1' }).catch((e) => e);
+
+    expect(error).toBeInstanceOf(FoundryMemoryError);
+    expect((error as FoundryMemoryError).message).toContain('not JSON');
+  });
+
+  it('passes the caller signal to the transport', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const memory = new MemoryStoreClient({
+      projectEndpoint: PROJECT,
+      credential,
+      fetch: (async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        init?.signal?.throwIfAborted();
+        return new Response('{}');
+      }) as typeof globalThis.fetch,
+    });
+
+    await expect(
+      memory.searchMemories({ name: 'my-store', scope: 'user-1' }, controller.signal),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/foundry/src/memory/client.ts
+++ b/packages/foundry/src/memory/client.ts
@@ -1,0 +1,342 @@
+/**
+ * The Microsoft Foundry Memory Store data-plane client.
+ *
+ * A hand-written client rather than an SDK wrapper: the JavaScript Azure SDK has no memory-store
+ * API, so the routes, headers and payloads here come from the service contract itself
+ * (`ai-foundry/data-plane/Foundry/src/memory-stores`) rather than from a generated surface. The
+ * shapes below carry the service's own snake_case, because they are the wire.
+ *
+ * Only the operations the provider needs are implemented — search, update, update-result polling,
+ * scope deletion, and the two store routes a caller needs to provision one. Memory *items* have
+ * their own CRUD routes; neither reference implementation reaches them from a context provider,
+ * and neither does this.
+ */
+
+import type { TokenCredential } from '@azure/identity';
+import { AgentFrameworkError } from '@polymind-inc/agent-framework-core';
+import { tokenProvider } from '../credential.js';
+import { FOUNDRY_API_VERSION, normalizeProjectEndpoint } from '../target.js';
+
+/**
+ * The preview opt-in every memory-store route requires.
+ *
+ * Not optional: the service contract marks these operations with a *required* `Foundry-Features`
+ * header, which is what the reference implementations send for you — Python by constructing its
+ * project client with `allow_preview=True`, .NET from the generated client's defaults.
+ */
+const MEMORY_PREVIEW_FEATURE = 'MemoryStores=V1Preview';
+
+/** One conversation item handed to the memory service, in the shape the service reads. */
+export interface MemoryInputItem {
+  type: 'message';
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+/** A single memory the service holds. */
+export interface MemoryItem {
+  memory_id?: string;
+  scope?: string;
+  content?: string;
+  kind?: string;
+  updated_at?: number;
+}
+
+/** The answer to a search: the memories, plus the id that makes the next search incremental. */
+export interface MemorySearchResponse {
+  search_id?: string;
+  memories?: Array<{ memory_item?: MemoryItem }>;
+}
+
+/** The status of one asynchronous memory extraction. */
+export interface MemoryUpdateResponse {
+  update_id?: string;
+  status?: 'queued' | 'in_progress' | 'completed' | 'failed' | 'superseded' | (string & {});
+  superseded_by?: string;
+  error?: { code?: string; message?: string };
+}
+
+/** How a memory store extracts and embeds; required when creating one. */
+export interface MemoryStoreDefinition {
+  kind: 'default';
+  chat_model: string;
+  embedding_model: string;
+  options?: {
+    user_profile_enabled?: boolean;
+    user_profile_details?: string;
+    chat_summary_enabled?: boolean;
+    procedural_memory_enabled?: boolean;
+    default_ttl_seconds?: number;
+  };
+}
+
+/** A memory store resource. */
+export interface MemoryStoreObject {
+  id?: string;
+  name?: string;
+  description?: string;
+  definition?: MemoryStoreDefinition;
+}
+
+/** The operations a {@link FoundryMemoryError} can come from. */
+export type MemoryOperation =
+  | 'search'
+  | 'update'
+  | 'updateResult'
+  | 'deleteScope'
+  | 'getStore'
+  | 'createStore';
+
+/** A memory-store call the service refused, or that never reached it. */
+export class FoundryMemoryError extends AgentFrameworkError {
+  /** Which call failed. */
+  readonly operation: MemoryOperation;
+  /** The HTTP status, or `undefined` when the request never got an answer. */
+  readonly status?: number;
+
+  constructor(operation: MemoryOperation, message: string, options?: ErrorOptions & { status?: number }) {
+    super(message, options);
+    this.name = 'FoundryMemoryError';
+    this.operation = operation;
+    if (options?.status !== undefined) {
+      this.status = options.status;
+    }
+  }
+}
+
+/** Construction options for {@link MemoryStoreClient}. */
+export interface MemoryStoreClientOptions {
+  /** The Foundry **project** endpoint. */
+  projectEndpoint: string;
+  /** The credential every call is authorized with. */
+  credential: TokenCredential;
+  /** Overridable for tests and proxies. */
+  fetch?: typeof globalThis.fetch;
+}
+
+/**
+ * The memory-store routes, as a typed client.
+ *
+ * ## No retry, deliberately
+ *
+ * Both references inherit a retry policy from their Azure HTTP pipeline; this client has none.
+ * Memory sits on the critical path of every run — a search runs before the model call and an
+ * update after it — and the provider's default is to continue without memories when the service
+ * fails. Retrying would spend a run's latency budget re-attempting an augmentation the run is
+ * already designed to survive losing. A caller who wants retries can supply a `fetch` that has
+ * them.
+ *
+ * ## Security considerations
+ *
+ * Every call carries an Entra bearer token for the project, and `scope` — the partition key,
+ * typically an end-user id — travels in the request body. Point this at a host you do not control
+ * and you hand it both.
+ */
+export class MemoryStoreClient {
+  readonly #endpoint: string;
+  readonly #getToken: () => Promise<string>;
+  readonly #fetch: typeof globalThis.fetch;
+
+  constructor(options: MemoryStoreClientOptions) {
+    this.#endpoint = normalizeProjectEndpoint(options.projectEndpoint);
+    this.#getToken = tokenProvider(options.credential);
+    this.#fetch = options.fetch ?? globalThis.fetch;
+  }
+
+  /** Memories relevant to `items`, or the scope's profile memories when `items` is absent. */
+  async searchMemories(
+    request: {
+      name: string;
+      scope: string;
+      items?: readonly MemoryInputItem[];
+      previousSearchId?: string;
+      maxMemories?: number;
+    },
+    signal?: AbortSignal,
+  ): Promise<MemorySearchResponse> {
+    const body: Record<string, unknown> = { scope: request.scope };
+    if (request.items !== undefined) {
+      body.items = request.items;
+    }
+    if (request.previousSearchId !== undefined) {
+      body.previous_search_id = request.previousSearchId;
+    }
+    if (request.maxMemories !== undefined) {
+      body.options = { max_memories: request.maxMemories };
+    }
+    const response = await this.#send('POST', `${this.#store(request.name)}:search_memories`, {
+      operation: 'search',
+      body,
+      signal,
+    });
+    return await MemoryStoreClient.#json<MemorySearchResponse>(response, 'search');
+  }
+
+  /**
+   * Queues an extraction over `items`.
+   *
+   * The service answers `202` with the update's id; extraction itself happens afterwards, which is
+   * what {@link whenUpdatesCompleted} on the provider waits for.
+   */
+  async updateMemories(
+    request: {
+      name: string;
+      scope: string;
+      items: readonly MemoryInputItem[];
+      previousUpdateId?: string;
+      updateDelay?: number;
+    },
+    signal?: AbortSignal,
+  ): Promise<MemoryUpdateResponse> {
+    const body: Record<string, unknown> = { scope: request.scope, items: request.items };
+    if (request.previousUpdateId !== undefined) {
+      body.previous_update_id = request.previousUpdateId;
+    }
+    if (request.updateDelay !== undefined) {
+      body.update_delay = request.updateDelay;
+    }
+    const response = await this.#send('POST', `${this.#store(request.name)}:update_memories`, {
+      operation: 'update',
+      body,
+      signal,
+    });
+    return await MemoryStoreClient.#json<MemoryUpdateResponse>(response, 'update');
+  }
+
+  /** The status of one queued extraction. */
+  async getUpdateResult(name: string, updateId: string, signal?: AbortSignal): Promise<MemoryUpdateResponse> {
+    const path = `${this.#store(name)}/updates/${encodeURIComponent(updateId)}`;
+    const response = await this.#send('GET', path, { operation: 'updateResult', signal });
+    return await MemoryStoreClient.#json<MemoryUpdateResponse>(response, 'updateResult');
+  }
+
+  /**
+   * Deletes every memory in `scope`.
+   *
+   * Answers `false` when the scope holds nothing — a scope that was never written has no resource
+   * to delete, and the reference treats that 404 as success rather than as a failure to clean up.
+   */
+  async deleteScope(name: string, scope: string, signal?: AbortSignal): Promise<boolean> {
+    const response = await this.#send('POST', `${this.#store(name)}:delete_scope`, {
+      operation: 'deleteScope',
+      body: { scope },
+      signal,
+      allowNotFound: true,
+    });
+    // Nothing here reads the body; draining it keeps the connection from being held open until
+    // the discarded response is collected.
+    await response.body?.cancel().catch(() => {});
+    return response.status !== 404;
+  }
+
+  /** The store, or `undefined` when it does not exist. */
+  async getMemoryStore(name: string, signal?: AbortSignal): Promise<MemoryStoreObject | undefined> {
+    const response = await this.#send('GET', this.#store(name), {
+      operation: 'getStore',
+      signal,
+      allowNotFound: true,
+    });
+    if (response.status === 404) {
+      // The body is an error envelope, not a store; draining it keeps the connection from being
+      // held open until the response is collected.
+      await response.body?.cancel().catch(() => {});
+      return undefined;
+    }
+    return await MemoryStoreClient.#json<MemoryStoreObject>(response, 'getStore');
+  }
+
+  /** Creates a store. Fails when one of the same name already exists. */
+  async createMemoryStore(
+    request: { name: string; definition: MemoryStoreDefinition; description?: string },
+    signal?: AbortSignal,
+  ): Promise<MemoryStoreObject> {
+    const body: Record<string, unknown> = { name: request.name, definition: request.definition };
+    if (request.description !== undefined) {
+      body.description = request.description;
+    }
+    const response = await this.#send('POST', 'memory_stores', {
+      operation: 'createStore',
+      body,
+      signal,
+    });
+    return await MemoryStoreClient.#json<MemoryStoreObject>(response, 'createStore');
+  }
+
+  /** The path of one store, with the name encoded and the action separator left intact. */
+  #store(name: string): string {
+    return `memory_stores/${encodeURIComponent(name)}`;
+  }
+
+  async #send(
+    method: string,
+    path: string,
+    options: {
+      operation: MemoryOperation;
+      body?: unknown;
+      signal?: AbortSignal | undefined;
+      allowNotFound?: boolean;
+    },
+  ): Promise<Response> {
+    const url = `${this.#endpoint}/${path}?${new URLSearchParams({ 'api-version': FOUNDRY_API_VERSION })}`;
+    const headers: Record<string, string> = {
+      authorization: `Bearer ${await this.#getToken()}`,
+      accept: 'application/json',
+      'Foundry-Features': MEMORY_PREVIEW_FEATURE,
+    };
+    if (options.body !== undefined) {
+      headers['content-type'] = 'application/json';
+    }
+    const response = await this.#fetch(url, {
+      method,
+      headers,
+      ...(options.body === undefined ? {} : { body: JSON.stringify(options.body) }),
+      ...(options.signal === undefined ? {} : { signal: options.signal }),
+    });
+    if (!response.ok && !(options.allowNotFound === true && response.status === 404)) {
+      throw await MemoryStoreClient.#failure(response, options.operation, `${method} ${path}`);
+    }
+    return response;
+  }
+
+  /**
+   * The body as `T`.
+   *
+   * A `202` from `:update_memories` carries the update resource, but a service that answers a
+   * successful call with no body at all must not become a parse error: memory is best-effort by
+   * default, and an empty object reads downstream as "nothing to carry forward".
+   */
+  static async #json<T>(response: Response, operation: MemoryOperation): Promise<T> {
+    const text = await response.text().catch(() => '');
+    if (text.trim() === '') {
+      return {} as T;
+    }
+    try {
+      return JSON.parse(text) as T;
+    } catch (error) {
+      throw new FoundryMemoryError(
+        operation,
+        `Foundry memory returned a body that is not JSON (${response.status}).`,
+        { cause: error, status: response.status },
+      );
+    }
+  }
+
+  /**
+   * The failure to raise for a refused call.
+   *
+   * The service's own message is included: this runs inside a container where the error text is
+   * the entire diagnostic.
+   */
+  static async #failure(
+    response: Response,
+    operation: MemoryOperation,
+    what: string,
+  ): Promise<FoundryMemoryError> {
+    const detail = (await response.text().catch(() => '')).slice(0, 500);
+    return new FoundryMemoryError(
+      operation,
+      `Foundry memory returned ${response.status} for ${what}.${detail === '' ? '' : ` ${detail}`}`,
+      { status: response.status },
+    );
+  }
+}

--- a/packages/foundry/src/memory/provider.test.ts
+++ b/packages/foundry/src/memory/provider.test.ts
@@ -487,6 +487,91 @@ describe('FoundryMemoryProvider', () => {
     });
   });
 
+  describe('cancellation', () => {
+    /**
+     * A provider whose transport aborts `controller` the first time `route` is hit, rejecting the
+     * way `fetch` rejects — with the signal's own abort reason.
+     */
+    function abortingProvider(route: ':search_memories' | ':update_memories'): {
+      memory: FoundryMemoryProvider;
+      controller: AbortController;
+      calls: Call[];
+      failures: FoundryMemoryFailure[];
+    } {
+      const controller = new AbortController();
+      const calls: Call[] = [];
+      const failures: FoundryMemoryFailure[] = [];
+      let armed = true;
+      const fetchStub = (async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const target = String(url);
+        calls.push({ url: target, body: typeof init?.body === 'string' ? JSON.parse(init.body) : {} });
+        if (armed && target.includes(route)) {
+          armed = false;
+          controller.abort();
+          init?.signal?.throwIfAborted();
+        }
+        const payload = target.includes(':update_memories') ? { update_id: 'upd_1' } : { memories: [] };
+        return new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }) as typeof globalThis.fetch;
+      return {
+        memory: new FoundryMemoryProvider({
+          projectEndpoint: PROJECT,
+          credential,
+          memoryStoreName: 'my-store',
+          scope: 'user-1',
+          fetch: fetchStub,
+          onFailure: (failure) => failures.push(failure),
+        }),
+        controller,
+        calls,
+        failures,
+      };
+    }
+
+    it('lets an abort during the profile search fail the run without burning the session', async () => {
+      const { memory, controller, calls, failures } = abortingProvider(':search_memories');
+      const { agent } = agentWith(memory);
+      const session = agent.createSession();
+
+      let error: unknown;
+      try {
+        await agent.run('one', { session, signal: controller.signal });
+      } catch (e) {
+        error = e;
+      }
+
+      expect((error as Error).name).toBe('AbortError');
+      // The cancellation is the caller's, not the service's: nothing is reported, and the session
+      // is not marked as initialized with an empty profile.
+      expect(failures).toHaveLength(0);
+      expect(
+        (session.state.foundry_memory as { initialized?: boolean } | undefined)?.initialized,
+      ).toBeUndefined();
+
+      // The run that replaces the cancelled one asks for the profile again.
+      await agent.run('two', { session });
+      expect(searchCalls(calls).filter((call) => call.body.items === undefined)).toHaveLength(2);
+    });
+
+    it('does not report a run whose memory write was aborted as a success', async () => {
+      const { memory, controller, failures } = abortingProvider(':update_memories');
+      const { agent } = agentWith(memory);
+
+      let error: unknown;
+      try {
+        await agent.run('hello', { signal: controller.signal });
+      } catch (e) {
+        error = e;
+      }
+
+      expect((error as Error).name).toBe('AbortError');
+      expect(failures).toHaveLength(0);
+    });
+  });
+
   describe('store maintenance', () => {
     it('creates the store only when it is missing', async () => {
       const definition = {

--- a/packages/foundry/src/memory/provider.test.ts
+++ b/packages/foundry/src/memory/provider.test.ts
@@ -225,6 +225,21 @@ describe('FoundryMemoryProvider', () => {
 
       expect(searchCalls(calls)).toHaveLength(1);
     });
+
+    it('replays the profile memories even when there is nothing to search contextually', async () => {
+      const { memory, calls } = provider({
+        search: [{ body: memories(['likes tea']) }],
+        config: { searchFilter: none },
+      });
+      const { agent, messagesOf } = agentWith(memory);
+
+      await agent.run('hello');
+
+      expect(searchCalls(calls)).toHaveLength(1);
+      expect(injected(messagesOf())?.contents[0]).toMatchObject({
+        text: expect.stringContaining('likes tea'),
+      });
+    });
   });
 
   describe('storage', () => {
@@ -388,6 +403,32 @@ describe('FoundryMemoryProvider', () => {
       expect(messagesOf()).toHaveLength(1);
       expect(failures.map((failure) => failure.operation)).toEqual(['search', 'search']);
       expect(failures[0]?.error).toBeInstanceOf(FoundryMemoryError);
+    });
+
+    it('still injects the profile memories when the contextual search fails and the run continues', async () => {
+      const failures: FoundryMemoryFailure[] = [];
+      const { memory } = provider({
+        search: [{ body: memories(['likes tea']) }, { status: 500 }],
+        config: { onFailure: (failure) => failures.push(failure) },
+      });
+      const { agent, messagesOf } = agentWith(memory);
+
+      const response = await agent.run('hello');
+
+      expect(response.text).toBe('ok');
+      expect(failures.map((failure) => failure.operation)).toEqual(['search']);
+      expect(injected(messagesOf())?.contents[0]).toMatchObject({
+        text: expect.stringContaining('likes tea'),
+      });
+    });
+
+    it('fails the run when the contextual search fails and the mode is to fail closed', async () => {
+      const { memory } = provider({
+        search: [{ body: memories(['likes tea']) }, { status: 500 }],
+        config: { failureMode: 'throw' },
+      });
+
+      await expect(agentWith(memory).agent.run('hello')).rejects.toBeInstanceOf(FoundryMemoryError);
     });
 
     it('fails the run instead when configured to fail closed', async () => {

--- a/packages/foundry/src/memory/provider.test.ts
+++ b/packages/foundry/src/memory/provider.test.ts
@@ -1,0 +1,488 @@
+import type { AccessToken, TokenCredential } from '@azure/identity';
+import type { AgentSession, Message } from '@polymind-inc/agent-framework-core';
+import { Agent, ConfigurationError, none, textContent } from '@polymind-inc/agent-framework-core';
+import { MockChatClient } from '@polymind-inc/agent-framework-core/testing';
+import { describe, expect, it } from 'vitest';
+import { FoundryMemoryError } from './client.js';
+import type { FoundryMemoryFailure, FoundryMemoryProviderConfig, FoundryMemoryScope } from './provider.js';
+import { FoundryMemoryProvider } from './provider.js';
+
+const PROJECT = 'https://my-resource.services.ai.azure.com/api/projects/my-project';
+
+const credential: TokenCredential = {
+  async getToken(): Promise<AccessToken> {
+    return { token: 'mi-token', expiresOnTimestamp: Date.now() + 3_600_000 };
+  },
+};
+
+interface Call {
+  url: string;
+  body: Record<string, unknown>;
+}
+
+/** A memory search answer holding `contents`. */
+function memories(contents: string[], searchId = 'srch_1'): unknown {
+  return { search_id: searchId, memories: contents.map((content) => ({ memory_item: { content } })) };
+}
+
+/**
+ * A provider whose transport is scripted.
+ *
+ * Replies are matched by route, so a test states what search and update answer without having to
+ * predict how many calls a run makes.
+ */
+function provider(
+  options: {
+    search?: Array<{ status?: number; body?: unknown }>;
+    update?: Array<{ status?: number; body?: unknown }>;
+    store?: Array<{ status?: number; body?: unknown }>;
+    scope?: FoundryMemoryScope;
+    config?: Partial<FoundryMemoryProviderConfig>;
+  } = {},
+): { memory: FoundryMemoryProvider; calls: Call[] } {
+  const calls: Call[] = [];
+  const taken = { search: 0, update: 0, store: 0 };
+  const fetchStub = (async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const target = String(url);
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : {};
+    calls.push({ url: target, body });
+    const route = target.includes(':search_memories')
+      ? 'search'
+      : target.includes(':update_memories')
+        ? 'update'
+        : 'store';
+    const scripted = options[route] ?? [];
+    const reply = scripted[Math.min(taken[route], scripted.length - 1)] ?? {};
+    taken[route]++;
+    const payload =
+      reply.body === undefined
+        ? JSON.stringify(route === 'update' ? { update_id: `upd_${taken.update}` } : { memories: [] })
+        : JSON.stringify(reply.body);
+    return new Response(payload, {
+      status: reply.status ?? 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof globalThis.fetch;
+
+  return {
+    memory: new FoundryMemoryProvider({
+      projectEndpoint: PROJECT,
+      credential,
+      memoryStoreName: 'my-store',
+      scope: options.scope ?? 'user-1',
+      fetch: fetchStub,
+      ...options.config,
+    }),
+    calls,
+  };
+}
+
+/** An agent that answers every turn with `reply` and carries `memory`, with the model it talks to. */
+function agentWith(
+  memory: FoundryMemoryProvider,
+  reply = 'ok',
+): { agent: Agent; model: MockChatClient; messagesOf: (run?: number) => Message[] } {
+  const model = new MockChatClient([{ contents: [textContent(reply)] }]);
+  return {
+    agent: new Agent({ client: model, contextProviders: [memory] }),
+    model,
+    messagesOf: (run = 0) => model.calls[run]?.messages ?? [],
+  };
+}
+
+/** The message the provider injected, or `undefined` when it injected none. */
+function injected(messages: Message[]): Message | undefined {
+  return messages.find((message) =>
+    message.contents.some((content) => content.type === 'text' && content.text.startsWith('## Memories')),
+  );
+}
+
+const searchCalls = (calls: Call[]): Call[] => calls.filter((call) => call.url.includes(':search_memories'));
+const updateCalls = (calls: Call[]): Call[] => calls.filter((call) => call.url.includes(':update_memories'));
+
+describe('FoundryMemoryProvider', () => {
+  describe('configuration', () => {
+    it('rejects an empty store name', () => {
+      expect(
+        () => new FoundryMemoryProvider({ projectEndpoint: PROJECT, memoryStoreName: ' ', scope: 'user-1' }),
+      ).toThrow(ConfigurationError);
+    });
+
+    it('rejects an empty scope', () => {
+      expect(
+        () =>
+          new FoundryMemoryProvider({ projectEndpoint: PROJECT, memoryStoreName: 'my-store', scope: ' ' }),
+      ).toThrow(ConfigurationError);
+    });
+
+    it('rejects a missing project endpoint', () => {
+      const saved = process.env.FOUNDRY_PROJECT_ENDPOINT;
+      delete process.env.FOUNDRY_PROJECT_ENDPOINT;
+      try {
+        expect(() => new FoundryMemoryProvider({ memoryStoreName: 'my-store', scope: 'user-1' })).toThrow(
+          ConfigurationError,
+        );
+      } finally {
+        if (saved !== undefined) {
+          process.env.FOUNDRY_PROJECT_ENDPOINT = saved;
+        }
+      }
+    });
+
+    it('names its state partition foundry_memory unless told otherwise', () => {
+      const { memory } = provider();
+      expect(memory.sourceId).toBe('foundry_memory');
+      expect(provider({ config: { sourceId: 'mine' } }).memory.sourceId).toBe('mine');
+    });
+  });
+
+  describe('retrieval', () => {
+    it('injects the retrieved memories as one user message under the context prompt', async () => {
+      const { memory, calls } = provider({
+        search: [{ body: memories(['likes black coffee']) }, { body: memories(['is called Rin']) }],
+      });
+      const { agent, messagesOf } = agentWith(memory);
+
+      await agent.run('order me a coffee');
+
+      const memoryMessage = injected(messagesOf());
+      expect(memoryMessage?.role).toBe('user');
+      expect(memoryMessage?.contents[0]).toMatchObject({
+        type: 'text',
+        text: '## Memories\nConsider the following memories when answering user questions:\nlikes black coffee\nis called Rin',
+      });
+      // The profile search carries no items; the contextual one carries the turn's input.
+      expect(searchCalls(calls)[0]?.body.items).toBeUndefined();
+      expect(searchCalls(calls)[1]?.body.items).toEqual([
+        { type: 'message', role: 'user', content: 'order me a coffee' },
+      ]);
+    });
+
+    it('asks for the profile memories once per session and replays them on later runs', async () => {
+      const { memory, calls } = provider({ search: [{ body: memories(['likes black coffee']) }] });
+      const { agent, messagesOf } = agentWith(memory);
+      const session = agent.createSession();
+
+      await agent.run('one', { session });
+      await agent.run('two', { session });
+
+      const withoutItems = searchCalls(calls).filter((call) => call.body.items === undefined);
+      expect(withoutItems).toHaveLength(1);
+      // Replayed: the second run's injection still opens with the profile memory.
+      expect(injected(messagesOf(1))?.contents[0]).toMatchObject({
+        text: expect.stringContaining('likes black coffee'),
+      });
+    });
+
+    it('injects nothing when the store holds no relevant memories', async () => {
+      const { memory } = provider({ search: [{ body: memories([]) }] });
+      const { agent, messagesOf } = agentWith(memory);
+
+      await agent.run('hello');
+
+      expect(messagesOf()).toHaveLength(1);
+      expect(messagesOf()[0]?.contents[0]).toMatchObject({ text: 'hello' });
+    });
+
+    it('does not search for context when the run carries no text', async () => {
+      const { memory, calls } = provider();
+      const { agent } = agentWith(memory);
+
+      await agent.run([{ role: 'user', contents: [] }]);
+
+      expect(searchCalls(calls)).toHaveLength(1);
+      expect(searchCalls(calls)[0]?.body.items).toBeUndefined();
+    });
+
+    it('advances the incremental search anchor only when a search found something', async () => {
+      const { memory, calls } = provider({
+        search: [
+          { body: memories([], 'srch_static') },
+          { body: memories([], 'srch_empty') },
+          { body: memories(['a fact'], 'srch_hit') },
+          { body: memories(['another'], 'srch_last') },
+        ],
+      });
+      const { agent } = agentWith(memory);
+      const session = agent.createSession();
+
+      await agent.run('one', { session });
+      await agent.run('two', { session });
+      await agent.run('three', { session });
+
+      const contextual = searchCalls(calls).filter((call) => call.body.items !== undefined);
+      expect(contextual[0]?.body.previous_search_id).toBeUndefined();
+      // The empty answer's id is not carried forward; the one that found memories is.
+      expect(contextual[1]?.body.previous_search_id).toBeUndefined();
+      expect(contextual[2]?.body.previous_search_id).toBe('srch_hit');
+    });
+
+    it('honours the search filter', async () => {
+      const { memory, calls } = provider({ config: { searchFilter: none } });
+      const { agent } = agentWith(memory);
+
+      await agent.run('hello');
+
+      expect(searchCalls(calls)).toHaveLength(1);
+    });
+  });
+
+  describe('storage', () => {
+    it('sends the request and response of the turn, with the roles the service models', async () => {
+      const { memory, calls } = provider();
+      const { agent } = agentWith(memory, 'one black coffee');
+
+      await agent.run('order me a coffee');
+
+      expect(updateCalls(calls)).toHaveLength(1);
+      expect(updateCalls(calls)[0]?.body).toMatchObject({
+        scope: 'user-1',
+        update_delay: 0,
+        items: [
+          { type: 'message', role: 'user', content: 'order me a coffee' },
+          { type: 'message', role: 'assistant', content: 'one black coffee' },
+        ],
+      });
+    });
+
+    it('stores nothing for a turn with no conversational text', async () => {
+      const { memory, calls } = provider();
+      const agent = new Agent({
+        client: new MockChatClient([{ contents: [] }]),
+        contextProviders: [memory],
+      });
+
+      await agent.run([{ role: 'tool', contents: [textContent('tool output')] }]);
+
+      expect(updateCalls(calls)).toHaveLength(0);
+    });
+
+    it('does not store a failed run', async () => {
+      const { memory, calls } = provider();
+      const failing = new Agent({
+        client: {
+          metadata: { providerName: 'boom' },
+          getResponse: () => {
+            throw new Error('model exploded');
+          },
+        } as never,
+        contextProviders: [memory],
+      });
+
+      await expect(failing.run('remember this')).rejects.toThrow('model exploded');
+      expect(updateCalls(calls)).toHaveLength(0);
+    });
+
+    it('chains updates through the previous update id', async () => {
+      const { memory, calls } = provider({
+        update: [
+          { status: 202, body: { update_id: 'upd_a' } },
+          { status: 202, body: { update_id: 'upd_b' } },
+        ],
+      });
+      const { agent } = agentWith(memory);
+      const session = agent.createSession();
+
+      await agent.run('one', { session });
+      await agent.run('two', { session });
+
+      expect(updateCalls(calls)[0]?.body.previous_update_id).toBeUndefined();
+      expect(updateCalls(calls)[1]?.body.previous_update_id).toBe('upd_a');
+    });
+
+    it('sends the configured update delay', async () => {
+      const { memory, calls } = provider({ config: { updateDelay: 300 } });
+
+      await agentWith(memory).agent.run('hello');
+
+      expect(updateCalls(calls)[0]?.body.update_delay).toBe(300);
+    });
+
+    it('honours the response filter', async () => {
+      const { memory, calls } = provider({ config: { storeResponseFilter: none } });
+
+      await agentWith(memory, 'one black coffee').agent.run('order me a coffee');
+
+      expect(updateCalls(calls)[0]?.body.items).toEqual([
+        { type: 'message', role: 'user', content: 'order me a coffee' },
+      ]);
+    });
+  });
+
+  describe('scope', () => {
+    it('resolves a function scope on every run', async () => {
+      const seen: string[] = [];
+      const { memory, calls } = provider({
+        scope: (ctx) => {
+          seen.push(ctx.session.sessionId);
+          return 'user-7';
+        },
+      });
+      const { agent } = agentWith(memory);
+      const session = agent.createSession();
+
+      await agent.run('one', { session });
+      await agent.run('two', { session });
+
+      expect(seen.length).toBeGreaterThanOrEqual(2);
+      expect(searchCalls(calls).every((call) => call.body.scope === 'user-7')).toBe(true);
+    });
+
+    it('fails the run when a session resolves a second scope', async () => {
+      let current = 'user-1';
+      const { memory } = provider({ scope: () => current });
+      const { agent } = agentWith(memory);
+      const session = agent.createSession();
+
+      await agent.run('one', { session });
+      current = 'user-2';
+
+      await expect(agent.run('two', { session })).rejects.toThrow(ConfigurationError);
+    });
+
+    it('fails the run when no scope can be resolved', async () => {
+      const { memory } = provider({ scope: () => '' });
+
+      await expect(agentWith(memory).agent.run('one')).rejects.toThrow(ConfigurationError);
+    });
+
+    it('keeps the pinned scope in its own partition of the session', async () => {
+      const { memory } = provider();
+      const { agent } = agentWith(memory);
+      const session: AgentSession = agent.createSession();
+
+      await agent.run('one', { session });
+
+      expect((session.state.foundry_memory as { scope?: string }).scope).toBe('user-1');
+    });
+  });
+
+  describe('failures', () => {
+    it('runs without memories when the search fails, and reports the failure', async () => {
+      const failures: FoundryMemoryFailure[] = [];
+      const { memory } = provider({
+        search: [{ status: 500, body: { error: { message: 'down' } } }],
+        config: { onFailure: (failure) => failures.push(failure) },
+      });
+      const { agent, messagesOf } = agentWith(memory);
+
+      const response = await agent.run('hello');
+
+      expect(response.text).toBe('ok');
+      expect(messagesOf()).toHaveLength(1);
+      expect(failures.map((failure) => failure.operation)).toEqual(['search', 'search']);
+      expect(failures[0]?.error).toBeInstanceOf(FoundryMemoryError);
+    });
+
+    it('fails the run instead when configured to fail closed', async () => {
+      const { memory } = provider({
+        search: [{ status: 500 }],
+        config: { failureMode: 'throw' },
+      });
+
+      await expect(agentWith(memory).agent.run('hello')).rejects.toBeInstanceOf(FoundryMemoryError);
+    });
+
+    it('keeps a failed run intact when the update fails and the mode is to continue', async () => {
+      const failures: FoundryMemoryFailure[] = [];
+      const { memory } = provider({
+        update: [{ status: 503 }],
+        config: { onFailure: (failure) => failures.push(failure) },
+      });
+
+      const response = await agentWith(memory).agent.run('hello');
+
+      expect(response.text).toBe('ok');
+      expect(failures.map((failure) => failure.operation)).toEqual(['update']);
+    });
+
+    it('does not retry the profile search on later runs of a session that already failed it', async () => {
+      const { memory, calls } = provider({ search: [{ status: 500 }] });
+      const { agent } = agentWith(memory);
+      const session = agent.createSession();
+
+      await agent.run('one', { session });
+      await agent.run('two', { session });
+
+      expect(searchCalls(calls).filter((call) => call.body.items === undefined)).toHaveLength(1);
+    });
+  });
+
+  describe('store maintenance', () => {
+    it('creates the store only when it is missing', async () => {
+      const definition = {
+        kind: 'default' as const,
+        chat_model: 'gpt-4o',
+        embedding_model: 'text-embedding-3-small',
+      };
+
+      const existing = provider({ store: [{ status: 200, body: { name: 'my-store' } }] });
+      expect(await existing.memory.ensureMemoryStoreCreated(definition)).toBe(false);
+      expect(existing.calls).toHaveLength(1);
+
+      const missing = provider({
+        store: [{ status: 404, body: { error: { code: 'not_found' } } }, { body: { name: 'my-store' } }],
+      });
+      expect(await missing.memory.ensureMemoryStoreCreated(definition, { description: 'demo' })).toBe(true);
+      expect(missing.calls).toHaveLength(2);
+      expect(missing.calls[1]?.body).toMatchObject({ name: 'my-store', definition, description: 'demo' });
+    });
+
+    it('deletes the memories of a scope the caller names', async () => {
+      const { memory, calls } = provider({ store: [{ status: 200, body: { deleted: true } }] });
+
+      expect(await memory.deleteStoredMemories('user-9')).toBe(true);
+      expect(calls[0]?.url).toContain(':delete_scope');
+      expect(calls[0]?.body).toEqual({ scope: 'user-9' });
+    });
+
+    it('waits for the queued extraction, and stops waiting once it completed', async () => {
+      const { memory, calls } = provider({
+        update: [{ status: 202, body: { update_id: 'upd_a' } }],
+        store: [
+          { body: { update_id: 'upd_a', status: 'in_progress' } },
+          { body: { update_id: 'upd_a', status: 'completed' } },
+        ],
+      });
+
+      await agentWith(memory).agent.run('hello');
+      await memory.whenUpdatesCompleted({ pollIntervalMs: 0 });
+
+      expect(calls.filter((call) => call.url.includes('/updates/'))).toHaveLength(2);
+
+      // Nothing is pending any more, so a second wait does not poll again.
+      await memory.whenUpdatesCompleted({ pollIntervalMs: 0 });
+      expect(calls.filter((call) => call.url.includes('/updates/'))).toHaveLength(2);
+    });
+
+    it('waits for nothing when no update was queued', async () => {
+      const { memory, calls } = provider();
+
+      await memory.whenUpdatesCompleted({ pollIntervalMs: 0 });
+
+      expect(calls).toHaveLength(0);
+    });
+
+    it('raises when the extraction failed', async () => {
+      const { memory } = provider({
+        update: [{ status: 202, body: { update_id: 'upd_a' } }],
+        store: [{ body: { update_id: 'upd_a', status: 'failed', error: { message: 'quota' } } }],
+      });
+
+      await agentWith(memory).agent.run('hello');
+
+      await expect(memory.whenUpdatesCompleted({ pollIntervalMs: 0 })).rejects.toThrow('quota');
+    });
+
+    it('raises on a status it does not model rather than polling forever', async () => {
+      const { memory } = provider({
+        update: [{ status: 202, body: { update_id: 'upd_a' } }],
+        store: [{ body: { update_id: 'upd_a', status: 'sideways' } }],
+      });
+
+      await agentWith(memory).agent.run('hello');
+
+      await expect(memory.whenUpdatesCompleted({ pollIntervalMs: 0 })).rejects.toThrow('sideways');
+    });
+  });
+});

--- a/packages/foundry/src/memory/provider.test.ts
+++ b/packages/foundry/src/memory/provider.test.ts
@@ -290,6 +290,22 @@ describe('FoundryMemoryProvider', () => {
       expect(updateCalls(calls)[1]?.body.previous_update_id).toBe('upd_a');
     });
 
+    it('stores a system message with its role preserved', async () => {
+      const { memory, calls } = provider();
+      const { agent } = agentWith(memory, 'noted');
+
+      await agent.run([
+        { role: 'system', contents: [textContent('The user is called Rin.')] },
+        { role: 'user', contents: [textContent('remember me')] },
+      ]);
+
+      expect(updateCalls(calls)[0]?.body.items).toEqual([
+        { type: 'message', role: 'system', content: 'The user is called Rin.' },
+        { type: 'message', role: 'user', content: 'remember me' },
+        { type: 'message', role: 'assistant', content: 'noted' },
+      ]);
+    });
+
     it('sends the configured update delay', async () => {
       const { memory, calls } = provider({ config: { updateDelay: 300 } });
 
@@ -396,6 +412,28 @@ describe('FoundryMemoryProvider', () => {
       expect(failures.map((failure) => failure.operation)).toEqual(['update']);
     });
 
+    it('retries the profile search on the next run when its failure failed the run', async () => {
+      const { memory, calls } = provider({
+        search: [
+          { status: 500 },
+          { body: memories(['likes black coffee'], 'srch_profile') },
+          { body: memories([], 'srch_ctx') },
+        ],
+        config: { failureMode: 'throw' },
+      });
+      const { agent, messagesOf } = agentWith(memory);
+      const session = agent.createSession();
+
+      await expect(agent.run('one', { session })).rejects.toBeInstanceOf(FoundryMemoryError);
+      await agent.run('two', { session });
+
+      // The failure failed the run, so the run that replaces it asks for the profile again.
+      expect(searchCalls(calls).filter((call) => call.body.items === undefined)).toHaveLength(2);
+      expect(injected(messagesOf(0))?.contents[0]).toMatchObject({
+        text: expect.stringContaining('likes black coffee'),
+      });
+    });
+
     it('does not retry the profile search on later runs of a session that already failed it', async () => {
       const { memory, calls } = provider({ search: [{ status: 500 }] });
       const { agent } = agentWith(memory);
@@ -461,6 +499,22 @@ describe('FoundryMemoryProvider', () => {
       await memory.whenUpdatesCompleted({ pollIntervalMs: 0 });
 
       expect(calls).toHaveLength(0);
+    });
+
+    it('stops waiting as soon as the caller aborts, not at the next poll', async () => {
+      const { memory } = provider({
+        update: [{ status: 202, body: { update_id: 'upd_a' } }],
+        store: [{ body: { update_id: 'upd_a', status: 'in_progress' } }],
+      });
+      await agentWith(memory).agent.run('hello');
+
+      const controller = new AbortController();
+      const started = Date.now();
+      const waiting = memory.whenUpdatesCompleted({ pollIntervalMs: 5_000, signal: controller.signal });
+      setTimeout(() => controller.abort(), 20);
+
+      await expect(waiting).rejects.toThrow();
+      expect(Date.now() - started).toBeLessThan(2_000);
     });
 
     it('raises when the extraction failed', async () => {

--- a/packages/foundry/src/memory/provider.ts
+++ b/packages/foundry/src/memory/provider.ts
@@ -1,0 +1,473 @@
+import type { TokenCredential } from '@azure/identity';
+import { DefaultAzureCredential } from '@azure/identity';
+import type {
+  ContextProvider,
+  Message,
+  MessageFilter,
+  ProviderAfterRunContext,
+  ProviderRunContext,
+} from '@polymind-inc/agent-framework-core';
+import {
+  ConfigurationError,
+  externalOnly,
+  passThrough,
+  textContent,
+  textOf,
+} from '@polymind-inc/agent-framework-core';
+import type { MemoryInputItem, MemoryOperation, MemoryStoreDefinition, MemoryStoreObject } from './client.js';
+import { FoundryMemoryError, MemoryStoreClient } from './client.js';
+
+/** The prefix the retrieved memories are handed to the model under. */
+const DEFAULT_CONTEXT_PROMPT = '## Memories\nConsider the following memories when answering user questions:';
+
+/** The default partition of {@link AgentSession.state} this provider writes to. */
+const DEFAULT_SOURCE_ID = 'foundry_memory';
+
+/** How many memories one search may return, unless configured otherwise. */
+const DEFAULT_MAX_MEMORIES = 5;
+
+/** How long the service waits for more conversation before extracting, in seconds. */
+const DEFAULT_UPDATE_DELAY = 0;
+
+/**
+ * Which memories a run reads and writes.
+ *
+ * A scope is a partition, so it is required: there is no fallback to the session id, because
+ * silently narrowing "what this user remembers" to "what this conversation remembers" turns a
+ * misconfiguration into behaviour that looks like it works. Pass a function when the partition is
+ * only known per run — a hosted container serves every user through one provider instance, and the
+ * function is evaluated on each run rather than once at construction.
+ */
+export type FoundryMemoryScope = string | ((ctx: ProviderRunContext) => string);
+
+/** What a memory-service failure did, for a host that wants to see it. */
+export interface FoundryMemoryFailure {
+  /** The call that failed. */
+  readonly operation: MemoryOperation;
+  /** The failure itself, usually a {@link FoundryMemoryError}. */
+  readonly error: unknown;
+}
+
+/** Construction options for {@link FoundryMemoryProvider}. */
+export interface FoundryMemoryProviderConfig {
+  /** The memory store in the Foundry project. Create it with {@link FoundryMemoryProvider.ensureMemoryStoreCreated}. */
+  memoryStoreName: string;
+  /**
+   * The namespace memories are partitioned by — an end-user id, a team id, whatever the
+   * application's isolation boundary is. In a hosted container, use `hostedUserScope()` from
+   * `@polymind-inc/agent-framework-foundry/hosting`.
+   */
+  scope: FoundryMemoryScope;
+  /** The Foundry **project** endpoint. Defaults to `FOUNDRY_PROJECT_ENDPOINT`. */
+  projectEndpoint?: string;
+  /** Defaults to {@link DefaultAzureCredential}. */
+  credential?: TokenCredential;
+  /** This provider's session-state partition and the source stamped on injected messages. */
+  sourceId?: string;
+  /** Prefixed to the retrieved memories. Defaults to a "## Memories" heading. */
+  contextPrompt?: string;
+  /** The most memories one search may return. Defaults to 5. */
+  maxMemories?: number;
+  /**
+   * Seconds the service waits for further conversation before extracting memories. Defaults to
+   * `0` — extract immediately — so a fact stated in one run is available to the next. Raise it
+   * (the service's own default is 300) to let the service batch a chatty conversation into one
+   * extraction.
+   */
+  updateDelay?: number;
+  /**
+   * What a memory-service failure does to the run. `'continue'` (the default) runs the agent
+   * without the memories it could not read, and drops the memories it could not write;
+   * `'throw'` fails the run.
+   *
+   * Scope resolution is not covered by this: a scope that cannot be resolved, or that changed
+   * under an existing session, always throws. That is an isolation boundary, not a degraded
+   * augmentation.
+   */
+  failureMode?: 'continue' | 'throw';
+  /**
+   * Called for every memory-service failure, in both failure modes.
+   *
+   * The scope is deliberately not passed: it is normally an end-user id, and a diagnostic hook is
+   * exactly where such a value leaks into logs.
+   */
+  onFailure?: (failure: FoundryMemoryFailure) => void;
+  /** Which request messages the search is built from. Defaults to caller-supplied messages only. */
+  searchFilter?: MessageFilter;
+  /** Which request messages are stored. Defaults to caller-supplied messages only. */
+  storeRequestFilter?: MessageFilter;
+  /** Which response messages are stored. Defaults to all of them. */
+  storeResponseFilter?: MessageFilter;
+  /** Overridable for tests and proxies. */
+  fetch?: typeof globalThis.fetch;
+}
+
+/** The provider's own slice of the session, as it is serialized. */
+interface MemoryState {
+  /** The partition this session is pinned to. */
+  scope?: string;
+  /** Whether the one-off profile search has run. */
+  initialized?: boolean;
+  /** The profile memories, retrieved once and replayed on every later run. */
+  staticMemories?: string[];
+  /** Makes the next search incremental. */
+  previousSearchId?: string;
+  /** Makes the next update incremental. */
+  previousUpdateId?: string;
+}
+
+/**
+ * Gives an agent persistent, semantic memory backed by a Microsoft Foundry Memory Store.
+ *
+ * Before each run it searches the store for memories relevant to the conversation and injects them
+ * as a single user message; after each run it sends the turn to the service, which extracts
+ * memories from it asynchronously.
+ *
+ * ```ts
+ * const memory = new FoundryMemoryProvider({
+ *   projectEndpoint: process.env.FOUNDRY_PROJECT_ENDPOINT!,
+ *   memoryStoreName: 'assistant-memories',
+ *   scope: userId,
+ * });
+ * const agent = new Agent({ client, instructions: '…', contextProviders: [memory] });
+ * ```
+ *
+ * ## Security considerations
+ *
+ * - **Memories are untrusted text.** They are extracted from conversations, so a memory can carry
+ *   an instruction aimed at the model, and everything injected here is indistinguishable from user
+ *   input once it reaches the model. Never let a memory drive an authorization decision.
+ * - **The scope is the isolation boundary.** One provider instance serves every user of a hosted
+ *   container, so the scope is resolved per run and then pinned to the session: a session that
+ *   resolves a different scope later fails the run instead of reading another user's memories.
+ * - **What goes in is what comes out.** Whatever the store is allowed to extract will be replayed
+ *   into later runs, including into a later conversation. Configure the store's extraction
+ *   (`userProfileDetails`) to exclude sensitive categories rather than relying on the model.
+ */
+export class FoundryMemoryProvider implements ContextProvider {
+  readonly sourceId: string;
+
+  readonly #client: MemoryStoreClient;
+  readonly #storeName: string;
+  readonly #scope: FoundryMemoryScope;
+  readonly #contextPrompt: string;
+  readonly #maxMemories: number;
+  readonly #updateDelay: number;
+  readonly #failureMode: 'continue' | 'throw';
+  readonly #onFailure: ((failure: FoundryMemoryFailure) => void) | undefined;
+  readonly #searchFilter: MessageFilter;
+  readonly #storeRequestFilter: MessageFilter;
+  readonly #storeResponseFilter: MessageFilter;
+
+  /** The most recent queued extraction, for {@link whenUpdatesCompleted}. */
+  #pendingUpdateId: string | undefined;
+
+  constructor(config: FoundryMemoryProviderConfig) {
+    if (config.memoryStoreName.trim() === '') {
+      throw new ConfigurationError('FoundryMemoryProvider needs a memory store name.');
+    }
+    if (typeof config.scope === 'string' && config.scope.trim() === '') {
+      throw new ConfigurationError('FoundryMemoryProvider needs a non-empty scope.');
+    }
+    const endpoint = config.projectEndpoint ?? process.env.FOUNDRY_PROJECT_ENDPOINT;
+    if (endpoint === undefined || endpoint.trim() === '') {
+      throw new ConfigurationError(
+        'FoundryMemoryProvider needs a project endpoint. Set FOUNDRY_PROJECT_ENDPOINT or pass ' +
+          '`projectEndpoint`.',
+      );
+    }
+
+    this.sourceId = config.sourceId ?? DEFAULT_SOURCE_ID;
+    this.#client = new MemoryStoreClient({
+      projectEndpoint: endpoint,
+      credential: config.credential ?? new DefaultAzureCredential(),
+      ...(config.fetch === undefined ? {} : { fetch: config.fetch }),
+    });
+    this.#storeName = config.memoryStoreName;
+    this.#scope = config.scope;
+    this.#contextPrompt = config.contextPrompt ?? DEFAULT_CONTEXT_PROMPT;
+    this.#maxMemories = config.maxMemories ?? DEFAULT_MAX_MEMORIES;
+    this.#updateDelay = config.updateDelay ?? DEFAULT_UPDATE_DELAY;
+    this.#failureMode = config.failureMode ?? 'continue';
+    this.#onFailure = config.onFailure;
+    this.#searchFilter = config.searchFilter ?? externalOnly;
+    this.#storeRequestFilter = config.storeRequestFilter ?? externalOnly;
+    this.#storeResponseFilter = config.storeResponseFilter ?? passThrough;
+  }
+
+  /**
+   * Searches the store and injects what it finds.
+   *
+   * Two searches, not one: the first run of a session also asks for the scope's profile memories —
+   * the durable facts that are relevant regardless of what was just said — and those are replayed
+   * on every later run of the session without asking again. Each run then searches for memories
+   * relevant to this turn's input.
+   */
+  async beforeRun(ctx: ProviderRunContext): Promise<void> {
+    const state = ctx.state as MemoryState;
+    const scope = this.#resolveScope(ctx, state);
+
+    if (state.initialized !== true) {
+      try {
+        const result = await this.#client.searchMemories(
+          { name: this.#storeName, scope, maxMemories: this.#maxMemories },
+          ctx.signal,
+        );
+        state.staticMemories = contentsOf(result);
+      } catch (error) {
+        state.staticMemories = [];
+        this.#failed('search', error);
+      } finally {
+        // Marked either way: a store that refused the profile search once will refuse it on every
+        // run of this session, and retrying it per run only adds latency to each of them.
+        state.initialized = true;
+      }
+    }
+
+    const items = searchItems(this.#searchFilter(ctx.inputMessages));
+    if (items.length === 0) {
+      return;
+    }
+
+    try {
+      const result = await this.#client.searchMemories(
+        {
+          name: this.#storeName,
+          scope,
+          items,
+          maxMemories: this.#maxMemories,
+          ...(state.previousSearchId === undefined ? {} : { previousSearchId: state.previousSearchId }),
+        },
+        ctx.signal,
+      );
+      const contextual = contentsOf(result);
+      // Only a search that found something moves the incremental anchor: carrying forward the id
+      // of an empty search would make the next one resume from nothing.
+      if (contextual.length > 0 && typeof result.search_id === 'string') {
+        state.previousSearchId = result.search_id;
+      }
+      const memories = [...(state.staticMemories ?? []), ...contextual];
+      if (memories.length === 0) {
+        return;
+      }
+      ctx.extendMessages([
+        { role: 'user', contents: [textContent(`${this.#contextPrompt}\n${memories.join('\n')}`)] },
+      ]);
+    } catch (error) {
+      this.#failed('search', error);
+    }
+  }
+
+  /**
+   * Sends the completed turn to the store.
+   *
+   * A failed run is not stored: its transcript is a partial exchange, and remembering a
+   * conversation that did not happen is worse than remembering nothing.
+   */
+  async afterRun(ctx: ProviderAfterRunContext): Promise<void> {
+    if (ctx.error !== undefined) {
+      return;
+    }
+    const state = ctx.state as MemoryState;
+    const scope = this.#resolveScope(ctx, state);
+
+    const items = storageItems([
+      ...this.#storeRequestFilter(ctx.inputMessages),
+      ...this.#storeResponseFilter(ctx.response?.messages ?? []),
+    ]);
+    if (items.length === 0) {
+      return;
+    }
+
+    try {
+      const result = await this.#client.updateMemories(
+        {
+          name: this.#storeName,
+          scope,
+          items,
+          updateDelay: this.#updateDelay,
+          ...(state.previousUpdateId === undefined ? {} : { previousUpdateId: state.previousUpdateId }),
+        },
+        ctx.signal,
+      );
+      if (typeof result.update_id === 'string') {
+        state.previousUpdateId = result.update_id;
+        this.#pendingUpdateId = result.update_id;
+      }
+    } catch (error) {
+      this.#failed('update', error);
+    }
+  }
+
+  /**
+   * Creates the memory store when it does not already exist, and reports whether it did.
+   *
+   * Provisioning, not a runtime path: call it from a setup script, or once at startup.
+   */
+  async ensureMemoryStoreCreated(
+    definition: MemoryStoreDefinition,
+    options: { description?: string; signal?: AbortSignal } = {},
+  ): Promise<boolean> {
+    const existing = await this.#client.getMemoryStore(this.#storeName, options.signal);
+    if (existing !== undefined) {
+      return false;
+    }
+    await this.#client.createMemoryStore(
+      {
+        name: this.#storeName,
+        definition,
+        ...(options.description === undefined ? {} : { description: options.description }),
+      },
+      options.signal,
+    );
+    return true;
+  }
+
+  /** The store, or `undefined` when it does not exist. */
+  async getMemoryStore(signal?: AbortSignal): Promise<MemoryStoreObject | undefined> {
+    return await this.#client.getMemoryStore(this.#storeName, signal);
+  }
+
+  /**
+   * Deletes everything stored under `scope`, and reports whether there was anything to delete.
+   *
+   * The scope is explicit rather than read from a session, because deletion is not part of a run:
+   * a caller erasing a user's memories has the user id, and taking it here keeps the operation
+   * from depending on which session happens to be at hand.
+   */
+  async deleteStoredMemories(scope: string, signal?: AbortSignal): Promise<boolean> {
+    return await this.#client.deleteScope(this.#storeName, scope, signal);
+  }
+
+  /**
+   * Waits for the most recent extraction to finish.
+   *
+   * Extraction is asynchronous: `afterRun` queues it and returns, so a memory stated in one run is
+   * not necessarily searchable at the start of the next one. Tests and samples that demonstrate
+   * cross-run recall need this; production code generally does not, and paying for it on every
+   * turn would put the service's extraction latency on the user's critical path.
+   *
+   * Updates are processed in order, so the newest one completing means the older ones have too.
+   *
+   * @throws {FoundryMemoryError} When the extraction failed.
+   */
+  async whenUpdatesCompleted(options: { pollIntervalMs?: number; signal?: AbortSignal } = {}): Promise<void> {
+    const updateId = this.#pendingUpdateId;
+    if (updateId === undefined) {
+      return;
+    }
+    const interval = options.pollIntervalMs ?? 5000;
+    for (;;) {
+      options.signal?.throwIfAborted();
+      const result = await this.#client.getUpdateResult(this.#storeName, updateId, options.signal);
+      if (result.status === 'completed' || result.status === 'superseded') {
+        // Cleared only after it completed, and only when nothing newer has been queued since.
+        if (this.#pendingUpdateId === updateId) {
+          this.#pendingUpdateId = undefined;
+        }
+        return;
+      }
+      if (result.status === 'failed') {
+        throw new FoundryMemoryError(
+          'updateResult',
+          `Foundry memory update '${updateId}' failed.${result.error?.message === undefined ? '' : ` ${result.error.message}`}`,
+        );
+      }
+      if (result.status !== 'queued' && result.status !== 'in_progress') {
+        throw new FoundryMemoryError(
+          'updateResult',
+          `Foundry memory update '${updateId}' reported an unknown status '${String(result.status)}'.`,
+        );
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, interval));
+    }
+  }
+
+  /**
+   * The partition this run reads and writes, pinned to the session on first use.
+   *
+   * @throws {ConfigurationError} When no scope can be resolved, or when the session already
+   * belongs to a different one.
+   */
+  #resolveScope(ctx: ProviderRunContext, state: MemoryState): string {
+    const resolved = typeof this.#scope === 'string' ? this.#scope : this.#scope(ctx);
+    if (typeof resolved !== 'string' || resolved.trim() === '') {
+      throw new ConfigurationError(
+        `FoundryMemoryProvider ('${this.sourceId}') resolved an empty memory scope. A scope is the ` +
+          'isolation boundary between users; it cannot be omitted.',
+      );
+    }
+    const pinned = state.scope;
+    if (typeof pinned === 'string' && pinned !== resolved) {
+      throw new ConfigurationError(
+        `FoundryMemoryProvider ('${this.sourceId}') resolved a different memory scope for a session ` +
+          'that is already pinned to one. A session belongs to exactly one scope; continuing would ' +
+          "read and write another partition's memories.",
+      );
+    }
+    state.scope = resolved;
+    return resolved;
+  }
+
+  /** Reports a failure, and re-raises it when the provider is configured to fail closed. */
+  #failed(operation: MemoryOperation, error: unknown): void {
+    this.#onFailure?.({ operation, error });
+    if (this.#failureMode === 'throw') {
+      throw error;
+    }
+  }
+}
+
+/** The memory texts a search answered with, in order, dropping the blank ones. */
+function contentsOf(result: { memories?: Array<{ memory_item?: { content?: string } }> }): string[] {
+  return (result.memories ?? [])
+    .map((memory) => memory.memory_item?.content)
+    .filter((content): content is string => typeof content === 'string' && content.trim() !== '');
+}
+
+/**
+ * The items a search is built from.
+ *
+ * Every non-empty message counts, whatever its role: a search is a similarity query, and a role
+ * the memory service does not model is still text worth matching on. Roles it does model are
+ * preserved; anything else is asked about as if the user had said it.
+ */
+function searchItems(messages: readonly Message[]): MemoryInputItem[] {
+  const items: MemoryInputItem[] = [];
+  for (const message of messages) {
+    const content = textOf(message);
+    if (content.trim() === '') {
+      continue;
+    }
+    items.push({ type: 'message', role: storableRole(message.role) ?? 'user', content });
+  }
+  return items;
+}
+
+/**
+ * The items a turn is stored as.
+ *
+ * Unlike a search, storage is selective: only the three conversational roles are remembered. A
+ * tool call's arguments and results are machinery, not something the user said, and extracting
+ * durable facts from them is how a store fills up with transient ids.
+ */
+function storageItems(messages: readonly Message[]): MemoryInputItem[] {
+  const items: MemoryInputItem[] = [];
+  for (const message of messages) {
+    const role = storableRole(message.role);
+    if (role === undefined) {
+      continue;
+    }
+    const content = textOf(message);
+    if (content.trim() === '') {
+      continue;
+    }
+    items.push({ type: 'message', role, content });
+  }
+  return items;
+}
+
+/** The message role as the memory service names it, or `undefined` when it models no such role. */
+function storableRole(role: string): MemoryInputItem['role'] | undefined {
+  return role === 'user' || role === 'assistant' || role === 'system' ? role : undefined;
+}

--- a/packages/foundry/src/memory/provider.ts
+++ b/packages/foundry/src/memory/provider.ts
@@ -229,38 +229,41 @@ export class FoundryMemoryProvider implements ContextProvider {
       }
     }
 
+    let contextual: string[] = [];
     const items = searchItems(this.#searchFilter(ctx.inputMessages));
-    if (items.length === 0) {
-      return;
+    if (items.length > 0) {
+      try {
+        const result = await this.#client.searchMemories(
+          {
+            name: this.#storeName,
+            scope,
+            items,
+            maxMemories: this.#maxMemories,
+            ...(state.previousSearchId === undefined ? {} : { previousSearchId: state.previousSearchId }),
+          },
+          ctx.signal,
+        );
+        contextual = contentsOf(result);
+        // Only a search that found something moves the incremental anchor: carrying forward the id
+        // of an empty search would make the next one resume from nothing.
+        if (contextual.length > 0 && typeof result.search_id === 'string') {
+          state.previousSearchId = result.search_id;
+        }
+      } catch (error) {
+        this.#failed('search', error);
+      }
     }
 
-    try {
-      const result = await this.#client.searchMemories(
-        {
-          name: this.#storeName,
-          scope,
-          items,
-          maxMemories: this.#maxMemories,
-          ...(state.previousSearchId === undefined ? {} : { previousSearchId: state.previousSearchId }),
-        },
-        ctx.signal,
-      );
-      const contextual = contentsOf(result);
-      // Only a search that found something moves the incremental anchor: carrying forward the id
-      // of an empty search would make the next one resume from nothing.
-      if (contextual.length > 0 && typeof result.search_id === 'string') {
-        state.previousSearchId = result.search_id;
-      }
-      const memories = [...(state.staticMemories ?? []), ...contextual];
-      if (memories.length === 0) {
-        return;
-      }
-      ctx.extendMessages([
-        { role: 'user', contents: [textContent(`${this.#contextPrompt}\n${memories.join('\n')}`)] },
-      ]);
-    } catch (error) {
-      this.#failed('search', error);
+    // The profile memories are injected whether or not this turn gave the contextual search
+    // anything to work with, and whether or not that search survived: they were retrieved to be
+    // replayed on every run, and a turn the agent is still going to answer deserves them.
+    const memories = [...(state.staticMemories ?? []), ...contextual];
+    if (memories.length === 0) {
+      return;
     }
+    ctx.extendMessages([
+      { role: 'user', contents: [textContent(`${this.#contextPrompt}\n${memories.join('\n')}`)] },
+    ]);
   }
 
   /**

--- a/packages/foundry/src/memory/provider.ts
+++ b/packages/foundry/src/memory/provider.ts
@@ -214,13 +214,18 @@ export class FoundryMemoryProvider implements ContextProvider {
           ctx.signal,
         );
         state.staticMemories = contentsOf(result);
-      } catch (error) {
-        state.staticMemories = [];
-        this.#failed('search', error);
-      } finally {
-        // Marked either way: a store that refused the profile search once will refuse it on every
-        // run of this session, and retrying it per run only adds latency to each of them.
         state.initialized = true;
+      } catch (error) {
+        // When failures are survivable, the failure is marked as initialization too: a store that
+        // refused the profile search once will refuse it on every run of this session, and
+        // retrying it per run only adds latency to each of them. A failure that throws instead
+        // fails the whole run — the run that replaces it deserves a fresh attempt, not a session
+        // quietly pinned to an empty profile.
+        if (this.#failureMode === 'continue') {
+          state.staticMemories = [];
+          state.initialized = true;
+        }
+        this.#failed('search', error);
       }
     }
 
@@ -379,7 +384,7 @@ export class FoundryMemoryProvider implements ContextProvider {
           `Foundry memory update '${updateId}' reported an unknown status '${String(result.status)}'.`,
         );
       }
-      await new Promise<void>((resolve) => setTimeout(resolve, interval));
+      await sleep(interval, options.signal);
     }
   }
 
@@ -416,6 +421,25 @@ export class FoundryMemoryProvider implements ContextProvider {
       throw error;
     }
   }
+}
+
+/** Resolves after `ms`, or rejects the moment `signal` aborts instead of at the timer. */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted === true) {
+      reject(signal.reason);
+      return;
+    }
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(signal?.reason);
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 /** The memory texts a search answered with, in order, dropping the blank ones. */

--- a/packages/foundry/src/memory/provider.ts
+++ b/packages/foundry/src/memory/provider.ts
@@ -216,6 +216,9 @@ export class FoundryMemoryProvider implements ContextProvider {
         state.staticMemories = contentsOf(result);
         state.initialized = true;
       } catch (error) {
+        // A cancelled call is the caller's decision, not a service failure: it is rethrown before
+        // any state is written or any failure is reported, whatever the failure mode.
+        ctx.signal?.throwIfAborted();
         // When failures are survivable, the failure is marked as initialization too: a store that
         // refused the profile search once will refuse it on every run of this session, and
         // retrying it per run only adds latency to each of them. A failure that throws instead
@@ -250,6 +253,7 @@ export class FoundryMemoryProvider implements ContextProvider {
           state.previousSearchId = result.search_id;
         }
       } catch (error) {
+        ctx.signal?.throwIfAborted();
         this.#failed('search', error);
       }
     }
@@ -303,6 +307,9 @@ export class FoundryMemoryProvider implements ContextProvider {
         this.#pendingUpdateId = result.update_id;
       }
     } catch (error) {
+      // A run whose memory write was cancelled must not read as one that succeeded and merely
+      // lost its memories: the cancellation propagates instead of being reported as a failure.
+      ctx.signal?.throwIfAborted();
       this.#failed('update', error);
     }
   }


### PR DESCRIPTION
Implements `FoundryMemoryProvider`, a first-party Foundry Memory integration built on the existing
`ContextProvider` contract. Closes #25.

## What it does

- **Before each run** it searches the memory store: once per session without items, for the scope's
  profile memories, and on every turn with the run's input, for memories relevant to it. What it
  finds is injected as a single user message under a configurable context prompt. Nothing is
  injected when the store returns nothing.
- **After each run** it sends the turn — request and response messages, `user` / `assistant` /
  `system` only — to the store, which extracts memories from it asynchronously. A failed run is not
  stored.
- Searches and updates chain through `previous_search_id` / `previous_update_id`, held in the
  provider's own partition of the session.

## Scoping

`scope` is required, and takes a value or a function of the run. It is resolved per run and then
**pinned to the session**: a session that later resolves a different scope fails the run rather than
reading another user's memories. `hostedUserScope()` (from `/hosting`) resolves it from the end-user
id the platform injects, and throws outside a hosted turn or when the turn carries no user id —
never falling back to a shared partition.

There is deliberately no tenant dimension: the platform injects one identity per request, a hosted
container is deployed per agent inside one tenant, and the reference implementation's hosted helper
is `PerUser()` only. The tenant boundary is the store's, not a partition inside it.

## Failure handling

`failureMode` defaults to `'continue'` — the run proceeds without the memories it could not read,
and drops the ones it could not write — and `'throw'` fails the run. `onFailure` is called in both
modes with the operation and the error; the scope is deliberately not passed, since it is normally
an end-user id. Scope resolution is outside this: an unresolvable or changed scope always throws.

## Transport

A hand-written `fetch` client for the preview memory-store routes (`Foundry-Features:
MemoryStores=V1Preview`, `api-version=v1`) — the JavaScript Azure SDK has no memory-store API. It
is overridable, so every test runs offline. There is no retry: memory sits on the critical path of
every run and the default is to survive losing it, so a caller who wants retries supplies a `fetch`
that has them.

The provider also carries the store operations a caller needs around it: `ensureMemoryStoreCreated`,
`getMemoryStore`, `deleteStoredMemories` and `whenUpdatesCompleted`.

## Tests

47 new tests, all offline: the wire contract of every route, and the provider driven through a real
`Agent` — injection, once-per-session profile retrieval, incremental anchors, storage filtering,
scope pinning, both failure modes, and the store operations. Negative controls were measured for
the scope pin, the fail-closed mode and the skip-on-failed-run rule: each fails when its check is
removed.

## Sample

`examples/02-foundry/06-memory-agent` — a Hosted Agent with memory, plus the script that provisions
the store, and a README that walks through stating a preference in one conversation and having it
recalled in the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
