### PR TITLE
Honour the on spelling of ENABLE_SENSITIVE_DATA

### DIFF
--- a/packages/core/src/observability/settings.test.ts
+++ b/packages/core/src/observability/settings.test.ts
@@ -41,10 +41,29 @@ describe('captureMessageContent', () => {
       ['false', false],
       ['0', false],
       ['no', false],
+      ['on', true],
+      ['off', false],
       ['', false],
       ['  True  ', true],
     ] as const) {
       vi.stubEnv(OTEL_ENV, value);
+      expect(captureMessageContent(), `value ${JSON.stringify(value)}`).toBe(expected);
+    }
+  });
+
+  // Python's own reader accepts `on`, so a deployment that sets one variable for a polyglot
+  // fleet has to be read the same way here or the opt-in silently applies to only half of it.
+  it('accepts every spelling Python accepts for the Python-named env var', () => {
+    for (const [value, expected] of [
+      ['true', true],
+      ['1', true],
+      ['yes', true],
+      ['on', true],
+      ['ON', true],
+      ['off', false],
+      ['false', false],
+    ] as const) {
+      vi.stubEnv(PYTHON_ENV, value);
       expect(captureMessageContent(), `value ${JSON.stringify(value)}`).toBe(expected);
     }
   });

--- a/packages/core/src/observability/settings.ts
+++ b/packages/core/src/observability/settings.ts
@@ -30,11 +30,15 @@ function readEnv(name: string): string | undefined {
   }
 }
 
+/** The spellings Python's own environment reader accepts as true, plus their negatives. */
+const TRUE_VALUES = new Set(['true', '1', 'yes', 'on']);
+const FALSE_VALUES = new Set(['false', '0', 'no', 'off', '']);
+
 function parseBool(value: string | undefined): boolean | undefined {
   if (value === undefined) return undefined;
   const normalized = value.trim().toLowerCase();
-  if (normalized === 'true' || normalized === '1' || normalized === 'yes') return true;
-  if (normalized === 'false' || normalized === '0' || normalized === 'no' || normalized === '') return false;
+  if (TRUE_VALUES.has(normalized)) return true;
+  if (FALSE_VALUES.has(normalized)) return false;
   return undefined;
 }
 

--- a/packages/core/src/observability/settings.ts
+++ b/packages/core/src/observability/settings.ts
@@ -30,7 +30,9 @@ function readEnv(name: string): string | undefined {
   }
 }
 
-/** The spellings Python's own environment reader accepts as true, plus their negatives. */
+// The truthy spellings are exactly what Python's own environment reader accepts; the falsy set is
+// their negatives plus the empty (or whitespace-only) string, so a variable that is explicitly
+// blanked or turned off does not fall through to the other variable name.
 const TRUE_VALUES = new Set(['true', '1', 'yes', 'on']);
 const FALSE_VALUES = new Set(['false', '0', 'no', 'off', '']);
 


### PR DESCRIPTION
`ENABLE_SENSITIVE_DATA` is honoured as a compatibility alias for the OTel GenAI capture switch, but
only `true`, `1` and `yes` were read as true. Python's own reader also accepts `on`, so
`ENABLE_SENSITIVE_DATA=on` captured message content in a Python process and silently did not here —
the exact case the alias exists to cover, failing in the quiet direction.

This accepts the same spellings Python does, and adds `off` alongside the other negatives so a
variable that is explicitly turned off is not treated as unset and allowed to fall through to the
other name.

The failing cases were measured against the current code before the fix.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)