### PR TITLE
Document what happens when a caller stops consuming an agent run early

### DIFF
--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -217,6 +217,31 @@ describe('Agent.run', () => {
     expect(afterRun.mock.calls[0]?.[0].response).toBeUndefined();
   });
 
+  it('resolves finalResponse with the partial response after a break, but rejects it after an abort', async () => {
+    // The two ways of stopping early differ here: a break is a decision, so the collected part is
+    // the answer; an abort is a failure, and a failed stream has no result to hand back.
+    const stopped = new Agent({
+      client: new MockChatClient([{ contents: [textContent('a'), textContent('b')] }]),
+    }).run('hi');
+    for await (const _ of stopped) {
+      break;
+    }
+    expect((await stopped.finalResponse()).text).toBe('a');
+
+    const controller = new AbortController();
+    const aborted = new Agent({
+      client: new MockChatClient([{ contents: [textContent('a'), textContent('b')] }]),
+    }).run('hi', { signal: controller.signal });
+    await expect(
+      (async () => {
+        for await (const _ of aborted) {
+          controller.abort();
+        }
+      })(),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    await expect(aborted.finalResponse()).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
   it('calls afterRun with the error when the consumer throws into the stream', async () => {
     const afterRun = vi.fn();
     const agent = new Agent({

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -53,7 +53,30 @@ import { agentAsTool } from './as-tool.js';
 import { parseContinuationToken, wrapContinuationToken } from './continuation.js';
 import { AgentSession } from './session.js';
 
-/** The hybrid stream returned by {@link Agent.run}: awaitable and iterable. */
+/**
+ * The hybrid stream returned by {@link Agent.run}: awaitable and iterable.
+ *
+ * ## Stopping early
+ *
+ * A caller may stop reading at any point — `break` out of the `for await`, or abort the run's
+ * signal. Relaying a run to an HTTP client makes that the normal case rather than the exceptional
+ * one, so what each does is part of the contract:
+ *
+ * - **`break`** closes the underlying provider stream, so the connection is released rather than
+ *   left to drain. The run then ends the way a finished one does: context providers get their
+ *   `afterRun`, the history provider persists the exchange *as far as it got*, and the
+ *   `invoke_agent` span is ended. Structured output is **not** parsed — the text stops wherever
+ *   the `break` landed, so parsing it would turn a legitimate `break` into an error. This follows
+ *   Go, whose run loop falls through to its `Invoked` calls after the consumer stops; .NET
+ *   abandons the run without notifying its providers, so a caller porting between the two should
+ *   not assume the transcript matches.
+ * - **Abort** ends the run as a failure instead. Providers are told with the error rather than a
+ *   response, so a history provider that stores only completed exchanges — the default — writes
+ *   nothing for that turn, and the span carries the error.
+ *
+ * Either way {@link ResponseStream.finalResponse} still returns what was collected, and the
+ * teardown runs exactly once no matter which path got there first.
+ */
 export type AgentRunStream<T = undefined> = ResponseStream<AgentResponseUpdate, AgentResponse<T>>;
 
 /** Maps a `responseFormat` to the type of `response.value`. */

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -74,8 +74,10 @@ import { AgentSession } from './session.js';
  *   response, so a history provider that stores only completed exchanges — the default — writes
  *   nothing for that turn, and the span carries the error.
  *
- * Either way {@link ResponseStream.finalResponse} still returns what was collected, and the
- * teardown runs exactly once no matter which path got there first.
+ * The two also differ in what {@link ResponseStream.finalResponse} does afterwards: after a
+ * `break` it returns the partial response that was collected, while after an abort it rejects
+ * with the abort error — the stream failed, and a failed stream has no result to hand back.
+ * Either way the teardown runs exactly once no matter which path got there first.
  */
 export type AgentRunStream<T = undefined> = ResponseStream<AgentResponseUpdate, AgentResponse<T>>;
 

--- a/packages/core/src/streaming/response-stream.ts
+++ b/packages/core/src/streaming/response-stream.ts
@@ -80,6 +80,19 @@ export interface ResponseStreamInit<TUpdate, TFinal> {
  * `await` or `for await` throws {@link StreamConsumedError} synchronously. After iterating,
  * {@link ResponseStream.finalResponse} returns the folded result.
  *
+ * ## Stopping early is supported
+ *
+ * A consumer may abandon the stream — `break` out of the `for await`, or call `return()` on the
+ * iterator — without leaking anything and without needing a `close()` of its own. The abandoned
+ * source is closed first, which propagates inward through every layer to the provider SDK stream,
+ * and the `cleanup` and `onResult` hooks then run exactly once, so whatever they hold is released
+ * at the point the caller stopped rather than whenever the object is collected.
+ *
+ * The folded result stays available from {@link ResponseStream.finalResponse}; it describes the
+ * part of the run that was actually produced, and `onResult` hooks are told so through
+ * {@link StreamResultContext.abandoned}. An aborted signal is a failure rather than an
+ * abandonment: the hooks still run, but the stream reports the abort.
+ *
  * ## Failure is permanent
  *
  * A stream that failed stays failed. Whatever killed it — the source, an abort, a consumer

--- a/packages/core/src/streaming/response-stream.ts
+++ b/packages/core/src/streaming/response-stream.ts
@@ -91,7 +91,8 @@ export interface ResponseStreamInit<TUpdate, TFinal> {
  * The folded result stays available from {@link ResponseStream.finalResponse}; it describes the
  * part of the run that was actually produced, and `onResult` hooks are told so through
  * {@link StreamResultContext.abandoned}. An aborted signal is a failure rather than an
- * abandonment: the hooks still run, but the stream reports the abort.
+ * abandonment: the hooks still run, but `finalResponse()` rejects with the abort error instead of
+ * returning a partial result.
  *
  * ## Failure is permanent
  *

--- a/packages/core/src/streaming/response-stream.ts
+++ b/packages/core/src/streaming/response-stream.ts
@@ -91,8 +91,9 @@ export interface ResponseStreamInit<TUpdate, TFinal> {
  * The folded result stays available from {@link ResponseStream.finalResponse}; it describes the
  * part of the run that was actually produced, and `onResult` hooks are told so through
  * {@link StreamResultContext.abandoned}. An aborted signal is a failure rather than an
- * abandonment: the hooks still run, but `finalResponse()` rejects with the abort error instead of
- * returning a partial result.
+ * abandonment: `cleanup` still runs, handed the abort as its `failure`, but there is no result —
+ * `finalize` and the `onResult` hooks never run, and `finalResponse()` rejects with the abort
+ * error instead of returning a partial one.
  *
  * ## Failure is permanent
  *


### PR DESCRIPTION
A consumer relaying `agent.run()` over Server-Sent Events sees clients disconnect routinely, so
`break` out of a `for await` — and an aborted signal — need to be documented promises rather than
implementation details.

Both behaviours are already implemented and covered by tests; this writes them down on
`AgentRunStream` and `ResponseStream`:

- `break` closes the underlying provider stream, then ends the run the way a finished one ends —
  `afterRun` for every provider, the exchange persisted as far as it got, the `invoke_agent` span
  closed. Structured output is deliberately not parsed, so a legitimate `break` cannot raise.
- An abort ends the run as a failure: providers are told with the error and no response, so the
  bundled history providers store nothing for that turn.

The note also records that this follows Go — whose run loop falls through to its `Invoked` calls
after the consumer stops — rather than .NET, which abandons the run without notifying its
providers. A caller porting between the two should not assume the transcripts match.

No behaviour change.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)