### PR TITLE
Pin and document how to read token usage after consuming a stream

### DIFF
--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -117,6 +117,39 @@ describe('Agent.run', () => {
     expect(stored.filter((m) => m.role === 'user')).toHaveLength(1);
   });
 
+  it('totals the usage of every round of a streamed run', async () => {
+    // The whole-run total is what a caller logs once per run, so it has to survive both the tool
+    // loop (several model calls) and streaming consumption (usage arrives as a trailing content).
+    const weather = tool({
+      name: 'get_weather',
+      description: 'd',
+      parameters: { type: 'object', properties: {} },
+      execute: async () => 'sunny',
+    });
+    const mock = new MockChatClient([
+      {
+        contents: [{ type: 'function_call', callId: 'c1', name: 'get_weather', arguments: '{}' }],
+        finishReason: 'tool_calls',
+        usage: { inputTokenCount: 10, outputTokenCount: 4 },
+      },
+      {
+        contents: [textContent('It is sunny.')],
+        finishReason: 'stop',
+        usage: { inputTokenCount: 20, outputTokenCount: 6 },
+      },
+    ]);
+    const stream = new Agent({ client: mock, tools: [weather] }).run('weather?');
+
+    for await (const _ of stream) {
+      // Drained to the end: the total is only complete once the last update has been seen.
+    }
+
+    expect((await stream.finalResponse()).usageDetails).toEqual({
+      inputTokenCount: 30,
+      outputTokenCount: 10,
+    });
+  });
+
   it('merges options run-first with agent options filling the blanks', async () => {
     const mock = client('x');
     const agent = new Agent({

--- a/packages/core/src/types/response.ts
+++ b/packages/core/src/types/response.ts
@@ -68,6 +68,15 @@ export interface ResponseBase<T> {
   /** ISO 8601 timestamp. */
   createdAt?: string;
   finishReason?: FinishReason;
+  /**
+   * Token usage, summed across every model call the response covers — including each round of a
+   * tool loop.
+   *
+   * Available from the response of an awaited run, and from `finalResponse()` after a stream has
+   * been read to the end. A stream abandoned partway reports only the usage the provider had
+   * already sent, which for most providers means none: usage typically arrives on the final
+   * update of a turn.
+   */
   usageDetails?: UsageDetails;
   continuationToken?: ContinuationToken;
   additionalProperties?: Record<string, unknown>;


### PR DESCRIPTION
A caller that logs token usage once per run reaches the total through `finalResponse()` after
draining the stream. That already worked — `usage` contents are summed into `usageDetails` as
updates are folded — but nothing pinned the path at the agent level, and the early-termination case
was undocumented.

- Adds a test that streams a run through a tool loop and asserts the total across both model calls,
  so the whole-run figure is pinned against both the loop and streaming consumption.
- Documents on the response type that usage is summed across every model call the response covers,
  and that a stream abandoned partway reports only what the provider had already sent — which for
  most providers is nothing, since usage arrives on a turn's final update.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)