### PR TITLE
Let a history provider store the messages other providers injected

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -429,6 +429,9 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
       options?.responseFormat ?? options?.options?.responseFormat ?? this.#defaultOptions.responseFormat;
 
     let providerContexts: Array<{ provider: ContextProvider; ctx: ProviderRunContext }> = [];
+    // Captured for `afterRun`: what the providers injected is decided during `start`, but a
+    // history provider is only told about it once the run is over.
+    let injectedMessages: readonly Message[] = [];
     let afterRunDone = false;
     let activeSession: AgentSession | undefined;
     // The `invoke_agent` span covers the whole run, including the tool loop and history
@@ -467,6 +470,7 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
         }
         const afterCtx: ProviderAfterRunContext = {
           ...ctx,
+          contextMessages: injectedMessages,
           ...(response === undefined ? {} : { response }),
           ...(error === undefined ? {} : { error }),
         };
@@ -520,6 +524,7 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
         }
       }
 
+      injectedMessages = [...accumulator.messages];
       const messages: Message[] = resuming ? [] : [...accumulator.messages, ...inputMessages];
       const chatOptions = this.#mergeOptions(
         options,

--- a/packages/core/src/context/context-provider.test.ts
+++ b/packages/core/src/context/context-provider.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Agent } from '../agent/agent.js';
+import type { AgentSession } from '../agent/session.js';
 import type { ChatOptions } from '../client/chat-client.js';
 import { MockChatClient } from '../client/test-support.js';
 import { ConfigurationError } from '../errors.js';
@@ -7,7 +8,12 @@ import { tool } from '../tools/tool.js';
 import { textContent } from '../types/content.js';
 import type { Message } from '../types/message.js';
 import { externalOnly, getMessageSource, notSourceTypes } from '../types/message.js';
-import type { ContextProvider, ProviderAfterRunContext, ProviderRunContext } from './context-provider.js';
+import type {
+  ContextProvider,
+  HistoryProvider,
+  ProviderAfterRunContext,
+  ProviderRunContext,
+} from './context-provider.js';
 import { InMemoryHistoryProvider } from './in-memory-history-provider.js';
 
 function client(...texts: string[]): MockChatClient {
@@ -187,6 +193,186 @@ describe('afterRun', () => {
     await stream.finalResponse();
 
     expect(provider.seen).toEqual(['success']);
+  });
+});
+
+/**
+ * The promises every history provider — file, blob, database — is written against.
+ *
+ * Asserted through a recording provider rather than the in-memory one, so the contract is pinned
+ * where an external implementer relies on it and not merely where the bundled implementation
+ * happens to satisfy it.
+ */
+describe('HistoryProvider contract', () => {
+  class RecordingHistoryProvider implements HistoryProvider {
+    readonly sourceId = 'recording';
+    readonly saved: Message[][] = [];
+    readonly afterRunCalls: Array<{ hasResponse: boolean; hasError: boolean }> = [];
+    #stored: Message[] = [];
+
+    async getMessages(): Promise<Message[]> {
+      return [...this.#stored];
+    }
+
+    async saveMessages(_session: AgentSession, messages: Message[]): Promise<void> {
+      this.saved.push([...messages]);
+      this.#stored = [...this.#stored, ...messages];
+    }
+
+    async beforeRun(ctx: ProviderRunContext): Promise<void> {
+      const history = await this.getMessages();
+      if (history.length > 0) {
+        ctx.extendMessages(history);
+      }
+    }
+
+    async afterRun(ctx: ProviderAfterRunContext): Promise<void> {
+      this.afterRunCalls.push({ hasResponse: ctx.response !== undefined, hasError: ctx.error !== undefined });
+      if (ctx.response === undefined) {
+        return;
+      }
+      await this.saveMessages(ctx.session, [...ctx.inputMessages, ...ctx.response.messages]);
+    }
+  }
+
+  it('passes only the messages new to each turn, never the whole transcript', async () => {
+    const history = new RecordingHistoryProvider();
+    const agent = new Agent({ client: client('one', 'two'), historyProvider: history });
+    const session = agent.createSession();
+
+    await agent.run('first', { session });
+    await agent.run('second', { session });
+
+    // Two appends of one exchange each. A provider that re-sent the transcript would make the
+    // second call four messages long, and an append-only store would then double every turn.
+    expect(history.saved.map((batch) => batch.map((message) => message.role))).toEqual([
+      ['user', 'assistant'],
+      ['user', 'assistant'],
+    ]);
+  });
+
+  it('replays what getMessages returned, oldest first, ahead of the caller input', async () => {
+    const history = new RecordingHistoryProvider();
+    const mock = client('one', 'two');
+    const agent = new Agent({ client: mock, historyProvider: history });
+    const session = agent.createSession();
+
+    await agent.run('first', { session });
+    await agent.run('second', { session });
+
+    expect(mock.calls[1]?.messages.map((message) => message.contents[0])).toEqual([
+      { type: 'text', text: 'first' },
+      { type: 'text', text: 'one' },
+      { type: 'text', text: 'second' },
+    ]);
+  });
+
+  it('loads history before any other provider contributes', async () => {
+    const order: string[] = [];
+    const history = new RecordingHistoryProvider();
+    const originalBefore = history.beforeRun.bind(history);
+    history.beforeRun = async (ctx): Promise<void> => {
+      order.push('history');
+      await originalBefore(ctx);
+    };
+    const other: ContextProvider = {
+      sourceId: 'other',
+      beforeRun: () => {
+        order.push('other');
+      },
+    };
+    const agent = new Agent({ client: client('x'), historyProvider: history, contextProviders: [other] });
+
+    await agent.run('hi', { session: agent.createSession() });
+
+    expect(order).toEqual(['history', 'other']);
+  });
+
+  it('reports a failed turn with the error and no response', async () => {
+    const history = new RecordingHistoryProvider();
+    const failing = {
+      metadata: { providerName: 'mock' },
+      getResponse: (): never => {
+        throw new Error('provider down');
+      },
+    };
+    const agent = new Agent({ client: failing as never, historyProvider: history });
+
+    await expect(agent.run('x', { session: agent.createSession() })).rejects.toThrow('provider down');
+
+    expect(history.afterRunCalls).toEqual([{ hasResponse: false, hasError: true }]);
+    expect(history.saved).toEqual([]);
+  });
+
+  it('stores nothing for a failed turn, so the transcript has no unanswered question in it', async () => {
+    const history = new InMemoryHistoryProvider();
+    const failing = {
+      metadata: { providerName: 'mock' },
+      getResponse: (): never => {
+        throw new Error('provider down');
+      },
+    };
+    const agent = new Agent({ client: failing as never, historyProvider: history });
+    const session = agent.createSession();
+
+    await expect(agent.run('x', { session })).rejects.toThrow('provider down');
+
+    expect(await history.getMessages(session, session.partition(history.sourceId))).toEqual([]);
+  });
+});
+
+describe('storeContextMessages', () => {
+  /** Injects one message, so a run always has something for the opt-in to pick up. */
+  const injector = (sourceId: string, text: string): ContextProvider => ({
+    sourceId,
+    beforeRun: (ctx: ProviderRunContext) => {
+      ctx.extendMessages([{ role: 'user', contents: [textContent(text)] }]);
+    },
+  });
+
+  async function storedTexts(history: InMemoryHistoryProvider): Promise<string[]> {
+    const agent = new Agent({
+      client: client('answer'),
+      historyProvider: history,
+      contextProviders: [injector('memory', 'remembered'), injector('docs', 'retrieved')],
+    });
+    const session = agent.createSession();
+    await agent.run('question', { session });
+    const stored = await history.getMessages(session, session.partition(history.sourceId));
+    return stored.flatMap((message) =>
+      message.contents.map((content) => (content.type === 'text' ? content.text : content.type)),
+    );
+  }
+
+  it('leaves injected context out of the transcript by default', async () => {
+    expect(await storedTexts(new InMemoryHistoryProvider())).toEqual(['question', 'answer']);
+  });
+
+  it('stores every injected message when opted in', async () => {
+    const stored = await storedTexts(new InMemoryHistoryProvider({ storeContextMessages: true }));
+    expect(stored).toEqual(['remembered', 'retrieved', 'question', 'answer']);
+  });
+
+  it('stores only the named sources when given a list', async () => {
+    const stored = await storedTexts(new InMemoryHistoryProvider({ storeContextMessages: ['docs'] }));
+    expect(stored).toEqual(['retrieved', 'question', 'answer']);
+  });
+
+  it('never stores the history it replayed itself, even when opted in', async () => {
+    const history = new InMemoryHistoryProvider({ storeContextMessages: true });
+    const agent = new Agent({ client: client('one', 'two'), historyProvider: history });
+    const session = agent.createSession();
+
+    await agent.run('first', { session });
+    await agent.run('second', { session });
+
+    const stored = await history.getMessages(session, session.partition(history.sourceId));
+    expect(stored.map((message) => message.contents[0])).toEqual([
+      { type: 'text', text: 'first' },
+      { type: 'text', text: 'one' },
+      { type: 'text', text: 'second' },
+      { type: 'text', text: 'two' },
+    ]);
   });
 });
 

--- a/packages/core/src/context/context-provider.ts
+++ b/packages/core/src/context/context-provider.ts
@@ -1,8 +1,8 @@
 import type { AgentSession } from '../agent/session.js';
 import type { Middleware } from '../middleware/middleware.js';
 import type { Tool } from '../tools/tool.js';
-import type { Message, MessageSourceType } from '../types/message.js';
-import { withMessageSource } from '../types/message.js';
+import type { Message, MessageFilter, MessageSourceType } from '../types/message.js';
+import { getMessageSource, withMessageSource } from '../types/message.js';
 import type { AgentResponse } from '../types/response.js';
 
 /** The minimal agent surface a provider is allowed to see. */
@@ -34,6 +34,16 @@ export interface ProviderAfterRunContext extends ProviderRunContext {
   readonly response?: AgentResponse<unknown>;
   /** The failure, absent when the run succeeded. */
   readonly error?: unknown;
+  /**
+   * Everything the providers of this run injected ahead of {@link ProviderRunContext.inputMessages},
+   * in the order the model saw it.
+   *
+   * Each message carries the source stamp of the provider that contributed it, so a history
+   * provider can persist retrieved documents or replayed memories alongside the exchange — see
+   * {@link HistoryStoreOptions.storeContextMessages}. Empty during a resumed run, which re-enters
+   * after the context was already applied.
+   */
+  readonly contextMessages: readonly Message[];
 }
 
 /**
@@ -77,12 +87,88 @@ export function sourceTypeOf(provider: ContextProvider): MessageSourceType {
  *
  * Registered before every other {@link ContextProvider}, so history is the oldest context in the
  * request.
+ *
+ * ## What an implementation may rely on
+ *
+ * The store behind this interface is append-only, and the framework holds up its side of that:
+ *
+ * - `saveMessages` is handed **only the messages new to that turn**. The transcript is never
+ *   re-sent, so an implementation appends what it is given and never has to diff or de-duplicate.
+ * - It is called once per run, not once per round of the tool loop, so one turn's function calls
+ *   and their results arrive together with the answer they produced.
+ * - `getMessages` returns the transcript oldest first, and whatever it returns is replayed ahead
+ *   of the caller's input for that run.
+ * - `beforeRun` runs before every other context provider's, so history is the oldest thing in the
+ *   request rather than something interleaved with retrieved documents.
+ *
+ * ## What an implementation decides
+ *
+ * `afterRun` is called for a failed run too, with `error` set and no `response`. The bundled
+ * providers store nothing in that case — a turn with an input and no answer would replay as an
+ * unanswered question — and an implementation that stores anyway is choosing differently, not
+ * fixing an omission. A run the caller abandoned partway *does* have a response, so it is stored
+ * like any other; see the note on stopping early in `AgentRunStream`.
+ *
+ * What reaches the store beyond the caller's input and the response is
+ * {@link HistoryStoreOptions.storeContextMessages}.
  */
 export interface HistoryProvider extends ContextProvider {
   /** Returns the stored transcript, oldest first. */
   getMessages(session: AgentSession, state: Record<string, unknown>): Promise<Message[]>;
   /** Appends `messages` to the stored transcript. */
   saveMessages(session: AgentSession, messages: Message[], state: Record<string, unknown>): Promise<void>;
+}
+
+/**
+ * What a bundled history provider replays and writes back.
+ *
+ * Shared by every history provider this framework ships, so switching storage does not change
+ * which messages are stored.
+ */
+export interface HistoryStoreOptions {
+  /**
+   * Narrows what the stored transcript contributes to a run. Defaults to everything.
+   */
+  provideFilter?: MessageFilter;
+  /**
+   * Narrows what a finished run writes back.
+   *
+   * Defaults to `notSourceTypes('ChatHistory')`: re-saving replayed history would grow the
+   * transcript geometrically. Replacing this is how a caller stores, say, only external messages.
+   */
+  storeFilter?: MessageFilter;
+  /**
+   * Also store the messages other context providers injected into the run.
+   *
+   * Off by default, matching Python: retrieved documents and remembered text are usually
+   * re-derived on the next run, and persisting them would both duplicate them and freeze a
+   * snapshot of something meant to stay live. .NET and Go store them by default instead, so a
+   * transcript written by this framework is the narrower of the two.
+   *
+   * `true` stores every injected message. A list of `sourceId`s stores only the ones those
+   * providers contributed, which is how a caller persists retrieved documents without also
+   * persisting everything else in the context window. Messages the history provider itself
+   * replayed are dropped by the default {@link HistoryStoreOptions.storeFilter} either way.
+   */
+  storeContextMessages?: boolean | readonly string[];
+}
+
+/** Applies {@link HistoryStoreOptions.storeContextMessages} to one run's injected messages. */
+export function selectContextMessages(
+  messages: readonly Message[],
+  option: boolean | readonly string[] | undefined,
+): Message[] {
+  if (option === undefined || option === false) {
+    return [];
+  }
+  if (option === true) {
+    return [...messages];
+  }
+  const wanted = new Set(option);
+  return messages.filter((message) => {
+    const sourceId = getMessageSource(message)?.sourceId;
+    return sourceId !== undefined && wanted.has(sourceId);
+  });
 }
 
 /** Returns `true` when `provider` also implements {@link HistoryProvider}. */

--- a/packages/core/src/context/in-memory-history-provider.ts
+++ b/packages/core/src/context/in-memory-history-provider.ts
@@ -3,32 +3,24 @@ import type { Message, MessageFilter } from '../types/message.js';
 import { notSourceTypes, passThrough } from '../types/message.js';
 import type { SerializedMessage } from '../types/serialization.js';
 import { deserializeMessages, serializeMessages } from '../types/serialization.js';
-import type { HistoryProvider, ProviderAfterRunContext, ProviderRunContext } from './context-provider.js';
+import type {
+  HistoryProvider,
+  HistoryStoreOptions,
+  ProviderAfterRunContext,
+  ProviderRunContext,
+} from './context-provider.js';
+import { selectContextMessages } from './context-provider.js';
 
 const MESSAGES_KEY = 'messages';
 
 /** Options for {@link InMemoryHistoryProvider}. */
-export interface InMemoryHistoryProviderConfig {
+export interface InMemoryHistoryProviderConfig extends HistoryStoreOptions {
   /**
    * Defaults to `'in_memory'` (Python `InMemoryHistoryProvider.DEFAULT_SOURCE_ID`, which also
    * names the session-state partition). Override when running several history providers side by
    * side.
    */
   sourceId?: string;
-  /**
-   * Narrows what the stored transcript contributes to a run. Defaults to everything.
-   *
-   * Go `ChatHistoryProviderOptions.ProvideOutputMessageFilter`.
-   */
-  provideFilter?: MessageFilter;
-  /**
-   * Narrows what a finished run writes back.
-   *
-   * Defaults to `notSourceTypes('ChatHistory')`: re-saving replayed history would grow the
-   * transcript geometrically (Go's `notSourceTypes(SourceTypeHistoryProvider)`). Replacing this is
-   * how a caller stores, say, only external messages.
-   */
-  storeFilter?: MessageFilter;
 }
 
 /**
@@ -51,11 +43,13 @@ export class InMemoryHistoryProvider implements HistoryProvider {
   readonly sourceId: string;
   readonly #provideFilter: MessageFilter;
   readonly #storeFilter: MessageFilter;
+  readonly #storeContextMessages: boolean | readonly string[];
 
   constructor(options?: InMemoryHistoryProviderConfig) {
     this.sourceId = options?.sourceId ?? 'in_memory';
     this.#provideFilter = options?.provideFilter ?? passThrough;
     this.#storeFilter = options?.storeFilter ?? notSourceTypes('ChatHistory');
+    this.#storeContextMessages = options?.storeContextMessages ?? false;
   }
 
   async getMessages(_session: AgentSession, state: Record<string, unknown>): Promise<Message[]> {
@@ -83,10 +77,16 @@ export class InMemoryHistoryProvider implements HistoryProvider {
   }
 
   async afterRun(ctx: ProviderAfterRunContext): Promise<void> {
+    // A run that failed produced no exchange to append. Storing its input alone would leave the
+    // transcript with a question the model never answered, which the next run would replay.
     if (ctx.response === undefined) {
       return;
     }
-    const toSave = this.#storeFilter([...ctx.inputMessages, ...ctx.response.messages]);
+    const toSave = this.#storeFilter([
+      ...selectContextMessages(ctx.contextMessages, this.#storeContextMessages),
+      ...ctx.inputMessages,
+      ...ctx.response.messages,
+    ]);
     if (toSave.length > 0) {
       await this.saveMessages(ctx.session, toSave, ctx.state);
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,11 +46,12 @@ export { APPROVAL_STATE_KEY, sessionApprovalStore, withToolApproval } from './cl
 export type {
   ContextProvider,
   HistoryProvider,
+  HistoryStoreOptions,
   ProviderAfterRunContext,
   ProviderAgentInfo,
   ProviderRunContext,
 } from './context/context-provider.js';
-export { isHistoryProvider } from './context/context-provider.js';
+export { isHistoryProvider, selectContextMessages } from './context/context-provider.js';
 export type { InMemoryHistoryProviderConfig } from './context/in-memory-history-provider.js';
 export { InMemoryHistoryProvider } from './context/in-memory-history-provider.js';
 // errors


### PR DESCRIPTION
Every external history provider — file, blob, database — rests on behaviour that was exercised only
through the in-memory provider, and the one knob the reference implementations offer was missing.

## The opt-in

What lands in the transcript by default differs across the reference implementations: .NET and Go
pass the whole assembled request to the provider and filter only history-sourced messages back out,
so context-provider injections are stored; Python stores the caller's input alone unless
`store_context_messages` is set. This framework matched Python's default but had no way to opt in —
`afterRun` never saw the injected messages at all.

- `ProviderAfterRunContext.contextMessages` now carries what the run's providers injected, each
  still stamped with its source.
- `HistoryStoreOptions.storeContextMessages` decides whether they are written back: `false` (the
  default), `true`, or a list of `sourceId`s so a caller can persist retrieved documents without
  persisting everything else in the context window — Python's `store_context_from`, folded into the
  same option. Messages the history provider itself replayed are dropped by the default store
  filter either way.

## The contract suite

Asserted through a recording provider rather than the in-memory one, so the promises are pinned
where an external implementer relies on them: only that turn's new messages are passed, the
transcript is replayed oldest first ahead of the caller input, history loads before any other
provider, and a failed turn arrives with the error and stores nothing. `HistoryProvider` now
documents all of it, including that storing on failure is a choice an implementation makes rather
than an omission to fix.

Public API additions: `HistoryStoreOptions`, `selectContextMessages`,
`ProviderAfterRunContext.contextMessages`. `InMemoryHistoryProviderConfig` keeps its shape,
now by extending `HistoryStoreOptions`.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)