### PR TITLE
Add a file-backed history provider

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/testing.d.ts",
       "default": "./dist/testing.js"
     },
+    "./node": {
+      "types": "./dist/node.d.ts",
+      "default": "./dist/node.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
@@ -61,6 +65,7 @@
     "@opentelemetry/resources": "^2.10.0",
     "@opentelemetry/sdk-metrics": "^2.10.0",
     "@opentelemetry/sdk-trace-base": "^2.10.0",
+    "@types/node": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/core/src/context/history-store.ts
+++ b/packages/core/src/context/history-store.ts
@@ -1,0 +1,45 @@
+import type { Message, MessageFilter } from '../types/message.js';
+import { notSourceTypes, passThrough } from '../types/message.js';
+import type { HistoryStoreOptions, ProviderAfterRunContext } from './context-provider.js';
+import { selectContextMessages } from './context-provider.js';
+
+/** {@link HistoryStoreOptions} with the defaults filled in. */
+export interface ResolvedHistoryStoreOptions {
+  provideFilter: MessageFilter;
+  storeFilter: MessageFilter;
+  storeContextMessages: boolean | readonly string[];
+}
+
+/**
+ * Applies the defaults every bundled history provider shares.
+ *
+ * Kept in one place so that swapping storage — session state, a file, something remote — never
+ * changes which messages the transcript ends up holding.
+ */
+export function resolveHistoryStoreOptions(options?: HistoryStoreOptions): ResolvedHistoryStoreOptions {
+  return {
+    provideFilter: options?.provideFilter ?? passThrough,
+    storeFilter: options?.storeFilter ?? notSourceTypes('ChatHistory'),
+    storeContextMessages: options?.storeContextMessages ?? false,
+  };
+}
+
+/**
+ * What a finished run appends to the transcript, in the order it is stored.
+ *
+ * Empty for a run that failed: it produced no exchange, and storing the input on its own would
+ * leave an unanswered question for the next run to replay.
+ */
+export function messagesToStore(
+  ctx: ProviderAfterRunContext,
+  options: ResolvedHistoryStoreOptions,
+): Message[] {
+  if (ctx.response === undefined) {
+    return [];
+  }
+  return options.storeFilter([
+    ...selectContextMessages(ctx.contextMessages, options.storeContextMessages),
+    ...ctx.inputMessages,
+    ...ctx.response.messages,
+  ]);
+}

--- a/packages/core/src/context/in-memory-history-provider.ts
+++ b/packages/core/src/context/in-memory-history-provider.ts
@@ -1,6 +1,5 @@
 import type { AgentSession } from '../agent/session.js';
-import type { Message, MessageFilter } from '../types/message.js';
-import { notSourceTypes, passThrough } from '../types/message.js';
+import type { Message } from '../types/message.js';
 import type { SerializedMessage } from '../types/serialization.js';
 import { deserializeMessages, serializeMessages } from '../types/serialization.js';
 import type {
@@ -9,7 +8,8 @@ import type {
   ProviderAfterRunContext,
   ProviderRunContext,
 } from './context-provider.js';
-import { selectContextMessages } from './context-provider.js';
+import type { ResolvedHistoryStoreOptions } from './history-store.js';
+import { messagesToStore, resolveHistoryStoreOptions } from './history-store.js';
 
 const MESSAGES_KEY = 'messages';
 
@@ -41,15 +41,11 @@ export interface InMemoryHistoryProviderConfig extends HistoryStoreOptions {
  */
 export class InMemoryHistoryProvider implements HistoryProvider {
   readonly sourceId: string;
-  readonly #provideFilter: MessageFilter;
-  readonly #storeFilter: MessageFilter;
-  readonly #storeContextMessages: boolean | readonly string[];
+  readonly #options: ResolvedHistoryStoreOptions;
 
   constructor(options?: InMemoryHistoryProviderConfig) {
     this.sourceId = options?.sourceId ?? 'in_memory';
-    this.#provideFilter = options?.provideFilter ?? passThrough;
-    this.#storeFilter = options?.storeFilter ?? notSourceTypes('ChatHistory');
-    this.#storeContextMessages = options?.storeContextMessages ?? false;
+    this.#options = resolveHistoryStoreOptions(options);
   }
 
   async getMessages(_session: AgentSession, state: Record<string, unknown>): Promise<Message[]> {
@@ -70,23 +66,14 @@ export class InMemoryHistoryProvider implements HistoryProvider {
   }
 
   async beforeRun(ctx: ProviderRunContext): Promise<void> {
-    const history = this.#provideFilter(await this.getMessages(ctx.session, ctx.state));
+    const history = this.#options.provideFilter(await this.getMessages(ctx.session, ctx.state));
     if (history.length > 0) {
       ctx.extendMessages(history);
     }
   }
 
   async afterRun(ctx: ProviderAfterRunContext): Promise<void> {
-    // A run that failed produced no exchange to append. Storing its input alone would leave the
-    // transcript with a question the model never answered, which the next run would replay.
-    if (ctx.response === undefined) {
-      return;
-    }
-    const toSave = this.#storeFilter([
-      ...selectContextMessages(ctx.contextMessages, this.#storeContextMessages),
-      ...ctx.inputMessages,
-      ...ctx.response.messages,
-    ]);
+    const toSave = messagesToStore(ctx, this.#options);
     if (toSave.length > 0) {
       await this.saveMessages(ctx.session, toSave, ctx.state);
     }

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -1,0 +1,10 @@
+/**
+ * `@polymind-inc/agent-framework-core/node` — the pieces that need a filesystem.
+ *
+ * Everything here imports `node:` built-ins, so it is kept out of the package's root entry: that
+ * one has to keep running on Deno, Bun, edge runtimes and in browsers. Importing this subpath from
+ * such a runtime is what fails, rather than importing the framework at all.
+ */
+
+export type { FileHistoryProviderConfig } from './node/file-history-provider.js';
+export { FileHistoryProvider } from './node/file-history-provider.js';

--- a/packages/core/src/node/file-history-provider.race.test.ts
+++ b/packages/core/src/node/file-history-provider.race.test.ts
@@ -1,0 +1,128 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentSession } from '../agent/session.js';
+import { textContent } from '../types/content.js';
+import type { Message } from '../types/message.js';
+import { FileHistoryProvider } from './file-history-provider.js';
+
+// A gate the mocked appendFile stops at halfway through its write, so a test can hold the file in
+// the exact state a reader racing an append would see: the line on disk ends mid-JSON.
+const gate = vi.hoisted(() => {
+  const state: {
+    holdNextAppend: boolean;
+    firstHalfWritten: (() => void) | undefined;
+    release: (() => void) | undefined;
+  } = { holdNextAppend: false, firstHalfWritten: undefined, release: undefined };
+  return state;
+});
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    appendFile: async (
+      path: Parameters<typeof actual.appendFile>[0],
+      data: string,
+      options: Parameters<typeof actual.appendFile>[2],
+    ): Promise<void> => {
+      if (!gate.holdNextAppend) {
+        return actual.appendFile(path, data, options);
+      }
+      gate.holdNextAppend = false;
+      const half = Math.ceil(data.length / 2);
+      await actual.appendFile(path, data.slice(0, half), options);
+      gate.firstHalfWritten?.();
+      await new Promise<void>((resolve) => {
+        gate.release = resolve;
+      });
+      await actual.appendFile(path, data.slice(half), options);
+    },
+  };
+});
+
+function userMessage(text: string): Message {
+  return { role: 'user', contents: [textContent(text)] };
+}
+
+const NO_STATE: Record<string, unknown> = {};
+
+let storagePath: string;
+
+beforeEach(async () => {
+  storagePath = await mkdtemp(join(tmpdir(), 'af-file-history-race-'));
+  gate.holdNextAppend = false;
+  gate.firstHalfWritten = undefined;
+  gate.release = undefined;
+});
+
+afterEach(async () => {
+  gate.release?.();
+  await rm(storagePath, { recursive: true, force: true });
+});
+
+describe('FileHistoryProvider read/write serialization', () => {
+  it('does not read a torn line while an append to the same session is in flight', async () => {
+    const provider = new FileHistoryProvider({ storagePath });
+    const session = new AgentSession({ sessionId: 'racing' });
+
+    const firstHalfOnDisk = new Promise<void>((resolve) => {
+      gate.firstHalfWritten = resolve;
+    });
+    gate.holdNextAppend = true;
+    const save = provider.saveMessages(session, [userMessage('hello')], NO_STATE);
+    await firstHalfOnDisk;
+
+    // The file now ends mid-JSON. A read that goes straight to the file reports the healthy
+    // transcript as corrupted; one queued behind the append waits and sees the whole line.
+    const read = provider.getMessages(session, NO_STATE);
+    let settled = false;
+    void read.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(settled, 'read settled while the append was still mid-line').toBe(false);
+
+    gate.release?.();
+    await save;
+    expect((await read).map((message) => message.contents[0])).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+
+  it('orders a read behind another instance writing the same directory', async () => {
+    // Two providers pointed at one directory are two handles on the same transcript, so the
+    // ordering has to hold across instances, not merely inside one.
+    const writer = new FileHistoryProvider({ storagePath });
+    const reader = new FileHistoryProvider({ storagePath });
+    const session = new AgentSession({ sessionId: 'shared' });
+
+    const firstHalfOnDisk = new Promise<void>((resolve) => {
+      gate.firstHalfWritten = resolve;
+    });
+    gate.holdNextAppend = true;
+    const save = writer.saveMessages(session, [userMessage('hello')], NO_STATE);
+    await firstHalfOnDisk;
+
+    const read = reader.getMessages(session, NO_STATE);
+    let settled = false;
+    void read.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(settled, 'read settled while the other instance was still mid-line').toBe(false);
+
+    gate.release?.();
+    await save;
+    expect((await read).map((message) => message.contents[0])).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+});

--- a/packages/core/src/node/file-history-provider.test.ts
+++ b/packages/core/src/node/file-history-provider.test.ts
@@ -1,0 +1,242 @@
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Agent } from '../agent/agent.js';
+import { AgentSession } from '../agent/session.js';
+import { MockChatClient } from '../client/test-support.js';
+import { ConfigurationError } from '../errors.js';
+import { textContent } from '../types/content.js';
+import type { Message } from '../types/message.js';
+import { FileHistoryProvider } from './file-history-provider.js';
+
+function client(...texts: string[]): MockChatClient {
+  return new MockChatClient(texts.map((text) => ({ contents: [textContent(text)], finishReason: 'stop' })));
+}
+
+function userMessage(text: string): Message {
+  return { role: 'user', contents: [textContent(text)] };
+}
+
+const NO_STATE: Record<string, unknown> = {};
+
+let storagePath: string;
+
+beforeEach(async () => {
+  storagePath = await mkdtemp(join(tmpdir(), 'af-file-history-'));
+});
+
+afterEach(async () => {
+  await rm(storagePath, { recursive: true, force: true });
+});
+
+describe('FileHistoryProvider', () => {
+  it('needs a storagePath', () => {
+    expect(() => new FileHistoryProvider({ storagePath: '' })).toThrow(ConfigurationError);
+  });
+
+  it('uses the Python-compatible default source id', () => {
+    expect(new FileHistoryProvider({ storagePath }).sourceId).toBe('file_history');
+  });
+
+  it('reads back what another instance wrote', async () => {
+    const session = new AgentSession({ sessionId: 'round-trip' });
+    const writer = new FileHistoryProvider({ storagePath });
+    await writer.saveMessages(session, [userMessage('one'), userMessage('two')], NO_STATE);
+
+    const reader = new FileHistoryProvider({ storagePath });
+    const restored = await reader.getMessages(session, NO_STATE);
+
+    expect(restored.map((message) => message.contents[0])).toEqual([
+      { type: 'text', text: 'one' },
+      { type: 'text', text: 'two' },
+    ]);
+  });
+
+  it('has no history for a session that was never written', async () => {
+    const provider = new FileHistoryProvider({ storagePath: join(storagePath, 'not-created-yet') });
+    expect(await provider.getMessages(new AgentSession({ sessionId: 's' }), NO_STATE)).toEqual([]);
+  });
+
+  it('appends, keeping the order across turns', async () => {
+    const mock = client('one', 'two', 'three');
+    const provider = new FileHistoryProvider({ storagePath });
+    const agent = new Agent({ client: mock, historyProvider: provider });
+    const session = agent.createSession({ sessionId: 'multi-turn' });
+
+    await agent.run('first', { session });
+    await agent.run('second', { session });
+    await agent.run('third', { session });
+
+    const stored = await provider.getMessages(session, NO_STATE);
+    expect(stored.map((message) => message.contents[0])).toEqual([
+      { type: 'text', text: 'first' },
+      { type: 'text', text: 'one' },
+      { type: 'text', text: 'second' },
+      { type: 'text', text: 'two' },
+      { type: 'text', text: 'third' },
+      { type: 'text', text: 'three' },
+    ]);
+  });
+
+  // The layout is the interoperability contract: a provider backed by other storage is written
+  // against it, so a change here is a change to something outside this repository.
+  it('writes one JSON Lines record per message, in the framework wire form', async () => {
+    const session = new AgentSession({ sessionId: 'layout' });
+    const provider = new FileHistoryProvider({ storagePath });
+
+    await provider.saveMessages(session, [userMessage('one'), userMessage('two')], NO_STATE);
+
+    const raw = await readFile(join(storagePath, 'layout.jsonl'), 'utf8');
+    expect(raw.endsWith('\n')).toBe(true);
+    expect(
+      raw
+        .trimEnd()
+        .split('\n')
+        .map((line) => JSON.parse(line)),
+    ).toEqual([
+      { role: 'user', contents: [{ type: 'text', text: 'one' }] },
+      { role: 'user', contents: [{ type: 'text', text: 'two' }] },
+    ]);
+  });
+
+  it('names the file after the session and creates the directory', async () => {
+    const nested = join(storagePath, 'deeper');
+    const provider = new FileHistoryProvider({ storagePath: nested });
+
+    await provider.saveMessages(new AgentSession({ sessionId: 'plain-id' }), [userMessage('x')], NO_STATE);
+
+    expect(await readdir(nested)).toEqual(['plain-id.jsonl']);
+  });
+
+  it('reports the line a corrupted file failed on', async () => {
+    const session = new AgentSession({ sessionId: 'corrupt' });
+    const provider = new FileHistoryProvider({ storagePath });
+    await provider.saveMessages(session, [userMessage('fine')], NO_STATE);
+    await writeFile(join(storagePath, 'corrupt.jsonl'), 'not json\n', { flag: 'a' });
+
+    await expect(provider.getMessages(session, NO_STATE)).rejects.toThrow(/line 2/);
+  });
+
+  it('skips blank lines rather than failing on them', async () => {
+    const session = new AgentSession({ sessionId: 'blanks' });
+    const provider = new FileHistoryProvider({ storagePath });
+    await provider.saveMessages(session, [userMessage('one')], NO_STATE);
+    await writeFile(join(storagePath, 'blanks.jsonl'), '\n\n', { flag: 'a' });
+    await provider.saveMessages(session, [userMessage('two')], NO_STATE);
+
+    expect((await provider.getMessages(session, NO_STATE)).map((m) => m.contents[0])).toEqual([
+      { type: 'text', text: 'one' },
+      { type: 'text', text: 'two' },
+    ]);
+  });
+
+  it('keeps concurrent appends to one session from interleaving', async () => {
+    const session = new AgentSession({ sessionId: 'concurrent' });
+    const provider = new FileHistoryProvider({ storagePath });
+
+    await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        provider.saveMessages(session, [userMessage(`m${index}`)], NO_STATE),
+      ),
+    );
+
+    const stored = await provider.getMessages(session, NO_STATE);
+    expect(stored).toHaveLength(20);
+    // Every line parsed, so nothing was written on top of anything else.
+    expect(new Set(stored.map((message) => (message.contents[0] as { text: string }).text)).size).toBe(20);
+  });
+
+  describe('session ids that are not filenames', () => {
+    // Ids are opaque, so anything unusable as a name is encoded instead of rejected — the session
+    // still works, and the file it maps to stays inside the storage directory.
+    const hostile = [
+      '../escape',
+      '../../escape',
+      'nested/child',
+      'C:\\windows\\system32',
+      '/etc/passwd',
+      '.hidden',
+      'CON',
+      'trailing.',
+      'with space',
+      'ünïcode',
+    ];
+
+    for (const sessionId of hostile) {
+      it(`keeps '${sessionId}' inside the storage directory`, async () => {
+        const provider = new FileHistoryProvider({ storagePath });
+        const session = new AgentSession({ sessionId });
+
+        await provider.saveMessages(session, [userMessage('x')], NO_STATE);
+
+        const written = await readdir(storagePath);
+        expect(written).toHaveLength(1);
+        expect(written[0]).toMatch(/^~session-[\w-]+\.jsonl$/);
+        // And the encoding is reversible enough to find the transcript again.
+        expect(await provider.getMessages(session, NO_STATE)).toHaveLength(1);
+      });
+    }
+
+    it('gives two hostile ids two different files', async () => {
+      const provider = new FileHistoryProvider({ storagePath });
+      await provider.saveMessages(new AgentSession({ sessionId: '../a' }), [userMessage('a')], NO_STATE);
+      await provider.saveMessages(new AgentSession({ sessionId: '../b' }), [userMessage('b')], NO_STATE);
+
+      expect(await readdir(storagePath)).toHaveLength(2);
+    });
+
+    it('hashes an id too long to encode into a filename', async () => {
+      const provider = new FileHistoryProvider({ storagePath });
+      const session = new AgentSession({ sessionId: `../${'x'.repeat(500)}` });
+
+      await provider.saveMessages(session, [userMessage('x')], NO_STATE);
+
+      const written = await readdir(storagePath);
+      expect(written[0]).toMatch(/^~session-sha256-[0-9a-f]{64}\.jsonl$/);
+      expect(await provider.getMessages(session, NO_STATE)).toHaveLength(1);
+    });
+  });
+
+  it('stores nothing for a failed run', async () => {
+    const provider = new FileHistoryProvider({ storagePath });
+    const failing = {
+      metadata: { providerName: 'mock' },
+      getResponse: (): never => {
+        throw new Error('provider down');
+      },
+    };
+    const agent = new Agent({ client: failing as never, historyProvider: provider });
+    const session = agent.createSession({ sessionId: 'failed' });
+
+    await expect(agent.run('x', { session })).rejects.toThrow('provider down');
+
+    expect(await provider.getMessages(session, NO_STATE)).toEqual([]);
+    expect(await readdir(storagePath)).toEqual([]);
+  });
+
+  it('honours storeContextMessages like the in-memory provider', async () => {
+    const provider = new FileHistoryProvider({ storagePath, storeContextMessages: true });
+    const agent = new Agent({
+      client: client('answer'),
+      historyProvider: provider,
+      contextProviders: [
+        {
+          sourceId: 'memory',
+          beforeRun: (ctx) => {
+            ctx.extendMessages([userMessage('remembered')]);
+          },
+        },
+      ],
+    });
+    const session = agent.createSession({ sessionId: 'with-context' });
+
+    await agent.run('question', { session });
+
+    expect((await provider.getMessages(session, NO_STATE)).map((m) => m.contents[0])).toEqual([
+      { type: 'text', text: 'remembered' },
+      { type: 'text', text: 'question' },
+      { type: 'text', text: 'answer' },
+    ]);
+  });
+});

--- a/packages/core/src/node/file-history-provider.test.ts
+++ b/packages/core/src/node/file-history-provider.test.ts
@@ -118,6 +118,15 @@ describe('FileHistoryProvider', () => {
     await expect(provider.getMessages(session, NO_STATE)).rejects.toThrow(/line 2/);
   });
 
+  it('reports the line when a record is valid JSON but not a message', async () => {
+    const session = new AgentSession({ sessionId: 'not-a-message' });
+    const provider = new FileHistoryProvider({ storagePath });
+    await provider.saveMessages(session, [userMessage('fine')], NO_STATE);
+    await writeFile(join(storagePath, 'not-a-message.jsonl'), 'null\n', { flag: 'a' });
+
+    await expect(provider.getMessages(session, NO_STATE)).rejects.toThrow(/line 2/);
+  });
+
   it('skips blank lines rather than failing on them', async () => {
     const session = new AgentSession({ sessionId: 'blanks' });
     const provider = new FileHistoryProvider({ storagePath });

--- a/packages/core/src/node/file-history-provider.test.ts
+++ b/packages/core/src/node/file-history-provider.test.ts
@@ -195,6 +195,58 @@ describe('FileHistoryProvider', () => {
       expect(await readdir(storagePath)).toHaveLength(2);
     });
 
+    it('keeps ids apart when they differ only by case, wherever the volume folds case', async () => {
+      // Two files named `abc.jsonl` and `ABC.jsonl` are one file on Windows and macOS, so distinct
+      // sessions would silently share — and leak — a transcript. Only an all-lowercase id may use
+      // its own name; anything with an uppercase letter is hashed.
+      const provider = new FileHistoryProvider({ storagePath });
+      const lower = new AgentSession({ sessionId: 'abc' });
+      const upper = new AgentSession({ sessionId: 'ABC' });
+
+      await provider.saveMessages(lower, [userMessage('lower')], NO_STATE);
+      await provider.saveMessages(upper, [userMessage('upper')], NO_STATE);
+
+      expect(await readdir(storagePath)).toHaveLength(2);
+      expect((await provider.getMessages(lower, NO_STATE)).map((m) => m.contents[0])).toEqual([
+        { type: 'text', text: 'lower' },
+      ]);
+      expect((await provider.getMessages(upper, NO_STATE)).map((m) => m.contents[0])).toEqual([
+        { type: 'text', text: 'upper' },
+      ]);
+    });
+
+    it("keeps '/' apart from an id that spells out an encoded stem", async () => {
+      // An id like '~session-Lw' is not a portable name (`~`), so it is hashed like any other —
+      // it cannot collide with the file the encoding chose for '/'.
+      const provider = new FileHistoryProvider({ storagePath });
+      const slash = new AgentSession({ sessionId: '/' });
+      const impostor = new AgentSession({ sessionId: '~session-Lw' });
+
+      await provider.saveMessages(slash, [userMessage('slash')], NO_STATE);
+      await provider.saveMessages(impostor, [userMessage('impostor')], NO_STATE);
+
+      expect(await readdir(storagePath)).toHaveLength(2);
+      expect((await provider.getMessages(slash, NO_STATE)).map((m) => m.contents[0])).toEqual([
+        { type: 'text', text: 'slash' },
+      ]);
+      expect((await provider.getMessages(impostor, NO_STATE)).map((m) => m.contents[0])).toEqual([
+        { type: 'text', text: 'impostor' },
+      ]);
+    });
+
+    it('hashes a long ASCII id instead of handing the filesystem an overlong name', async () => {
+      const provider = new FileHistoryProvider({ storagePath });
+      const session = new AgentSession({ sessionId: 'a'.repeat(300) });
+
+      await provider.saveMessages(session, [userMessage('long')], NO_STATE);
+
+      const written = await readdir(storagePath);
+      expect(written[0]).toMatch(/^~session-sha256-[0-9a-f]{64}\.jsonl$/);
+      expect((await provider.getMessages(session, NO_STATE)).map((m) => m.contents[0])).toEqual([
+        { type: 'text', text: 'long' },
+      ]);
+    });
+
     it('hashes an id too long to encode into a filename', async () => {
       const provider = new FileHistoryProvider({ storagePath });
       const session = new AgentSession({ sessionId: `../${'x'.repeat(500)}` });

--- a/packages/core/src/node/file-history-provider.test.ts
+++ b/packages/core/src/node/file-history-provider.test.ts
@@ -182,7 +182,7 @@ describe('FileHistoryProvider', () => {
         const written = await readdir(storagePath);
         expect(written).toHaveLength(1);
         expect(written[0]).toMatch(/^~session-[\w-]+\.jsonl$/);
-        // And the encoding is reversible enough to find the transcript again.
+        // And the mapping is deterministic — the same id finds its transcript again.
         expect(await provider.getMessages(session, NO_STATE)).toHaveLength(1);
       });
     }

--- a/packages/core/src/node/file-history-provider.ts
+++ b/packages/core/src/node/file-history-provider.ts
@@ -1,0 +1,267 @@
+import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import { isAbsolute, resolve, sep } from 'node:path';
+import type { AgentSession } from '../agent/session.js';
+import type {
+  HistoryProvider,
+  HistoryStoreOptions,
+  ProviderAfterRunContext,
+  ProviderRunContext,
+} from '../context/context-provider.js';
+import type { ResolvedHistoryStoreOptions } from '../context/history-store.js';
+import { messagesToStore, resolveHistoryStoreOptions } from '../context/history-store.js';
+import { ConfigurationError } from '../errors.js';
+import type { Message } from '../types/message.js';
+import type { SerializedMessage } from '../types/serialization.js';
+import { deserializeMessage, serializeMessage } from '../types/serialization.js';
+
+/** Options for {@link FileHistoryProvider}. */
+export interface FileHistoryProviderConfig extends HistoryStoreOptions {
+  /**
+   * Directory holding one file per session. Created when it does not exist.
+   *
+   * Treat it as application storage, not as a secret store: transcripts are written as plain text
+   * and are readable by anything that can read the directory.
+   */
+  storagePath: string;
+  /**
+   * Defaults to `'file_history'` (Python `FileHistoryProvider.DEFAULT_SOURCE_ID`, which also names
+   * the session-state partition). Override when running several history providers side by side.
+   */
+  sourceId?: string;
+}
+
+/** Filenames Windows refuses whatever the extension is. */
+const WINDOWS_RESERVED_STEMS = new Set([
+  'CON',
+  'PRN',
+  'AUX',
+  'NUL',
+  ...Array.from({ length: 9 }, (_, index) => `COM${index + 1}`),
+  ...Array.from({ length: 9 }, (_, index) => `LPT${index + 1}`),
+]);
+
+/** Beyond this an encoded stem risks the platform's own path limits, so it is hashed instead. */
+const MAX_ENCODED_STEM_LENGTH = 180;
+const ENCODED_STEM_PREFIX = '~session-';
+
+/**
+ * Whether a session id can be used as a filename as it stands.
+ *
+ * Session ids are opaque: a caller may use a UUID, but also a path, an email address or a
+ * Windows-reserved word. Anything that is not plainly portable is encoded rather than rejected, so
+ * a working session never becomes unusable because of how it was named.
+ */
+function isLiteralStemSafe(sessionId: string): boolean {
+  if (sessionId === '' || sessionId.startsWith('.') || /[ .]$/.test(sessionId)) {
+    return false;
+  }
+  const windowsStem = (sessionId.split('.')[0] ?? '').toUpperCase();
+  if (WINDOWS_RESERVED_STEMS.has(windowsStem)) {
+    return false;
+  }
+  // Control characters, non-ASCII and anything outside the portable set are encoded: a filesystem
+  // that normalizes them (macOS's Unicode folding, a case-insensitive volume) would otherwise let
+  // two distinct session ids collide onto one file.
+  return /^[A-Za-z0-9._-]+$/.test(sessionId);
+}
+
+/** Base64url without padding, which `~session-` stems use. */
+function encodeStem(sessionId: string): string {
+  const bytes = new TextEncoder().encode(sessionId);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * Persists one session per file, appending as the conversation grows.
+ *
+ * Each line is one message in the same wire form the rest of the framework serializes, so a
+ * transcript written here can be read by anything that understands JSON Lines — including
+ * implementations of this interface backed by other storage, which is why the layout is part of
+ * the contract rather than an internal detail.
+ *
+ * ```ts
+ * const agent = new Agent({
+ *   client,
+ *   historyProvider: new FileHistoryProvider({ storagePath: './sessions' }),
+ * });
+ * ```
+ *
+ * ## Security considerations
+ *
+ * - **Transcripts are stored in the clear.** They routinely contain whatever a user typed and
+ *   whatever a tool returned. Put `storagePath` somewhere with access controls that match the
+ *   conversation's, and consider encryption at rest.
+ * - **A session id never escapes `storagePath`.** Ids that are not portable filenames are encoded,
+ *   and the resolved path is checked against the directory, so an id carrying `../` or an absolute
+ *   path cannot address a file elsewhere.
+ * - **History is replayed verbatim into every later model call.** A transcript an attacker can
+ *   write to is a prompt-injection channel; treat the directory as trusted input.
+ */
+export class FileHistoryProvider implements HistoryProvider {
+  readonly sourceId: string;
+  readonly #storagePath: string;
+  readonly #options: ResolvedHistoryStoreOptions;
+  /** One promise chain per file, so concurrent appends cannot interleave partial lines. */
+  readonly #writes = new Map<string, Promise<unknown>>();
+  #directoryReady: Promise<unknown> | undefined;
+
+  constructor(config: FileHistoryProviderConfig) {
+    if (config.storagePath === '') {
+      throw new ConfigurationError('FileHistoryProvider needs a storagePath.');
+    }
+    this.sourceId = config.sourceId ?? 'file_history';
+    this.#storagePath = resolve(config.storagePath);
+    this.#options = resolveHistoryStoreOptions(config);
+  }
+
+  /** The directory this provider writes to, resolved to an absolute path. */
+  get storagePath(): string {
+    return this.#storagePath;
+  }
+
+  async getMessages(session: AgentSession, _state: Record<string, unknown>): Promise<Message[]> {
+    const path = await this.#sessionFile(session);
+    let contents: string;
+    try {
+      contents = await readFile(path, 'utf8');
+    } catch (error) {
+      // A session that has never been written has no file, which is not an error: it is an empty
+      // transcript. Anything else — a permission problem, a directory in the way — is real and is
+      // surfaced rather than reported as "no history".
+      if ((error as { code?: string }).code === 'ENOENT') {
+        return [];
+      }
+      throw error;
+    }
+
+    const messages: Message[] = [];
+    const lines = contents.split('\n');
+    for (const [index, line] of lines.entries()) {
+      // Trailing newline, and any blank line a partially written file left behind.
+      if (line.trim() === '') {
+        continue;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch (error) {
+        throw new Error(`Failed to read history line ${index + 1} of '${path}'.`, { cause: error });
+      }
+      messages.push(deserializeMessage(parsed as SerializedMessage));
+    }
+    return messages;
+  }
+
+  async saveMessages(
+    session: AgentSession,
+    messages: Message[],
+    _state: Record<string, unknown>,
+  ): Promise<void> {
+    if (messages.length === 0) {
+      return;
+    }
+    const lines = messages.map((message) => {
+      const line = JSON.stringify(serializeMessage(message));
+      if (line.includes('\n')) {
+        // `JSON.stringify` escapes newlines, so reaching this means a custom serializer produced
+        // something that would split one message across two lines and corrupt every later read.
+        throw new Error('A serialized message contains a raw newline, which would break the JSONL file.');
+      }
+      return line;
+    });
+    const path = await this.#sessionFile(session);
+    await this.#serialized(path, async () => {
+      await appendFile(path, `${lines.join('\n')}\n`, 'utf8');
+    });
+  }
+
+  async beforeRun(ctx: ProviderRunContext): Promise<void> {
+    const history = this.#options.provideFilter(await this.getMessages(ctx.session, ctx.state));
+    if (history.length > 0) {
+      ctx.extendMessages(history);
+    }
+  }
+
+  async afterRun(ctx: ProviderAfterRunContext): Promise<void> {
+    const toSave = messagesToStore(ctx, this.#options);
+    if (toSave.length > 0) {
+      await this.saveMessages(ctx.session, toSave, ctx.state);
+    }
+  }
+
+  /**
+   * Runs `write` after every append already queued for `path`.
+   *
+   * Two runs of the same session finishing at once would otherwise both append to the same file
+   * and interleave their lines. The queued link swallows failures so one failed append does not
+   * wedge every later one, and the entry is dropped when nothing is queued behind it, so the map
+   * does not grow with every session the process ever sees.
+   */
+  async #serialized(path: string, write: () => Promise<void>): Promise<void> {
+    const previous = this.#writes.get(path) ?? Promise.resolve();
+    const run = previous.then(write, write);
+    const link = run.catch(() => undefined);
+    this.#writes.set(path, link);
+    try {
+      await run;
+    } finally {
+      if (this.#writes.get(path) === link) {
+        this.#writes.delete(path);
+      }
+    }
+  }
+
+  async #sessionFile(session: AgentSession): Promise<string> {
+    const stem = isLiteralStemSafe(session.sessionId)
+      ? session.sessionId
+      : await this.#encodedStem(session.sessionId);
+    const path = resolve(this.#storagePath, `${stem}.jsonl`);
+    // The stem is derived, never taken verbatim from an untrusted id, so this cannot fail today.
+    // It is checked anyway: the encoding is the only thing standing between an opaque session id
+    // and the filesystem, and a future change to it must not silently become a path traversal.
+    if (!isWithin(this.#storagePath, path)) {
+      throw new ConfigurationError(
+        `Session '${session.sessionId}' does not map to a file inside storagePath.`,
+      );
+    }
+    await this.#ensureDirectory();
+    return path;
+  }
+
+  async #encodedStem(sessionId: string): Promise<string> {
+    const encoded = `${ENCODED_STEM_PREFIX}${encodeStem(sessionId)}`;
+    if (encoded.length <= MAX_ENCODED_STEM_LENGTH) {
+      return encoded;
+    }
+    return `${ENCODED_STEM_PREFIX}sha256-${await sha256Hex(sessionId)}`;
+  }
+
+  async #ensureDirectory(): Promise<void> {
+    // Created once per provider rather than per write, and retried on the next call if it failed.
+    this.#directoryReady ??= mkdir(this.#storagePath, { recursive: true }).catch((error: unknown) => {
+      this.#directoryReady = undefined;
+      throw error;
+    });
+    await this.#directoryReady;
+  }
+}
+
+/** Whether `path` is `directory` itself or something under it. */
+function isWithin(directory: string, path: string): boolean {
+  if (!isAbsolute(path)) {
+    return false;
+  }
+  const root = directory.endsWith(sep) ? directory : `${directory}${sep}`;
+  return path === directory || path.startsWith(root);
+}

--- a/packages/core/src/node/file-history-provider.ts
+++ b/packages/core/src/node/file-history-provider.ts
@@ -1,5 +1,5 @@
 import { appendFile, mkdir, readFile } from 'node:fs/promises';
-import { isAbsolute, resolve, sep } from 'node:path';
+import { resolve } from 'node:path';
 import type { AgentSession } from '../agent/session.js';
 import type {
   HistoryProvider,
@@ -13,6 +13,7 @@ import { ConfigurationError } from '../errors.js';
 import type { Message } from '../types/message.js';
 import type { SerializedMessage } from '../types/serialization.js';
 import { deserializeMessage, serializeMessage } from '../types/serialization.js';
+import { isWithin } from './paths.js';
 
 /** Options for {@link FileHistoryProvider}. */
 export interface FileHistoryProviderConfig extends HistoryStoreOptions {
@@ -83,6 +84,42 @@ async function sha256Hex(value: string): Promise<string> {
 }
 
 /**
+ * One promise chain per file, shared by every provider in the process.
+ *
+ * Appends to one session must not interleave their lines, and a read must not observe an append
+ * that is partway through being flushed — it would see a line that ends mid-JSON and report a
+ * healthy transcript as corrupted. Both orderings have to hold across provider instances too,
+ * since nothing stops two of them from pointing at the same directory, so the chains are keyed by
+ * resolved file path at module level rather than held per instance. Processes are another matter:
+ * nothing here coordinates two of them writing the same file.
+ */
+const fileChains = new Map<string, Promise<unknown>>();
+
+/**
+ * Runs `operation` after everything already queued for `path`.
+ *
+ * The queued link swallows failures so one failed operation does not wedge every later one, and
+ * the entry is dropped when nothing is queued behind it, so the map does not grow with every
+ * session the process ever sees.
+ */
+async function enqueueFileOperation<T>(path: string, operation: () => Promise<T>): Promise<T> {
+  const previous = fileChains.get(path) ?? Promise.resolve();
+  const run = previous.then(operation, operation);
+  const link = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  fileChains.set(path, link);
+  try {
+    return await run;
+  } finally {
+    if (fileChains.get(path) === link) {
+      fileChains.delete(path);
+    }
+  }
+}
+
+/**
  * Persists one session per file, appending as the conversation grows.
  *
  * Each line is one message in the same wire form the rest of the framework serializes, so a
@@ -107,13 +144,18 @@ async function sha256Hex(value: string): Promise<string> {
  *   path cannot address a file elsewhere.
  * - **History is replayed verbatim into every later model call.** A transcript an attacker can
  *   write to is a prompt-injection channel; treat the directory as trusted input.
+ *
+ * ## Concurrency
+ *
+ * Reads and appends to one session's file are ordered within the process, across provider
+ * instances included, so overlapping runs of a session cannot interleave lines or observe a
+ * half-flushed one. Nothing coordinates two *processes* sharing a directory — give each its own,
+ * or put external locking around the shared one.
  */
 export class FileHistoryProvider implements HistoryProvider {
   readonly sourceId: string;
   readonly #storagePath: string;
   readonly #options: ResolvedHistoryStoreOptions;
-  /** One promise chain per file, so concurrent appends cannot interleave partial lines. */
-  readonly #writes = new Map<string, Promise<unknown>>();
   #directoryReady: Promise<unknown> | undefined;
 
   constructor(config: FileHistoryProviderConfig) {
@@ -132,35 +174,37 @@ export class FileHistoryProvider implements HistoryProvider {
 
   async getMessages(session: AgentSession, _state: Record<string, unknown>): Promise<Message[]> {
     const path = await this.#sessionFile(session);
-    let contents: string;
-    try {
-      contents = await readFile(path, 'utf8');
-    } catch (error) {
-      // A session that has never been written has no file, which is not an error: it is an empty
-      // transcript. Anything else — a permission problem, a directory in the way — is real and is
-      // surfaced rather than reported as "no history".
-      if ((error as { code?: string }).code === 'ENOENT') {
-        return [];
-      }
-      throw error;
-    }
-
-    const messages: Message[] = [];
-    const lines = contents.split('\n');
-    for (const [index, line] of lines.entries()) {
-      // Trailing newline, and any blank line a partially written file left behind.
-      if (line.trim() === '') {
-        continue;
-      }
-      let parsed: unknown;
+    // Queued behind any append in flight for the same file: a read overlapping an append could
+    // otherwise observe a partially flushed line and report a healthy transcript as corrupted.
+    return await enqueueFileOperation(path, async () => {
+      let contents: string;
       try {
-        parsed = JSON.parse(line);
+        contents = await readFile(path, 'utf8');
       } catch (error) {
-        throw new Error(`Failed to read history line ${index + 1} of '${path}'.`, { cause: error });
+        // A session that has never been written has no file, which is not an error: it is an empty
+        // transcript. Anything else — a permission problem, a directory in the way — is real and
+        // is surfaced rather than reported as "no history".
+        if ((error as { code?: string }).code === 'ENOENT') {
+          return [];
+        }
+        throw error;
       }
-      messages.push(deserializeMessage(parsed as SerializedMessage));
-    }
-    return messages;
+
+      const messages: Message[] = [];
+      const lines = contents.split('\n');
+      for (const [index, line] of lines.entries()) {
+        // Trailing newline, and any blank line a partially written file left behind.
+        if (line.trim() === '') {
+          continue;
+        }
+        try {
+          messages.push(deserializeMessage(JSON.parse(line) as SerializedMessage));
+        } catch (error) {
+          throw new Error(`Failed to read history line ${index + 1} of '${path}'.`, { cause: error });
+        }
+      }
+      return messages;
+    });
   }
 
   async saveMessages(
@@ -181,7 +225,8 @@ export class FileHistoryProvider implements HistoryProvider {
       return line;
     });
     const path = await this.#sessionFile(session);
-    await this.#serialized(path, async () => {
+    await this.#ensureDirectory();
+    await enqueueFileOperation(path, async () => {
       await appendFile(path, `${lines.join('\n')}\n`, 'utf8');
     });
   }
@@ -200,28 +245,6 @@ export class FileHistoryProvider implements HistoryProvider {
     }
   }
 
-  /**
-   * Runs `write` after every append already queued for `path`.
-   *
-   * Two runs of the same session finishing at once would otherwise both append to the same file
-   * and interleave their lines. The queued link swallows failures so one failed append does not
-   * wedge every later one, and the entry is dropped when nothing is queued behind it, so the map
-   * does not grow with every session the process ever sees.
-   */
-  async #serialized(path: string, write: () => Promise<void>): Promise<void> {
-    const previous = this.#writes.get(path) ?? Promise.resolve();
-    const run = previous.then(write, write);
-    const link = run.catch(() => undefined);
-    this.#writes.set(path, link);
-    try {
-      await run;
-    } finally {
-      if (this.#writes.get(path) === link) {
-        this.#writes.delete(path);
-      }
-    }
-  }
-
   async #sessionFile(session: AgentSession): Promise<string> {
     const stem = isLiteralStemSafe(session.sessionId)
       ? session.sessionId
@@ -235,7 +258,6 @@ export class FileHistoryProvider implements HistoryProvider {
         `Session '${session.sessionId}' does not map to a file inside storagePath.`,
       );
     }
-    await this.#ensureDirectory();
     return path;
   }
 
@@ -255,13 +277,4 @@ export class FileHistoryProvider implements HistoryProvider {
     });
     await this.#directoryReady;
   }
-}
-
-/** Whether `path` is `directory` itself or something under it. */
-function isWithin(directory: string, path: string): boolean {
-  if (!isAbsolute(path)) {
-    return false;
-  }
-  const root = directory.endsWith(sep) ? directory : `${directory}${sep}`;
-  return path === directory || path.startsWith(root);
 }

--- a/packages/core/src/node/file-history-provider.ts
+++ b/packages/core/src/node/file-history-provider.ts
@@ -41,39 +41,36 @@ const WINDOWS_RESERVED_STEMS = new Set([
   ...Array.from({ length: 9 }, (_, index) => `LPT${index + 1}`),
 ]);
 
-/** Beyond this an encoded stem risks the platform's own path limits, so it is hashed instead. */
-const MAX_ENCODED_STEM_LENGTH = 180;
-const ENCODED_STEM_PREFIX = '~session-';
+/** Beyond this a stem risks the platform's own filename limits, so the id is hashed instead. */
+const MAX_LITERAL_STEM_LENGTH = 180;
+const HASHED_STEM_PREFIX = '~session-sha256-';
 
 /**
  * Whether a session id can be used as a filename as it stands.
  *
  * Session ids are opaque: a caller may use a UUID, but also a path, an email address or a
- * Windows-reserved word. Anything that is not plainly portable is encoded rather than rejected, so
+ * Windows-reserved word. Anything that is not plainly portable is hashed rather than rejected, so
  * a working session never becomes unusable because of how it was named.
+ *
+ * The mapping has to be injective on every platform, including volumes that fold case (Windows,
+ * macOS) — `abc.jsonl` and `ABC.jsonl` are one file there, and two sessions sharing a file means
+ * each replays the other's transcript. So a literal stem must be entirely lowercase; distinct
+ * all-lowercase names stay distinct under case folding, and everything else maps to a lowercase
+ * hex digest, where the same holds.
  */
 function isLiteralStemSafe(sessionId: string): boolean {
-  if (sessionId === '' || sessionId.startsWith('.') || /[ .]$/.test(sessionId)) {
+  if (
+    sessionId === '' ||
+    sessionId.length > MAX_LITERAL_STEM_LENGTH ||
+    sessionId.startsWith('.') ||
+    /[ .]$/.test(sessionId)
+  ) {
     return false;
   }
-  const windowsStem = (sessionId.split('.')[0] ?? '').toUpperCase();
-  if (WINDOWS_RESERVED_STEMS.has(windowsStem)) {
+  if (WINDOWS_RESERVED_STEMS.has((sessionId.split('.')[0] ?? '').toUpperCase())) {
     return false;
   }
-  // Control characters, non-ASCII and anything outside the portable set are encoded: a filesystem
-  // that normalizes them (macOS's Unicode folding, a case-insensitive volume) would otherwise let
-  // two distinct session ids collide onto one file.
-  return /^[A-Za-z0-9._-]+$/.test(sessionId);
-}
-
-/** Base64url without padding, which `~session-` stems use. */
-function encodeStem(sessionId: string): string {
-  const bytes = new TextEncoder().encode(sessionId);
-  let binary = '';
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+  return /^[a-z0-9._-]+$/.test(sessionId);
 }
 
 async function sha256Hex(value: string): Promise<string> {
@@ -139,9 +136,10 @@ async function enqueueFileOperation<T>(path: string, operation: () => Promise<T>
  * - **Transcripts are stored in the clear.** They routinely contain whatever a user typed and
  *   whatever a tool returned. Put `storagePath` somewhere with access controls that match the
  *   conversation's, and consider encryption at rest.
- * - **A session id never escapes `storagePath`.** Ids that are not portable filenames are encoded,
- *   and the resolved path is checked against the directory, so an id carrying `../` or an absolute
- *   path cannot address a file elsewhere.
+ * - **A session id never escapes `storagePath`.** An id that is not a portable all-lowercase
+ *   filename is replaced by its SHA-256 digest, and the resolved path is checked against the
+ *   directory, so an id carrying `../` or an absolute path cannot address a file elsewhere — and
+ *   two ids differing only by case cannot share a file on a volume that folds case.
  * - **History is replayed verbatim into every later model call.** A transcript an attacker can
  *   write to is a prompt-injection channel; treat the directory as trusted input.
  *
@@ -246,9 +244,11 @@ export class FileHistoryProvider implements HistoryProvider {
   }
 
   async #sessionFile(session: AgentSession): Promise<string> {
+    // A literal id cannot begin with `~`, so an id that spells out a hashed stem cannot collide
+    // with the file the hash chose for another id.
     const stem = isLiteralStemSafe(session.sessionId)
       ? session.sessionId
-      : await this.#encodedStem(session.sessionId);
+      : `${HASHED_STEM_PREFIX}${await sha256Hex(session.sessionId)}`;
     const path = resolve(this.#storagePath, `${stem}.jsonl`);
     // The stem is derived, never taken verbatim from an untrusted id, so this cannot fail today.
     // It is checked anyway: the encoding is the only thing standing between an opaque session id
@@ -259,14 +259,6 @@ export class FileHistoryProvider implements HistoryProvider {
       );
     }
     return path;
-  }
-
-  async #encodedStem(sessionId: string): Promise<string> {
-    const encoded = `${ENCODED_STEM_PREFIX}${encodeStem(sessionId)}`;
-    if (encoded.length <= MAX_ENCODED_STEM_LENGTH) {
-      return encoded;
-    }
-    return `${ENCODED_STEM_PREFIX}sha256-${await sha256Hex(sessionId)}`;
   }
 
   async #ensureDirectory(): Promise<void> {

--- a/packages/core/src/node/paths.ts
+++ b/packages/core/src/node/paths.ts
@@ -1,0 +1,15 @@
+import { isAbsolute, sep } from 'node:path';
+
+/**
+ * Whether `path` is `directory` itself or something under it.
+ *
+ * Purely lexical, so both sides must already be resolved absolute paths; a relative `path` is
+ * refused outright rather than guessed at.
+ */
+export function isWithin(directory: string, path: string): boolean {
+  if (!isAbsolute(path)) {
+    return false;
+  }
+  const root = directory.endsWith(sep) ? directory : `${directory}${sep}`;
+  return path === directory || path.startsWith(root);
+}

--- a/packages/core/tsconfig.src.json
+++ b/packages/core/tsconfig.src.json
@@ -9,5 +9,7 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  // `src/node/` is the one place Node APIs are allowed, reached only through the `./node`
+  // subpath; it is type-checked by tsconfig.json, which does supply the Node types.
+  "exclude": ["src/**/*.test.ts", "src/node.ts", "src/node/**/*.ts"]
 }

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/testing.ts'],
+  entry: ['src/index.ts', 'src/testing.ts', 'src/node.ts'],
   format: ['esm'],
   platform: 'neutral',
   dts: { oxc: true, sourcemap: false },

--- a/packages/meta/package.json
+++ b/packages/meta/package.json
@@ -45,6 +45,10 @@
       "types": "./dist/testing.d.ts",
       "default": "./dist/testing.js"
     },
+    "./node": {
+      "types": "./dist/node.d.ts",
+      "default": "./dist/node.js"
+    },
     "./openai": {
       "types": "./dist/openai.d.ts",
       "default": "./dist/openai.js"

--- a/packages/meta/src/exports.test.ts
+++ b/packages/meta/src/exports.test.ts
@@ -6,6 +6,7 @@ import * as sourceAgentserverNode from '@polymind-inc/agent-framework-agentserve
 import * as sourceAgentserverObservability from '@polymind-inc/agent-framework-agentserver/observability';
 import * as sourceAnthropic from '@polymind-inc/agent-framework-anthropic';
 import * as sourceCore from '@polymind-inc/agent-framework-core';
+import * as sourceNode from '@polymind-inc/agent-framework-core/node';
 import * as sourceTesting from '@polymind-inc/agent-framework-core/testing';
 import * as sourceFoundry from '@polymind-inc/agent-framework-foundry';
 import * as sourceFoundryHosting from '@polymind-inc/agent-framework-foundry/hosting';
@@ -21,6 +22,7 @@ import * as metaFoundryHosting from './foundry/hosting.js';
 import * as metaFoundry from './foundry.js';
 import * as metaRoot from './index.js';
 import * as metaMcp from './mcp.js';
+import * as metaNode from './node.js';
 import * as metaOpenai from './openai.js';
 import * as metaTesting from './testing.js';
 
@@ -28,6 +30,7 @@ describe('every entry re-exports its package exactly', () => {
   const entries: ReadonlyArray<[subpath: string, meta: object, source: object]> = [
     ['.', metaRoot, sourceCore],
     ['./testing', metaTesting, sourceTesting],
+    ['./node', metaNode, sourceNode],
     ['./openai', metaOpenai, sourceOpenai],
     ['./anthropic', metaAnthropic, sourceAnthropic],
     ['./mcp', metaMcp, sourceMcp],

--- a/packages/meta/src/node.ts
+++ b/packages/meta/src/node.ts
@@ -1,0 +1,2 @@
+// `@polymind-inc/agent-framework/node` — re-export of `@polymind-inc/agent-framework-core/node`.
+export * from '@polymind-inc/agent-framework-core/node';

--- a/packages/meta/tsdown.config.ts
+++ b/packages/meta/tsdown.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: [
     'src/index.ts',
     'src/testing.ts',
+    'src/node.ts',
     'src/openai.ts',
     'src/anthropic.ts',
     'src/mcp.ts',

--- a/packages/meta/vitest.config.ts
+++ b/packages/meta/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       // Subpath aliases must come before their bare package name: a bare prefix match would
       // otherwise rewrite the subpath into a path inside the package's index.ts.
       '@polymind-inc/agent-framework-core/testing': src('../core/src/testing.ts'),
+      '@polymind-inc/agent-framework-core/node': src('../core/src/node.ts'),
       '@polymind-inc/agent-framework-core': src('../core/src/index.ts'),
       '@polymind-inc/agent-framework-foundry/hosting': src('../foundry/src/hosting.ts'),
       '@polymind-inc/agent-framework-foundry': src('../foundry/src/index.ts'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       '@opentelemetry/sdk-trace-base':
         specifier: ^2.10.0
         version: 2.10.0(@opentelemetry/api@1.9.1)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
       tsdown:
         specifier: 'catalog:'
         version: 0.22.14(tsx@4.23.11)(typescript@7.0.2)

--- a/scripts/type-resolution/smoke.ts
+++ b/scripts/type-resolution/smoke.ts
@@ -1,5 +1,6 @@
 import '@polymind-inc/agent-framework';
 import '@polymind-inc/agent-framework/testing';
+import '@polymind-inc/agent-framework/node';
 import '@polymind-inc/agent-framework/openai';
 import '@polymind-inc/agent-framework/anthropic';
 import '@polymind-inc/agent-framework/mcp';
@@ -12,6 +13,7 @@ import '@polymind-inc/agent-framework/agentserver/observability';
 
 import '@polymind-inc/agent-framework-core';
 import '@polymind-inc/agent-framework-core/testing';
+import '@polymind-inc/agent-framework-core/node';
 import '@polymind-inc/agent-framework-openai';
 import '@polymind-inc/agent-framework-anthropic';
 import '@polymind-inc/agent-framework-mcp';


### PR DESCRIPTION
> Stacked on #69 — that branch is the base, so review this one after it. The diff shown here is
> only this change once #69 has landed.

The only bundled history provider keeps the transcript in session state, so a session does not
survive a process restart without a custom implementation. Of the reference implementations only
Python ships a file-backed one, and adopting its JSON Lines layout means a provider written against
other storage can read and write the same transcripts.

`FileHistoryProvider` appends one message per line to `{storagePath}/{sessionId}.jsonl`, in the same
wire form the rest of the framework serializes.

- **Session ids are opaque**, so an id that is not a portable filename is encoded rather than
  rejected — `../escape`, `nested/child`, `CON` and a non-ASCII id all keep working, and the
  resolved path is checked to be inside the storage directory. Ids too long to encode are hashed.
- **Appends to one session are serialized**, so two runs of the same session finishing at once
  cannot interleave their lines.
- **A corrupted file names the line it failed on**; blank lines are skipped rather than treated as
  corruption.
- Failed runs store nothing, and `storeContextMessages` behaves as it does for the in-memory
  provider.

## The `/node` subpath

It needs `node:fs`, so it is reached through a new `@polymind-inc/agent-framework/node` entry rather
than the root one, which has to keep working on Deno, Bun, edge runtimes and in browsers. The
source-tree type check that forbids Node APIs still covers everything outside `src/node`, which is
excluded there and checked by the config that does supply the Node types.

The store options both bundled providers share moved into one place, so switching storage does not
change which messages the transcript ends up holding.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

