### PR TITLE
Add a filesystem-backed skills source

### DIFF
--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -6,5 +6,11 @@
  * such a runtime is what fails, rather than importing the framework at all.
  */
 
+export type {
+  DirectorySkillScript,
+  DirectorySkillScriptRunner,
+  DirectorySkillsSourceConfig,
+} from './node/directory-skills-source.js';
+export { directorySkillsSource } from './node/directory-skills-source.js';
 export type { FileHistoryProviderConfig } from './node/file-history-provider.js';
 export { FileHistoryProvider } from './node/file-history-provider.js';

--- a/packages/core/src/node/directory-skills-source.race.test.ts
+++ b/packages/core/src/node/directory-skills-source.race.test.ts
@@ -1,0 +1,78 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentSession } from '../agent/session.js';
+import type { SkillLoadFailure, SkillsSourceContext } from '../skills/source.js';
+import { directorySkillsSource } from './directory-skills-source.js';
+
+// Discovery checks `SKILL.md` with lstat and the load reads it afterwards, so there is a window in
+// which the file can be swapped for a symbolic link. The window cannot be held open from outside,
+// so this lstat double lies exactly once — reporting the on-disk link as a plain file, the state
+// discovery would have seen before the swap — and tells the truth from then on.
+const gate = vi.hoisted(() => {
+  const state: { lieOnceAbout: string | undefined } = { lieOnceAbout: undefined };
+  return state;
+});
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    lstat: async (path: Parameters<typeof actual.lstat>[0]) => {
+      const stats = await actual.lstat(path);
+      if (gate.lieOnceAbout !== undefined && String(path) === gate.lieOnceAbout) {
+        gate.lieOnceAbout = undefined;
+        return { ...stats, isFile: () => true, isSymbolicLink: () => false };
+      }
+      return stats;
+    },
+  };
+});
+
+let root: string;
+const failures: SkillLoadFailure[] = [];
+
+function context(): SkillsSourceContext {
+  return {
+    agent: { id: 'agent-1' },
+    session: new AgentSession(),
+    reportSkillError: (failure) => {
+      failures.push(failure);
+    },
+  };
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'af-dir-skills-race-'));
+  failures.length = 0;
+  gate.lieOnceAbout = undefined;
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe('directorySkillsSource discovery-to-read window', () => {
+  it('refuses a SKILL.md that has become a link by the time it is read', async () => {
+    await writeFile(join(root, 'secret.md'), '---\nname: secret\ndescription: Outside.\n---\n', 'utf8');
+    const skillDir = join(root, 'skill');
+    await mkdir(skillDir);
+    const skillFile = join(skillDir, 'SKILL.md');
+    try {
+      await symlink(join(root, 'secret.md'), skillFile);
+    } catch {
+      // Creating a link needs a privilege the runner may not have; nothing to exercise then.
+      return;
+    }
+    gate.lieOnceAbout = skillFile;
+
+    const skills = await directorySkillsSource({ paths: [skillDir] }).getSkills(context());
+
+    // The load is refused rather than following the link to content outside the directory; the
+    // failure is reported and costs only this skill.
+    expect(skills).toEqual([]);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.origin).toBe(skillDir);
+  });
+});

--- a/packages/core/src/node/directory-skills-source.test.ts
+++ b/packages/core/src/node/directory-skills-source.test.ts
@@ -1,0 +1,252 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AgentSession } from '../agent/session.js';
+import type { SkillLoadFailure, SkillsSourceContext } from '../skills/source.js';
+import { cacheSkills } from '../skills/source.js';
+import { directorySkillsSource } from './directory-skills-source.js';
+
+let root: string;
+const failures: SkillLoadFailure[] = [];
+
+function context(): SkillsSourceContext {
+  return {
+    agent: { id: 'agent-1' },
+    session: new AgentSession(),
+    reportSkillError: (failure) => {
+      failures.push(failure);
+    },
+  };
+}
+
+async function writeSkill(directory: string, name: string, body = 'Do the thing.'): Promise<string> {
+  const path = join(root, directory);
+  await mkdir(path, { recursive: true });
+  await writeFile(
+    join(path, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: Does ${name} things.\n---\n\n${body}\n`,
+    'utf8',
+  );
+  return path;
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'af-dir-skills-'));
+  failures.length = 0;
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe('directorySkillsSource', () => {
+  it('loads a skill from a directory holding a SKILL.md', async () => {
+    const path = await writeSkill('summarize', 'summarize');
+
+    const skills = await directorySkillsSource({ paths: [path] }).getSkills(context());
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0]?.frontmatter).toMatchObject({
+      name: 'summarize',
+      description: 'Does summarize things.',
+    });
+    expect(await skills[0]?.getContent()).toContain('Do the thing.');
+  });
+
+  it('loads every skill directory under a parent', async () => {
+    await writeSkill('skills/summarize', 'summarize');
+    await writeSkill('skills/report', 'report');
+    await mkdir(join(root, 'skills/not-a-skill'), { recursive: true });
+
+    const skills = await directorySkillsSource({ paths: [join(root, 'skills')] }).getSkills(context());
+
+    expect(skills.map((skill) => skill.frontmatter.name).sort()).toEqual(['report', 'summarize']);
+  });
+
+  it('serves sibling files as resources named by their relative path', async () => {
+    const path = await writeSkill('summarize', 'summarize');
+    await writeFile(join(path, 'style-guide.md'), 'Be brief.', 'utf8');
+    await mkdir(join(path, 'references'), { recursive: true });
+    await writeFile(join(path, 'references/pricing.csv'), 'plan,price', 'utf8');
+
+    const [skill] = await directorySkillsSource({ paths: [path] }).getSkills(context());
+    const content = await skill?.getContent();
+
+    expect(content).toContain('<resource name="style-guide.md"/>');
+    expect(content).toContain('<resource name="references/pricing.csv"/>');
+    const resource = await skill?.getResource?.('references/pricing.csv');
+    expect(await resource?.read({ skill: skill!, callId: 'c1' })).toBe('plan,price');
+  });
+
+  it('leaves files outside the resource extensions alone', async () => {
+    const path = await writeSkill('summarize', 'summarize');
+    await writeFile(join(path, 'notes.md'), 'kept', 'utf8');
+    await writeFile(join(path, 'binary.bin'), 'skipped', 'utf8');
+
+    const [skill] = await directorySkillsSource({ paths: [path] }).getSkills(context());
+
+    expect(await skill?.getResource?.('notes.md')).toBeDefined();
+    expect(await skill?.getResource?.('binary.bin')).toBeUndefined();
+  });
+
+  it('stops at the configured depth', async () => {
+    const path = await writeSkill('summarize', 'summarize');
+    await mkdir(join(path, 'a/b'), { recursive: true });
+    await writeFile(join(path, 'a/near.md'), 'near', 'utf8');
+    await writeFile(join(path, 'a/b/far.md'), 'far', 'utf8');
+
+    const [shallow] = await directorySkillsSource({ paths: [path], searchDepth: 1 }).getSkills(context());
+    expect(await shallow?.getResource?.('a/near.md')).toBeUndefined();
+
+    const [deep] = await directorySkillsSource({ paths: [path], searchDepth: 3 }).getSkills(context());
+    expect(await deep?.getResource?.('a/b/far.md')).toBeDefined();
+  });
+
+  it('applies the resource filter', async () => {
+    const path = await writeSkill('summarize', 'summarize');
+    await writeFile(join(path, 'keep.md'), 'keep', 'utf8');
+    await writeFile(join(path, 'drop.md'), 'drop', 'utf8');
+
+    const [skill] = await directorySkillsSource({
+      paths: [path],
+      resourceFilter: (_name, relativePath) => relativePath !== 'drop.md',
+    }).getSkills(context());
+
+    expect(await skill?.getResource?.('keep.md')).toBeDefined();
+    expect(await skill?.getResource?.('drop.md')).toBeUndefined();
+  });
+
+  describe('scope', () => {
+    it('refuses a resource name that climbs out of the skill directory', async () => {
+      const path = await writeSkill('summarize', 'summarize');
+      await writeFile(join(root, 'secret.md'), 'top secret', 'utf8');
+      await writeFile(join(path, 'public.md'), 'fine', 'utf8');
+
+      const [skill] = await directorySkillsSource({ paths: [path] }).getSkills(context());
+
+      // Resources are served by name from what discovery found, so a name that climbs out of the
+      // directory resolves to nothing — there is no path for it to be joined onto.
+      for (const name of ['../secret.md', '../../secret.md', join(root, 'secret.md'), '/etc/passwd']) {
+        expect(await skill?.getResource?.(name), name).toBeUndefined();
+      }
+      const allowed = await skill?.getResource?.('public.md');
+      expect(await allowed?.read({ skill: skill!, callId: 'c1' })).toBe('fine');
+    });
+
+    it('does not serve a file reached through a symbolic link', async () => {
+      const path = await writeSkill('summarize', 'summarize');
+      await writeFile(join(root, 'secret.md'), 'top secret', 'utf8');
+      try {
+        await symlink(join(root, 'secret.md'), join(path, 'link.md'));
+      } catch {
+        // Creating a link needs a privilege the runner may not have; the guard is exercised by
+        // the linked-directory case below either way.
+        return;
+      }
+
+      const [skill] = await directorySkillsSource({ paths: [path] }).getSkills(context());
+
+      expect(await skill?.getResource?.('link.md')).toBeUndefined();
+    });
+
+    it('refuses to read a listed resource that has since become a link', async () => {
+      // Discovery decides what exists, but the read happens later, after the name has travelled
+      // through the model. A file swapped for a link in between must not be followed.
+      const path = await writeSkill('summarize', 'summarize');
+      await writeFile(join(root, 'secret.md'), 'top secret', 'utf8');
+      await writeFile(join(path, 'notes.md'), 'ordinary', 'utf8');
+
+      const [skill] = await directorySkillsSource({ paths: [path] }).getSkills(context());
+      const resource = await skill?.getResource?.('notes.md');
+      expect(resource).toBeDefined();
+
+      await rm(join(path, 'notes.md'));
+      try {
+        await symlink(join(root, 'secret.md'), join(path, 'notes.md'));
+      } catch {
+        return;
+      }
+
+      await expect(resource?.read({ skill: skill!, callId: 'c1' })).rejects.toThrow(/symbolic link/);
+    });
+
+    it('does not descend into a linked directory', async () => {
+      const path = await writeSkill('summarize', 'summarize');
+      await mkdir(join(root, 'elsewhere'), { recursive: true });
+      await writeFile(join(root, 'elsewhere/secret.md'), 'top secret', 'utf8');
+      try {
+        await symlink(join(root, 'elsewhere'), join(path, 'linked'), 'dir');
+      } catch {
+        return;
+      }
+
+      const [skill] = await directorySkillsSource({ paths: [path] }).getSkills(context());
+
+      expect(await skill?.getResource?.('linked/secret.md')).toBeUndefined();
+    });
+  });
+
+  describe('failures', () => {
+    it('reports a skill it cannot parse and keeps the others', async () => {
+      await writeSkill('skills/good', 'good');
+      const broken = join(root, 'skills/broken');
+      await mkdir(broken, { recursive: true });
+      await writeFile(join(broken, 'SKILL.md'), 'no frontmatter here', 'utf8');
+
+      const skills = await directorySkillsSource({ paths: [join(root, 'skills')] }).getSkills(context());
+
+      expect(skills.map((skill) => skill.frontmatter.name)).toEqual(['good']);
+      expect(failures).toHaveLength(1);
+      expect(failures[0]?.origin).toBe(broken);
+    });
+
+    it('reports a directory that does not exist rather than throwing', async () => {
+      const skills = await directorySkillsSource({ paths: [join(root, 'missing')] }).getSkills(context());
+
+      expect(skills).toEqual([]);
+      expect(failures).toHaveLength(1);
+    });
+  });
+
+  describe('scripts', () => {
+    it('discovers none without a runner', async () => {
+      const path = await writeSkill('summarize', 'summarize');
+      await writeFile(join(path, 'run.py'), 'print(1)', 'utf8');
+
+      const [skill] = await directorySkillsSource({ paths: [path] }).getSkills(context());
+
+      expect(await skill?.getScript?.('run.py')).toBeUndefined();
+      expect(await skill?.getContent()).toContain('<available_scripts />');
+    });
+
+    it('hands a discovered script to the runner with the model arguments', async () => {
+      const path = await writeSkill('summarize', 'summarize');
+      await writeFile(join(path, 'run.py'), 'print(1)', 'utf8');
+      const seen: Array<{ name: string; skillName: string; args: unknown }> = [];
+
+      const [skill] = await directorySkillsSource({
+        paths: [path],
+        scriptRunner: (script, args) => {
+          seen.push({ name: script.name, skillName: script.skillName, args });
+          return 'ran';
+        },
+      }).getSkills(context());
+
+      const script = await skill?.getScript?.('run.py');
+      expect(await script?.run({ length: 24 }, { skill: skill!, callId: 'c1' })).toBe('ran');
+      expect(seen).toEqual([{ name: 'run.py', skillName: 'summarize', args: { length: 24 } }]);
+    });
+  });
+
+  it('composes with cacheSkills, walking the filesystem once', async () => {
+    const path = await writeSkill('summarize', 'summarize');
+    const cached = cacheSkills(directorySkillsSource({ paths: [path] }));
+
+    const first = await cached.getSkills(context());
+    await rm(path, { recursive: true, force: true });
+    const second = await cached.getSkills(context());
+
+    expect(second).toBe(first);
+  });
+});

--- a/packages/core/src/node/directory-skills-source.test.ts
+++ b/packages/core/src/node/directory-skills-source.test.ts
@@ -171,6 +171,21 @@ describe('directorySkillsSource', () => {
       await expect(resource?.read({ skill: skill!, callId: 'c1' })).rejects.toThrow(/symbolic link/);
     });
 
+    it('does not treat a directory whose SKILL.md is a link as a skill', async () => {
+      await writeFile(join(root, 'secret.md'), '---\nname: secret\ndescription: Outside.\n---\n', 'utf8');
+      const skillDir = join(root, 'linked-skill');
+      await mkdir(skillDir, { recursive: true });
+      try {
+        await symlink(join(root, 'secret.md'), join(skillDir, 'SKILL.md'));
+      } catch {
+        return;
+      }
+
+      const skills = await directorySkillsSource({ paths: [skillDir] }).getSkills(context());
+
+      expect(skills).toEqual([]);
+    });
+
     it('does not descend into a linked directory', async () => {
       const path = await writeSkill('summarize', 'summarize');
       await mkdir(join(root, 'elsewhere'), { recursive: true });

--- a/packages/core/src/node/directory-skills-source.ts
+++ b/packages/core/src/node/directory-skills-source.ts
@@ -1,0 +1,312 @@
+import { lstat, readdir, readFile } from 'node:fs/promises';
+import { join, relative, resolve, sep } from 'node:path';
+import type { Skill, SkillResource, SkillScript, SkillScriptArguments } from '../skills/skill.js';
+import { markdownSkill, skillResource } from '../skills/skill.js';
+import type { SkillsSource, SkillsSourceContext } from '../skills/source.js';
+
+/** The document that makes a directory a skill. */
+const SKILL_FILE = 'SKILL.md';
+
+/** Files served as resources unless the caller narrows it. */
+const DEFAULT_RESOURCE_EXTENSIONS = ['.md', '.json', '.yaml', '.yml', '.csv', '.xml', '.txt'] as const;
+/** Files served as scripts, when a runner is supplied. */
+const DEFAULT_SCRIPT_EXTENSIONS = ['.py'] as const;
+/** `1` is the skill root alone; `2` adds one level of subdirectories. */
+const DEFAULT_SEARCH_DEPTH = 2;
+
+/** A file-based script, handed to the caller's runner with the arguments the model supplied. */
+export interface DirectorySkillScript {
+  /** The name the model uses, relative to the skill directory (`scripts/convert.py`). */
+  readonly name: string;
+  /** The absolute path of the script file, already checked to be inside the skill directory. */
+  readonly path: string;
+  /** The skill that owns it. */
+  readonly skillName: string;
+}
+
+/**
+ * Runs a script a skill directory contains.
+ *
+ * ## Security considerations
+ *
+ * This is a code-execution seam, and the arguments come from the model. Nothing in the framework
+ * runs a discovered file: a source without a runner discovers no scripts at all, so executing one
+ * is always something the application opted into and implemented itself.
+ */
+export type DirectorySkillScriptRunner = (
+  script: DirectorySkillScript,
+  args: SkillScriptArguments,
+) => unknown | Promise<unknown>;
+
+/** Options for {@link directorySkillsSource}. */
+export interface DirectorySkillsSourceConfig {
+  /**
+   * Directories to load skills from.
+   *
+   * Each may be a skill directory — one holding a `SKILL.md` — or a parent whose immediate
+   * children are skill directories.
+   */
+  paths: readonly string[];
+  /**
+   * Extensions served as resources. Defaults to `.md`, `.json`, `.yaml`, `.yml`, `.csv`, `.xml`
+   * and `.txt`; an empty list discovers none.
+   */
+  resourceExtensions?: readonly string[];
+  /** Extensions served as scripts, used only when `scriptRunner` is given. Defaults to `.py`. */
+  scriptExtensions?: readonly string[];
+  /**
+   * How deep to look inside a skill directory for resources and scripts. Defaults to `2` — the
+   * root plus one level of subdirectories, as in Python.
+   */
+  searchDepth?: number;
+  /** Decides which discovered resources are served, by skill name and relative path. */
+  resourceFilter?: (skillName: string, relativePath: string) => boolean;
+  /** Decides which discovered scripts are served, by skill name and relative path. */
+  scriptFilter?: (skillName: string, relativePath: string) => boolean;
+  /** Runs a discovered script. Without one, no scripts are discovered. */
+  scriptRunner?: DirectorySkillScriptRunner;
+}
+
+/**
+ * Serves the skills held in one or more directories.
+ *
+ * A skill is a directory with a `SKILL.md` in it; its sibling files become the resources the model
+ * can pull in with `read_skill_resource`, named by their path relative to the skill directory
+ * (`references/pricing.md`). Pass the directories themselves, or a parent holding several:
+ *
+ * ```ts
+ * const agent = new Agent({
+ *   client,
+ *   contextProviders: [skillsProvider(cacheSkills(directorySkillsSource({ paths: ['./skills'] })))],
+ * });
+ * ```
+ *
+ * Discovery walks the filesystem on every run, so wrap it in `cacheSkills` unless the catalogue is
+ * expected to change between runs. A skill that cannot be read is reported through
+ * `reportSkillError` and the others still load.
+ *
+ * ## Security considerations
+ *
+ * - **A read never escapes the skill directory.** Resources are discovered up front and served by
+ *   name, so a path from the model never reaches the filesystem; the resolved path is checked
+ *   against the skill directory as well, and any symbolic link or reparse point along the way is
+ *   refused rather than followed. .NET and Python refuse links the same way — resolving them first
+ *   and then checking the prefix would accept a link that happens to point back inside, which is a
+ *   weaker guarantee than either.
+ * - **Skill content is model context.** A `SKILL.md` body is injected verbatim and its resources
+ *   are read on the model's say-so, so a directory anyone else can write to is a prompt-injection
+ *   channel. Load skills from directories you control.
+ * - **Scripts are not run.** Discovery only lists them, and only when the application supplies a
+ *   {@link DirectorySkillScriptRunner} that decides how — and whether — to execute one.
+ */
+export function directorySkillsSource(config: DirectorySkillsSourceConfig): SkillsSource {
+  const paths = [...config.paths];
+  const resourceExtensions = normalizeExtensions(config.resourceExtensions ?? DEFAULT_RESOURCE_EXTENSIONS);
+  const scriptExtensions = normalizeExtensions(config.scriptExtensions ?? DEFAULT_SCRIPT_EXTENSIONS);
+  const searchDepth = Math.max(1, config.searchDepth ?? DEFAULT_SEARCH_DEPTH);
+
+  return {
+    getSkills: async (ctx: SkillsSourceContext): Promise<readonly Skill[]> => {
+      const skills: Skill[] = [];
+      for (const path of paths) {
+        const directory = resolve(path);
+        let candidates: string[];
+        try {
+          candidates = await skillDirectories(directory);
+        } catch (error) {
+          ctx.signal?.throwIfAborted();
+          ctx.reportSkillError({ origin: directory, error });
+          continue;
+        }
+        for (const candidate of candidates) {
+          ctx.signal?.throwIfAborted();
+          try {
+            skills.push(
+              await loadSkill(candidate, {
+                resourceExtensions,
+                scriptExtensions,
+                searchDepth,
+                ...(config.resourceFilter === undefined ? {} : { resourceFilter: config.resourceFilter }),
+                ...(config.scriptFilter === undefined ? {} : { scriptFilter: config.scriptFilter }),
+                ...(config.scriptRunner === undefined ? {} : { scriptRunner: config.scriptRunner }),
+              }),
+            );
+          } catch (error) {
+            // One unreadable skill — bad frontmatter, a permission problem — must not cost the run
+            // the skills that did load, or fail a run that never needed this one.
+            ctx.signal?.throwIfAborted();
+            ctx.reportSkillError({ origin: candidate, error });
+          }
+        }
+      }
+      return skills;
+    },
+  };
+}
+
+interface LoadOptions {
+  resourceExtensions: ReadonlySet<string>;
+  scriptExtensions: ReadonlySet<string>;
+  searchDepth: number;
+  resourceFilter?: (skillName: string, relativePath: string) => boolean;
+  scriptFilter?: (skillName: string, relativePath: string) => boolean;
+  scriptRunner?: DirectorySkillScriptRunner;
+}
+
+/** The directory itself when it holds a `SKILL.md`, otherwise its immediate children that do. */
+async function skillDirectories(directory: string): Promise<string[]> {
+  if (await isReadableFile(join(directory, SKILL_FILE))) {
+    return [directory];
+  }
+  const entries = await readdir(directory, { withFileTypes: true });
+  const found: string[] = [];
+  for (const entry of entries) {
+    // A linked directory is skipped rather than followed: what it points at is outside the tree
+    // the caller named, and the whole guarantee here is that a skill's files are its own.
+    if (!entry.isDirectory() || entry.isSymbolicLink()) {
+      continue;
+    }
+    const child = join(directory, entry.name);
+    if (await isReadableFile(join(child, SKILL_FILE))) {
+      found.push(child);
+    }
+  }
+  return found;
+}
+
+async function loadSkill(directory: string, options: LoadOptions): Promise<Skill> {
+  const markdown = await readFile(join(directory, SKILL_FILE), 'utf8');
+  // Parsed first: the skill's name is what the filters see, and a document that does not parse
+  // should fail before the directory is walked.
+  const named = markdownSkill({ markdown });
+  const skillName = named.frontmatter.name;
+
+  const files = await walk(directory, options.searchDepth);
+  const resources: SkillResource[] = [];
+  const scripts: SkillScript[] = [];
+
+  for (const relativePath of files) {
+    if (relativePath === SKILL_FILE) {
+      continue;
+    }
+    const extension = extensionOf(relativePath);
+    if (options.resourceExtensions.has(extension)) {
+      if (options.resourceFilter?.(skillName, relativePath) === false) {
+        continue;
+      }
+      resources.push(
+        skillResource({
+          name: relativePath,
+          read: () => readWithin(directory, relativePath),
+        }),
+      );
+      continue;
+    }
+    const runner = options.scriptRunner;
+    if (runner !== undefined && options.scriptExtensions.has(extension)) {
+      if (options.scriptFilter?.(skillName, relativePath) === false) {
+        continue;
+      }
+      scripts.push({
+        name: relativePath,
+        run: async (args: SkillScriptArguments) =>
+          await runner(
+            { name: relativePath, path: await resolveWithin(directory, relativePath), skillName },
+            args,
+          ),
+      });
+    }
+  }
+
+  return markdownSkill({ markdown, resources, scripts });
+}
+
+/** Relative paths of the files under `directory`, to `depth` levels (`1` being the root alone). */
+async function walk(directory: string, depth: number): Promise<string[]> {
+  const found: string[] = [];
+  const visit = async (current: string, remaining: number): Promise<void> => {
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const path = join(current, entry.name);
+      // A directory entry reports what it *is*, not what it points at, so a link is neither a file
+      // nor a directory here: links are left unlisted and undescended without a case of their own.
+      if (entry.isFile()) {
+        found.push(toPosix(relative(directory, path)));
+      } else if (entry.isDirectory() && remaining > 1) {
+        await visit(path, remaining - 1);
+      }
+    }
+  };
+  await visit(directory, depth);
+  return found.sort();
+}
+
+/** Reads a discovered file, re-checking that it is still inside the skill directory. */
+async function readWithin(directory: string, relativePath: string): Promise<string> {
+  return await readFile(await resolveWithin(directory, relativePath), 'utf8');
+}
+
+/**
+ * Resolves a path inside a skill directory, or refuses.
+ *
+ * Discovery already decided which files exist, so this is the second lock rather than the first:
+ * the name travelled through the model on its way back, and a resource whose path has changed
+ * shape — or acquired a link — since it was listed must not be readable.
+ */
+async function resolveWithin(directory: string, relativePath: string): Promise<string> {
+  const normalized = toPosix(relativePath).replace(/^\.\//, '');
+  const resolved = resolve(directory, normalized);
+  if (!isWithin(directory, resolved)) {
+    throw new Error(`Resource '${relativePath}' is outside the skill directory.`);
+  }
+  await refuseLinks(directory, resolved);
+  return resolved;
+}
+
+/** Rejects a path with a symbolic link or reparse point anywhere between the directory and it. */
+async function refuseLinks(directory: string, path: string): Promise<void> {
+  const steps = toPosix(relative(directory, path))
+    .split('/')
+    .filter((step) => step !== '');
+  let current = directory;
+  for (const step of steps) {
+    current = join(current, step);
+    const stats = await lstat(current);
+    if (stats.isSymbolicLink()) {
+      // The path is not named back: what the model may learn about the filesystem stops at the
+      // fact that this resource is unavailable.
+      throw new Error('A skill resource may not be reached through a symbolic link.');
+    }
+  }
+}
+
+function isWithin(directory: string, path: string): boolean {
+  const root = directory.endsWith(sep) ? directory : `${directory}${sep}`;
+  return path === directory || path.startsWith(root);
+}
+
+async function isReadableFile(path: string): Promise<boolean> {
+  try {
+    return (await lstat(path)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function toPosix(path: string): string {
+  return path.replaceAll('\\', '/');
+}
+
+function extensionOf(path: string): string {
+  const name = path.slice(path.lastIndexOf('/') + 1);
+  const dot = name.lastIndexOf('.');
+  return dot <= 0 ? '' : name.slice(dot).toLowerCase();
+}
+
+function normalizeExtensions(extensions: readonly string[]): ReadonlySet<string> {
+  return new Set(
+    extensions.map((extension) =>
+      extension.startsWith('.') ? extension.toLowerCase() : `.${extension.toLowerCase()}`,
+    ),
+  );
+}

--- a/packages/core/src/node/directory-skills-source.ts
+++ b/packages/core/src/node/directory-skills-source.ts
@@ -91,9 +91,11 @@ export interface DirectorySkillsSourceConfig {
  * - **A read never escapes the skill directory.** Resources are discovered up front and served by
  *   name, so a path from the model never reaches the filesystem; the resolved path is checked
  *   against the skill directory as well, and any symbolic link or reparse point along the way is
- *   refused rather than followed. .NET and Python refuse links the same way — resolving them first
- *   and then checking the prefix would accept a link that happens to point back inside, which is a
- *   weaker guarantee than either.
+ *   refused rather than followed — `SKILL.md` itself included. .NET and Python refuse links the
+ *   same way — resolving them first and then checking the prefix would accept a link that happens
+ *   to point back inside, which is a weaker guarantee than either. The directories named in
+ *   `paths` are the anchor of that guarantee: what the caller points the source at — including
+ *   through a link of the caller's own making — is the tree the reads are confined to.
  * - **Skill content is model context.** A `SKILL.md` body is injected verbatim and its resources
  *   are read on the model's say-so, so a directory anyone else can write to is a prompt-injection
  *   channel. Load skills from directories you control.
@@ -176,7 +178,9 @@ async function skillDirectories(directory: string): Promise<string[]> {
 }
 
 async function loadSkill(directory: string, options: LoadOptions): Promise<Skill> {
-  const markdown = await readFile(join(directory, SKILL_FILE), 'utf8');
+  // Read with the same containment check as a resource: discovery saw a plain file, but that was
+  // an instant ago, and a file swapped for a link in between must not be followed.
+  const markdown = await readWithin(directory, SKILL_FILE);
   // Parsed first: the skill's name is what the filters see, and a document that does not parse
   // should fail before the directory is walked.
   const named = markdownSkill({ markdown });

--- a/packages/core/src/node/directory-skills-source.ts
+++ b/packages/core/src/node/directory-skills-source.ts
@@ -1,8 +1,9 @@
 import { lstat, readdir, readFile } from 'node:fs/promises';
-import { join, relative, resolve, sep } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 import type { Skill, SkillResource, SkillScript, SkillScriptArguments } from '../skills/skill.js';
 import { markdownSkill, skillResource } from '../skills/skill.js';
 import type { SkillsSource, SkillsSourceContext } from '../skills/source.js';
+import { isWithin } from './paths.js';
 
 /** The document that makes a directory a skill. */
 const SKILL_FILE = 'SKILL.md';
@@ -278,11 +279,6 @@ async function refuseLinks(directory: string, path: string): Promise<void> {
       throw new Error('A skill resource may not be reached through a symbolic link.');
     }
   }
-}
-
-function isWithin(directory: string, path: string): boolean {
-  const root = directory.endsWith(sep) ? directory : `${directory}${sep}`;
-  return path === directory || path.startsWith(root);
 }
 
 async function isReadableFile(path: string): Promise<boolean> {


### PR DESCRIPTION
> Stacked on #70 (which is itself stacked on #69) — it carries the `/node` subpath this entry lands
> on. Review after those.

Skills authored as `SKILL.md` directories are the convention all three reference implementations
support — Python's `FileSkillsSource`, .NET's `AgentFileSkillsSource`, Go's `fsskills` — but the core
has no filesystem, so every application had to write the loader itself.

`directorySkillsSource` takes skill directories, or a parent holding several, and serves the
`SKILL.md` body as the skill with sibling files as resources named by their path relative to the
skill directory (`references/pricing.csv`). Discovery walks to a bounded depth, both the extensions
and the individual files can be narrowed, and a skill that cannot be read is reported through
`reportSkillError` while the others still load.

## Scoping

A read never leaves the owning skill's directory:

- Resources are discovered up front and served by name, so a path chosen by the model never reaches
  the filesystem — `../secret.md` and absolute paths resolve to no resource at all.
- The resolved path is checked against the skill directory again at read time, and a symbolic link
  anywhere along it is refused rather than followed. .NET and Python both refuse links outright, at
  discovery and at read; resolving links first and then comparing prefixes would accept a link that
  happens to point back inside, which is weaker than either.
- The read-time check is not redundant with discovery: a test replaces a listed file with a link
  between discovery and the read, and the read is refused.

## Scripts

Narrower than the issue described, deliberately. Scripts are discovered **only** when the
application supplies a `DirectorySkillScriptRunner`, and nothing here executes a file it found on
disk — the runner decides how, and whether. Python's equivalent lists scripts even with no runner
configured, which advertises to the model an action it then cannot perform; that seemed worse than
not listing them.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)