### PR TITLE
Move agentserver path and JSON file helpers to an internal subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **BREAKING** — **`@polymind-inc/agent-framework-agentserver`** — `resolveUnder` and
+  `validatePathSegment` are no longer exported from the package's main entry. They are path-safety
+  primitives for file-backed stores, not part of the server protocol surface (the reference
+  implementation exposes only the domain-scoped state-root helper, which `stateRoot` continues to
+  mirror). The framework's own Foundry hosting adapter now reaches them — together with the shared
+  atomic JSON file helpers `readJsonFile` / `writeJsonFile`, previously duplicated between the two
+  packages — through the new `./internal` subpath, an internal contract like
+  `@polymind-inc/agent-framework-openai/internal` whose exports may change in any release.
 - **`@polymind-inc/agent-framework-core`** — new **Agent Skills** support
   ([#21](https://github.com/polymind-inc/agent-framework-js/issues/21)): `skillsProvider()` is a
   `ContextProvider` that advertises each available skill's name and description in the system

--- a/packages/agentserver/package.json
+++ b/packages/agentserver/package.json
@@ -45,6 +45,10 @@
       "types": "./dist/observability.d.ts",
       "default": "./dist/observability.js"
     },
+    "./internal": {
+      "types": "./dist/internal.d.ts",
+      "default": "./dist/internal.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",

--- a/packages/agentserver/src/index.ts
+++ b/packages/agentserver/src/index.ts
@@ -66,7 +66,6 @@ export { isTerminalEventType, TERMINAL_EVENT_TYPES } from './wire.js';
 
 export type { LifecycleViolation } from './lifecycle.js';
 
-export { resolveUnder, validatePathSegment } from './paths.js';
 export type {
   HandlerContext,
   ResponseHandler,

--- a/packages/agentserver/src/internal.ts
+++ b/packages/agentserver/src/internal.ts
@@ -1,0 +1,12 @@
+/**
+ * Internal contract between the framework's own packages — not part of the documented surface.
+ *
+ * The Foundry hosting adapter keeps its per-user state files with the same path-safety and
+ * atomic-write discipline as this package's own file-backed response store, so the two share one
+ * implementation of each primitive rather than drifting apart. Everything exported here may
+ * change or disappear in any release; import from `@polymind-inc/agent-framework-agentserver`
+ * instead for the supported surface.
+ */
+
+export { resolveUnder, validatePathSegment } from './paths.js';
+export { readJsonFile, writeJsonFile } from './store/json-file.js';

--- a/packages/agentserver/src/store/file.ts
+++ b/packages/agentserver/src/store/file.ts
@@ -1,9 +1,9 @@
-import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { rm } from 'node:fs/promises';
 import { stateRoot } from '../config.js';
 import { notFound } from '../errors.js';
 import { resolveUnder } from '../paths.js';
 import type { OutputItem, ResponseEvent } from '../wire.js';
+import { readJsonFile, writeJsonFile } from './json-file.js';
 import type { ResponseGeneration, ResponseOwner, ResponseProvider, StoredResponse } from './provider.js';
 import {
   assertOwnerCanWrite,
@@ -99,19 +99,7 @@ export class FileResponseProvider implements ResponseProvider {
    * instead of policed. `#readEvents` carries the same assertion for the same reason.
    */
   async #read(id: string): Promise<StoredResponse | undefined> {
-    return this.#readJson<StoredResponse>(this.#pathFor(id));
-  }
-
-  /** Reads and parses one JSON file, reading a missing file as absent. */
-  async #readJson<T>(path: string): Promise<T | undefined> {
-    try {
-      return JSON.parse(await readFile(path, 'utf8')) as T;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        return undefined;
-      }
-      throw error;
-    }
+    return readJsonFile<StoredResponse>(this.#pathFor(id));
   }
 
   async get(id: string, owner: ResponseOwner): Promise<StoredResponse | undefined> {
@@ -121,7 +109,7 @@ export class FileResponseProvider implements ResponseProvider {
   async put(stored: StoredResponse): Promise<void> {
     return this.#serialized(stored.response.id, async () => {
       assertWritable(await this.#read(stored.response.id), stored);
-      await this.#writeAtomic(this.#pathFor(stored.response.id), stored);
+      await writeJsonFile(this.#pathFor(stored.response.id), stored);
     });
   }
 
@@ -133,18 +121,7 @@ export class FileResponseProvider implements ResponseProvider {
   }
 
   async #readEvents(id: string): Promise<StoredEventsFile | undefined> {
-    return this.#readJson<StoredEventsFile>(this.#eventsPathFor(id));
-  }
-
-  /**
-   * Atomically writes `payload` as JSON to `path`. Write-then-rename: a reader never sees a
-   * half-written file, even if the container is killed mid-write.
-   */
-  async #writeAtomic(path: string, payload: unknown): Promise<void> {
-    await mkdir(dirname(path), { recursive: true });
-    const temporary = `${path}.${crypto.randomUUID()}.tmp`;
-    await writeFile(temporary, JSON.stringify(payload), 'utf8');
-    await rename(temporary, path);
+    return readJsonFile<StoredEventsFile>(this.#eventsPathFor(id));
   }
 
   async putEvents(
@@ -173,7 +150,7 @@ export class FileResponseProvider implements ResponseProvider {
         generation,
         events: [...events],
       };
-      await this.#writeAtomic(this.#eventsPathFor(id), payload);
+      await writeJsonFile(this.#eventsPathFor(id), payload);
     });
   }
 

--- a/packages/agentserver/src/store/json-file.ts
+++ b/packages/agentserver/src/store/json-file.ts
@@ -4,9 +4,9 @@ import { dirname } from 'node:path';
 /**
  * Reads and parses a JSON file, treating a missing file as `undefined`.
  *
- * Shared by the session store and the approval storage: both keep per-user state files that
- * legitimately do not exist before the first write, and everything else — a parse failure above
- * all — must surface rather than silently become an empty state.
+ * Every file-backed store built on this helper keeps records that legitimately do not exist
+ * before the first write, and everything else — a parse failure above all — must surface rather
+ * than silently become an empty state.
  */
 export async function readJsonFile<T>(path: string): Promise<T | undefined> {
   let raw: string;
@@ -25,7 +25,8 @@ export async function readJsonFile<T>(path: string): Promise<T | undefined> {
  * Writes `value` as JSON via write-then-rename, creating the parent directory.
  *
  * The rename is what makes the replacement atomic: a process killed mid-write leaves the previous
- * file intact rather than a truncated one holding half a JSON object.
+ * file intact rather than a truncated one holding half a JSON object, and a reader never sees a
+ * half-written file.
  */
 export async function writeJsonFile(path: string, value: unknown): Promise<void> {
   await mkdir(dirname(path), { recursive: true });

--- a/packages/agentserver/tsdown.config.ts
+++ b/packages/agentserver/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/node.ts', 'src/observability.ts'],
+  entry: ['src/index.ts', 'src/node.ts', 'src/observability.ts', 'src/internal.ts'],
   format: ['esm'],
   platform: 'node',
   // The gRPC exporters are optional peers, but they are also devDependencies so the tests can

--- a/packages/foundry/src/hosting/approval-storage.ts
+++ b/packages/foundry/src/hosting/approval-storage.ts
@@ -1,7 +1,10 @@
 import { homedir } from 'node:os';
-import { resolveUnder } from '@polymind-inc/agent-framework-agentserver';
+import {
+  readJsonFile,
+  resolveUnder,
+  writeJsonFile,
+} from '@polymind-inc/agent-framework-agentserver/internal';
 import type { FunctionApprovalRequestContent } from '@polymind-inc/agent-framework-core';
-import { readJsonFile, writeJsonFile } from './json-file.js';
 
 /**
  * Remembers the approval requests this container issued, keyed by the id they went out under.

--- a/packages/foundry/src/hosting/session-store.ts
+++ b/packages/foundry/src/hosting/session-store.ts
@@ -1,7 +1,10 @@
 import { homedir } from 'node:os';
-import { resolveUnder } from '@polymind-inc/agent-framework-agentserver';
+import {
+  readJsonFile,
+  resolveUnder,
+  writeJsonFile,
+} from '@polymind-inc/agent-framework-agentserver/internal';
 import type { SerializedAgentSession } from '@polymind-inc/agent-framework-core';
-import { readJsonFile, writeJsonFile } from './json-file.js';
 
 /** A session snapshot plus the user it belongs to. */
 export interface StoredSession {

--- a/packages/foundry/vitest.config.ts
+++ b/packages/foundry/vitest.config.ts
@@ -4,6 +4,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   resolve: {
     alias: {
+      // The subpath alias must come first: a bare prefix match would otherwise rewrite
+      // `@polymind-inc/agent-framework-agentserver/internal` into a path inside index.ts.
+      '@polymind-inc/agent-framework-agentserver/internal': fileURLToPath(
+        new URL('../agentserver/src/internal.ts', import.meta.url),
+      ),
       '@polymind-inc/agent-framework-agentserver': fileURLToPath(
         new URL('../agentserver/src/index.ts', import.meta.url),
       ),

--- a/packages/meta/vitest.config.ts
+++ b/packages/meta/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       '@polymind-inc/agent-framework-foundry': src('../foundry/src/index.ts'),
       '@polymind-inc/agent-framework-agentserver/node': src('../agentserver/src/node.ts'),
       '@polymind-inc/agent-framework-agentserver/observability': src('../agentserver/src/observability.ts'),
+      '@polymind-inc/agent-framework-agentserver/internal': src('../agentserver/src/internal.ts'),
       '@polymind-inc/agent-framework-agentserver': src('../agentserver/src/index.ts'),
       '@polymind-inc/agent-framework-openai/internal': src('../openai/src/internal.ts'),
       '@polymind-inc/agent-framework-openai': src('../openai/src/index.ts'),


### PR DESCRIPTION
**Breaking**: `resolveUnder` and `validatePathSegment` are no longer exported from the `@polymind-inc/agent-framework-agentserver` main entry.

They are path-safety primitives for file-backed stores, not part of the server protocol surface — the reference implementation's public API exposes only the domain-scoped state-root helper, which `stateRoot` continues to mirror. The framework's own Foundry hosting adapter was the only intended consumer, and now reaches them through the new `./internal` subpath, the same internal-contract mechanism as `@polymind-inc/agent-framework-openai/internal`: not documented, not mirrored by the umbrella package, may change in any release.

The subpath also carries `readJsonFile` / `writeJsonFile`, the ENOENT-tolerant read and write-then-rename atomic JSON write that were previously implemented twice — once inside the agentserver file store, once in the Foundry hosting adapter. Both packages now share one implementation; the duplicate in `foundry` is deleted. Dependency direction is unchanged (`foundry` → `agentserver`), and the CHANGELOG calls out the removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)