### PR TITLE
Spell the MCP acronym as Mcp in public identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **BREAKING** — the MCP acronym in public identifiers is now spelled `Mcp`, matching the official
+  `@modelcontextprotocol` SDK and this framework's own newer API (`McpConnection`,
+  `mcpSkillsSource()`, `withMcpClientSpan`). The wire format is unaffected. Renames —
+  `@polymind-inc/agent-framework-mcp`: `MCPClient` → `McpClient`, `MCPClientConfig` →
+  `McpClientConfig`; `@polymind-inc/agent-framework-core`: `MCPToolOptions` → `McpToolOptions`,
+  `SupportsMCPTool` → `SupportsMcpTool`, `supportsMCP` → `supportsMcp`, and the capability method
+  `getMCPTool` → `getMcpTool` (the OpenAI, Anthropic and Foundry clients implement the renamed
+  method). There are no deprecated aliases; update imports and any custom `ChatClient` that
+  declares the MCP capability.
 - **`@polymind-inc/agent-framework-core`** — new **Agent Skills** support
   ([#21](https://github.com/polymind-inc/agent-framework-js/issues/21)): `skillsProvider()` is a
   `ContextProvider` that advertises each available skill's name and description in the system
@@ -26,7 +35,7 @@ contain breaking changes**; patch releases are fixes only.
   Walking a directory of `SKILL.md` files is deliberately not part of the core, which has no
   filesystem; the extensibility examples show the recipe.
 - **`@polymind-inc/agent-framework-mcp`** — new `mcpSkillsSource()`, also reachable as
-  `MCPClient.skillsSource()`: discovers the Agent Skills an MCP server publishes by reading the
+  `McpClient.skillsSource()`: discovers the Agent Skills an MCP server publishes by reading the
   well-known `skill://index.json` catalogue, fetching each `SKILL.md` body and any document it
   refers to only when the model asks. `McpConnection.readResource()` is exposed for it, with the
   same reconnect-once behaviour as `callTool` and a `resources/read` client span. A server with no

--- a/examples/03-extensibility/04-mcp.ts
+++ b/examples/03-extensibility/04-mcp.ts
@@ -1,14 +1,14 @@
 /**
  * 04 — MCP tools.
  *
- * `MCPClient` turns an MCP server's tools into framework tools, so the agent calls them exactly
+ * `McpClient` turns an MCP server's tools into framework tools, so the agent calls them exactly
  * like local ones. The connection opens on the first `getTools()` and each `tools/call` is traced
  * as an MCP client span.
  *
  * Run: `OPENAI_API_KEY=... MCP_SERVER_URL=https://… pnpm --filter example-03-extensibility mcp`
  */
 import { Agent, approvalResponse } from '@polymind-inc/agent-framework';
-import { MCPClient } from '@polymind-inc/agent-framework/mcp';
+import { McpClient } from '@polymind-inc/agent-framework/mcp';
 import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
 
 const url = process.env.MCP_SERVER_URL;
@@ -17,7 +17,7 @@ if (url === undefined) {
   process.exit(1);
 }
 
-const mcp = new MCPClient({
+const mcp = new McpClient({
   url,
   ...(process.env.MCP_AUTH_TOKEN === undefined
     ? {}

--- a/packages/anthropic/src/chat-client.test.ts
+++ b/packages/anthropic/src/chat-client.test.ts
@@ -92,7 +92,7 @@ describe('construction', () => {
 
   it('rejects a blank MCP server label with a ConfigurationError', () => {
     const { client } = clientWith([]);
-    expect(() => client.getMCPTool({ serverLabel: '  ', serverUrl: 'https://mcp.example/sse' })).toThrow(
+    expect(() => client.getMcpTool({ serverLabel: '  ', serverUrl: 'https://mcp.example/sse' })).toThrow(
       ConfigurationError,
     );
   });
@@ -167,7 +167,7 @@ describe('request mapping', () => {
       execute: () => 'ok',
     });
     const request = client.buildRequest([{ role: 'user', contents: [textContent('hi')] }], {
-      tools: [search, client.getMCPTool({ serverLabel: 'docs', serverUrl: 'https://mcp.example/sse' })],
+      tools: [search, client.getMcpTool({ serverLabel: 'docs', serverUrl: 'https://mcp.example/sse' })],
       toolChoice: 'required',
     });
 
@@ -189,12 +189,12 @@ describe('request mapping', () => {
     // (`_chat_client.py:520`), and the openai package already does the same.
     const { client } = clientWith([message('hi')]);
     const request = client.buildRequest([{ role: 'user', contents: [textContent('hi')] }], {
-      tools: [client.getMCPTool({ serverLabel: 'my docs', serverUrl: 'https://mcp.example/sse' })],
+      tools: [client.getMcpTool({ serverLabel: 'my docs', serverUrl: 'https://mcp.example/sse' })],
     });
 
     expect(request.mcp_servers).toEqual([{ type: 'url', name: 'my_docs', url: 'https://mcp.example/sse' }]);
     // The hosted tool's own name is the normalised label too, so an approval keyed by it matches.
-    expect(client.getMCPTool({ serverLabel: 'my docs', serverUrl: 'https://x' }).name).toBe('my_docs');
+    expect(client.getMcpTool({ serverLabel: 'my docs', serverUrl: 'https://x' }).name).toBe('my_docs');
   });
 
   it('maps tool choice, approximating a multi-name requirement as any', () => {
@@ -287,7 +287,7 @@ describe('beta namespace routing', () => {
     const { client, messages } = clientWith([message('hi')]);
 
     await client.getResponse([{ role: 'user', contents: [textContent('hello')] }], {
-      tools: [client.getMCPTool({ serverLabel: 'docs', serverUrl: 'https://mcp.example/sse' })],
+      tools: [client.getMcpTool({ serverLabel: 'docs', serverUrl: 'https://mcp.example/sse' })],
     });
 
     const request = messages.requests[0];

--- a/packages/anthropic/src/chat-client.ts
+++ b/packages/anthropic/src/chat-client.ts
@@ -7,9 +7,9 @@ import type {
   ChatResponseUpdate,
   ClientErrorNormalizer,
   HostedTool,
-  MCPToolOptions,
+  McpToolOptions,
   Message,
-  SupportsMCPTool,
+  SupportsMcpTool,
   SupportsWebSearchTool,
   WebSearchToolOptions,
 } from '@polymind-inc/agent-framework-core';
@@ -113,7 +113,7 @@ export interface AnthropicChatClientConfig {
  *   loop and the authorization token is disclosed to it on every call.
  */
 export class AnthropicChatClient
-  implements ChatClient<AnthropicChatOptions>, SupportsMCPTool, SupportsWebSearchTool
+  implements ChatClient<AnthropicChatOptions>, SupportsMcpTool, SupportsWebSearchTool
 {
   readonly metadata: ChatClientMetadata;
   readonly #client: Anthropic;
@@ -152,8 +152,8 @@ export class AnthropicChatClient
     return this.#client;
   }
 
-  /** Declares a remote MCP server Anthropic calls directly. See {@link supportsMCP}. */
-  getMCPTool(options: MCPToolOptions): HostedTool {
+  /** Declares a remote MCP server Anthropic calls directly. See {@link supportsMcp}. */
+  getMcpTool(options: McpToolOptions): HostedTool {
     return mcpTool(options);
   }
 

--- a/packages/anthropic/src/hosted-tools.test.ts
+++ b/packages/anthropic/src/hosted-tools.test.ts
@@ -1,4 +1,4 @@
-import { supportsMCP, supportsWebSearch, textContent } from '@polymind-inc/agent-framework-core';
+import { supportsMcp, supportsWebSearch, textContent } from '@polymind-inc/agent-framework-core';
 import { describe, expect, it } from 'vitest';
 import { AnthropicChatClient } from './chat-client.js';
 import { webSearchTool } from './hosted-tools.js';
@@ -50,7 +50,7 @@ describe('hosted tool capability protocol', () => {
   it('advertises web search and MCP', () => {
     const c = client();
     expect(supportsWebSearch(c)).toBe(true);
-    expect(supportsMCP(c)).toBe(true);
+    expect(supportsMcp(c)).toBe(true);
   });
 
   it('delegates getWebSearchTool to the factory', () => {

--- a/packages/anthropic/src/hosted-tools.ts
+++ b/packages/anthropic/src/hosted-tools.ts
@@ -1,4 +1,4 @@
-import type { HostedTool, MCPToolOptions, WebSearchToolOptions } from '@polymind-inc/agent-framework-core';
+import type { HostedTool, McpToolOptions, WebSearchToolOptions } from '@polymind-inc/agent-framework-core';
 import { ConfigurationError, hostedTool, withoutUndefined } from '@polymind-inc/agent-framework-core';
 
 /**
@@ -37,7 +37,7 @@ export const MCP_SERVER_SPEC_TYPE = 'anthropic.mcp_server';
  * Declares a remote MCP server for Anthropic to connect to directly.
  *
  * Messages API takes an `authorization_token` rather than arbitrary headers, so only the
- * `authorization` entry of {@link MCPToolOptions.headers} is used; `requireApproval` has no
+ * `authorization` entry of {@link McpToolOptions.headers} is used; `requireApproval` has no
  * Messages API equivalent and is ignored.
  *
  * ## Security considerations
@@ -46,7 +46,7 @@ export const MCP_SERVER_SPEC_TYPE = 'anthropic.mcp_server';
  * compromised server runs with whatever those tools can reach. The authorization token is
  * disclosed to that server on every call.
  */
-export function mcpTool(options: MCPToolOptions): HostedTool {
+export function mcpTool(options: McpToolOptions): HostedTool {
   if (options.serverLabel.trim() === '') {
     throw new ConfigurationError('mcpTool requires a non-empty serverLabel.');
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -158,10 +158,10 @@ export type {
   CodeInterpreterToolOptions,
   FileSearchToolOptions,
   HostedTool,
-  MCPToolOptions,
+  McpToolOptions,
   SupportsCodeInterpreterTool,
   SupportsFileSearchTool,
-  SupportsMCPTool,
+  SupportsMcpTool,
   SupportsWebSearchTool,
   WebSearchToolOptions,
 } from './tools/hosted.js';
@@ -169,7 +169,7 @@ export {
   hostedTool,
   supportsCodeInterpreter,
   supportsFileSearch,
-  supportsMCP,
+  supportsMcp,
   supportsWebSearch,
 } from './tools/hosted.js';
 export type { JsonSchema, SchemaInput } from './tools/json-schema.js';

--- a/packages/core/src/middleware/middleware.test.ts
+++ b/packages/core/src/middleware/middleware.test.ts
@@ -5,7 +5,7 @@ import { MockChatClient } from '../client/test-support.js';
 import type { ContextProvider } from '../context/context-provider.js';
 import { ConfigurationError } from '../errors.js';
 import { approvalResponse } from '../tools/approval.js';
-import { supportsMCP, supportsWebSearch } from '../tools/hosted.js';
+import { supportsMcp, supportsWebSearch } from '../tools/hosted.js';
 import { tool } from '../tools/tool.js';
 import { textContent } from '../types/content.js';
 import type { AgentResponse, AgentResponseUpdate } from '../types/response.js';
@@ -574,15 +574,15 @@ describe('toolApprovalMiddleware', () => {
 
   it('keeps the wrapped client hosted-tool capabilities visible through withMiddleware', () => {
     const capable = Object.assign(new MockChatClient([{ contents: [textContent('x')] }]), {
-      getMCPTool: (options: { serverLabel: string }) => ({
+      getMcpTool: (options: { serverLabel: string }) => ({
         kind: 'hosted' as const,
         name: 'mcp',
         spec: { server_label: options.serverLabel },
       }),
     });
     const wrapped = withMiddleware(capable, []);
-    expect(supportsMCP(wrapped)).toBe(true);
-    expect(supportsMCP(wrapped) && wrapped.getMCPTool({ serverLabel: 'docs' }).spec).toEqual({
+    expect(supportsMcp(wrapped)).toBe(true);
+    expect(supportsMcp(wrapped) && wrapped.getMcpTool({ serverLabel: 'docs' }).spec).toEqual({
       server_label: 'docs',
     });
     expect(supportsWebSearch(wrapped)).toBe(false);

--- a/packages/core/src/middleware/middleware.ts
+++ b/packages/core/src/middleware/middleware.ts
@@ -313,7 +313,7 @@ export function withMiddleware<TOptions extends ChatOptions>(
 ): ChatClient<TOptions> & { readonly middleware: readonly Middleware[] } {
   const existing = (client as { middleware?: readonly Middleware[] }).middleware ?? [];
   // The hosted-tool capability protocol is duck-typed on method presence, so the wrapper
-  // has to carry the underlying client's capability methods or `supportsMCP` and friends would
+  // has to carry the underlying client's capability methods or `supportsMcp` and friends would
   // report a capable client as incapable after wrapping.
   const capabilities: Record<string, unknown> = {};
   for (const method of HOSTED_TOOL_CAPABILITY_METHODS) {

--- a/packages/core/src/tools/hosted.ts
+++ b/packages/core/src/tools/hosted.ts
@@ -54,7 +54,7 @@ export interface CodeInterpreterToolOptions {
 }
 
 /** Options for a provider-hosted (remote) MCP server. */
-export interface MCPToolOptions {
+export interface McpToolOptions {
   /** The label the provider reports on `mcp_call` items. */
   serverLabel: string;
   serverUrl?: string;
@@ -85,15 +85,15 @@ export interface SupportsCodeInterpreterTool {
 }
 
 /** A client that can attach a remote MCP server the provider talks to directly. */
-export interface SupportsMCPTool {
-  getMCPTool(options: MCPToolOptions): HostedTool;
+export interface SupportsMcpTool {
+  getMcpTool(options: McpToolOptions): HostedTool;
 }
 
 /** The method names of the duck-typed hosted-tool capability protocol defined above. */
 type CapabilityMethod = keyof (SupportsWebSearchTool &
   SupportsFileSearchTool &
   SupportsCodeInterpreterTool &
-  SupportsMCPTool);
+  SupportsMcpTool);
 
 /**
  * Every capability method, keyed exhaustively so the compiler flags this record when a capability
@@ -105,7 +105,7 @@ const CAPABILITY_METHOD_RECORD: Record<CapabilityMethod, true> = {
   getWebSearchTool: true,
   getFileSearchTool: true,
   getCodeInterpreterTool: true,
-  getMCPTool: true,
+  getMcpTool: true,
 };
 
 /** The hosted-tool capability methods a wrapping client must carry over from the wrapped one. */
@@ -133,6 +133,6 @@ export function supportsCodeInterpreter(
 }
 
 /** Narrows a client that can attach a remote MCP server. */
-export function supportsMCP(client: ChatClient): client is ChatClient & SupportsMCPTool {
-  return hasMethod(client, 'getMCPTool');
+export function supportsMcp(client: ChatClient): client is ChatClient & SupportsMcpTool {
+  return hasMethod(client, 'getMcpTool');
 }

--- a/packages/foundry/src/chat-client.test.ts
+++ b/packages/foundry/src/chat-client.test.ts
@@ -137,7 +137,7 @@ describe('FoundryChatClient', () => {
       vector_store_ids: ['vs_1'],
     });
     expect(client.getCodeInterpreterTool().spec).toMatchObject({ type: 'code_interpreter' });
-    expect(client.getMCPTool({ serverLabel: 'docs', serverUrl: 'https://mcp.example' }).spec).toMatchObject({
+    expect(client.getMcpTool({ serverLabel: 'docs', serverUrl: 'https://mcp.example' }).spec).toMatchObject({
       type: 'mcp',
       server_label: 'docs',
     });

--- a/packages/foundry/src/chat-client.ts
+++ b/packages/foundry/src/chat-client.ts
@@ -7,11 +7,11 @@ import type {
   CodeInterpreterToolOptions,
   FileSearchToolOptions,
   HostedTool,
-  MCPToolOptions,
+  McpToolOptions,
   Message,
   SupportsCodeInterpreterTool,
   SupportsFileSearchTool,
-  SupportsMCPTool,
+  SupportsMcpTool,
   SupportsWebSearchTool,
   WebSearchToolOptions,
 } from '@polymind-inc/agent-framework-core';
@@ -76,7 +76,7 @@ export class FoundryChatClient
     SupportsWebSearchTool,
     SupportsFileSearchTool,
     SupportsCodeInterpreterTool,
-    SupportsMCPTool
+    SupportsMcpTool
 {
   readonly metadata: ChatClientMetadata;
   readonly #inner: OpenAIChatClient;
@@ -155,8 +155,8 @@ export class FoundryChatClient
   }
 
   /** Declares a remote MCP server Foundry connects to on the model's behalf. */
-  getMCPTool(options: MCPToolOptions): HostedTool {
-    return this.#inner.getMCPTool(options);
+  getMcpTool(options: McpToolOptions): HostedTool {
+    return this.#inner.getMcpTool(options);
   }
 
   /** Builds the request body without sending it. See {@link OpenAIChatClient.buildRequest}. */

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -6,7 +6,7 @@
 > this package to its exact version. Installing this package directly works and resolves to the
 > same modules, but examples and documentation import through the main package.
 
-Model Context Protocol client integration for the Agent Framework: `MCPClient` connects to an MCP
+Model Context Protocol client integration for the Agent Framework: `McpClient` connects to an MCP
 server and exposes its tools as framework `FunctionTool`s, so an agent calls them like any other
 tool. Built on `@modelcontextprotocol/client` v2. Each `tools/call` is traced as an MCP client span
 per the OpenTelemetry MCP semantic conventions.
@@ -58,7 +58,7 @@ above can read per-item labels a server attached.
 
 ## Connection sources
 
-`MCPClient` accepts exactly one connection source:
+`McpClient` accepts exactly one connection source:
 
 - `url` creates a fresh Streamable HTTP transport when the connection must be reopened.
 - `transportFactory` creates a fresh stdio, in-memory, or custom transport per connection attempt

--- a/packages/mcp/src/client.test.ts
+++ b/packages/mcp/src/client.test.ts
@@ -16,7 +16,7 @@ import {
 } from '@polymind-inc/agent-framework-core';
 import { MockChatClient } from '@polymind-inc/agent-framework-core/testing';
 import { describe, expect, it, vi } from 'vitest';
-import { MCPClient } from './client.js';
+import { McpClient } from './client.js';
 import { fromMcpContent } from './content.js';
 import type { TestTool } from './test-server.js';
 import { TestMcpServer } from './test-server.js';
@@ -46,7 +46,7 @@ function server(): TestMcpServer {
 
 describe('tool enumeration', () => {
   it('stays disconnected until tools are needed', async () => {
-    const mcp = new MCPClient({ transport: server() });
+    const mcp = new McpClient({ transport: server() });
     expect(mcp.connected).toBe(false);
 
     await mcp.getTools();
@@ -60,7 +60,7 @@ describe('tool enumeration', () => {
     // the capability is what invites `sampling/createMessage` and `elicitation/create`, so a
     // well-behaved server never sends either. See the package README for why they are out of scope.
     const transport = server();
-    const mcp = new MCPClient({ transport });
+    const mcp = new McpClient({ transport });
 
     await mcp.getTools();
 
@@ -71,7 +71,7 @@ describe('tool enumeration', () => {
   });
 
   it('exposes the server tools with their own schemas', async () => {
-    const mcp = new MCPClient({ transport: server() });
+    const mcp = new McpClient({ transport: server() });
 
     const tools = await mcp.getTools();
 
@@ -86,7 +86,7 @@ describe('tool enumeration', () => {
   });
 
   it('leaves the description empty when the server declares none', async () => {
-    const mcp = new MCPClient({
+    const mcp = new McpClient({
       transport: new TestMcpServer([{ name: 'bare', call: () => ({ content: [] }) }]),
     });
     const [bare] = await mcp.getTools();
@@ -96,14 +96,14 @@ describe('tool enumeration', () => {
   });
 
   it('honours the allowlist', async () => {
-    const mcp = new MCPClient({ transport: server(), allowedTools: ['echo'] });
+    const mcp = new McpClient({ transport: server(), allowedTools: ['echo'] });
     const tools = await mcp.getTools();
     expect(tools.map((t) => t.name)).toEqual(['echo']);
     await mcp.close();
   });
 
   it('applies the approval policy', async () => {
-    const mcp = new MCPClient({
+    const mcp = new McpClient({
       transport: server(),
       approvalMode: (name) => (name === 'echo' ? 'never_require' : 'always_require'),
     });
@@ -117,7 +117,7 @@ describe('tool enumeration', () => {
   });
 
   it('applies a constant approval mode to every tool', async () => {
-    const mcp = new MCPClient({ transport: server(), approvalMode: 'always_require' });
+    const mcp = new McpClient({ transport: server(), approvalMode: 'always_require' });
     const tools = await mcp.getTools();
     expect(new Set(tools.map((t) => t.approvalMode))).toEqual(new Set(['always_require']));
     await mcp.close();
@@ -132,7 +132,7 @@ describe('tool enumeration', () => {
       return new Response('nope', { status: 500 });
     }) as unknown as typeof globalThis.fetch;
     let issued = 0;
-    const mcp = new MCPClient({
+    const mcp = new McpClient({
       url: 'https://mcp.example.com/mcp',
       headers: () => {
         issued += 1;
@@ -148,11 +148,11 @@ describe('tool enumeration', () => {
   });
 
   it('refuses a configuration without exactly one connection source', () => {
-    expect(() => new MCPClient({})).toThrow(ConfigurationError);
-    expect(() => new MCPClient({ url: 'https://example.com/mcp', transport: server() })).toThrow(
+    expect(() => new McpClient({})).toThrow(ConfigurationError);
+    expect(() => new McpClient({ url: 'https://example.com/mcp', transport: server() })).toThrow(
       ConfigurationError,
     );
-    expect(() => new MCPClient({ transport: server(), transportFactory: server })).toThrow(
+    expect(() => new McpClient({ transport: server(), transportFactory: server })).toThrow(
       ConfigurationError,
     );
   });
@@ -161,7 +161,7 @@ describe('tool enumeration', () => {
 describe('tool invocation', () => {
   it('calls the server and returns its content', async () => {
     const transport = server();
-    const mcp = new MCPClient({ transport });
+    const mcp = new McpClient({ transport });
     const [echo] = await mcp.getTools();
 
     const result = await echo?.execute?.({ value: 'hi' }, { callId: 'call_1' });
@@ -172,7 +172,7 @@ describe('tool invocation', () => {
   });
 
   it('turns an isError result into a ToolInvocationError carrying the text', async () => {
-    const mcp = new MCPClient({ transport: server() });
+    const mcp = new McpClient({ transport: server() });
     const tools = await mcp.getTools();
     const explode = tools.find((t) => t.name === 'explode');
 
@@ -181,7 +181,7 @@ describe('tool invocation', () => {
   });
 
   it('supplies a generic message when an error result carries no text', async () => {
-    const mcp = new MCPClient({
+    const mcp = new McpClient({
       transport: new TestMcpServer([
         { name: 'mute-failure', description: 'fails silently', call: () => ({ content: [], isError: true }) },
       ]),
@@ -195,7 +195,7 @@ describe('tool invocation', () => {
   });
 
   it('wraps a protocol-level failure', async () => {
-    const mcp = new MCPClient({ transport: server() });
+    const mcp = new McpClient({ transport: server() });
     const tools = await mcp.getTools();
     const crash = tools.find((t) => t.name === 'crash');
 
@@ -206,7 +206,7 @@ describe('tool invocation', () => {
   it('surfaces structuredContent as a JSON text content', async () => {
     // A server may answer with *only* structuredContent; dropping it would hand the model an
     // empty result. Python appends json.dumps(structuredContent) as a text content.
-    const mcp = new MCPClient({
+    const mcp = new McpClient({
       transport: new TestMcpServer([
         { name: 'structured', call: () => ({ content: [], structuredContent: { answer: 42 } }) },
       ]),
@@ -220,7 +220,7 @@ describe('tool invocation', () => {
   });
 
   it('appends structuredContent after the regular content', async () => {
-    const mcp = new MCPClient({
+    const mcp = new McpClient({
       transport: new TestMcpServer([
         {
           name: 'both',
@@ -245,7 +245,7 @@ describe('tool invocation', () => {
     // `additional_properties["_meta"]` (`_mcp.py` `_parse_tool_result_from_mcp`) so downstream
     // security layers can derive per-item labels; dropping it loses that signal entirely.
     const meta = { ifc: { label: 'confidential' } };
-    const mcp = new MCPClient({
+    const mcp = new McpClient({
       transport: new TestMcpServer([
         {
           name: 'labelled',
@@ -270,7 +270,7 @@ describe('tool invocation', () => {
   it('leaves additionalProperties alone when the result carries no _meta', async () => {
     // Python only passes `additional_properties` when the envelope is non-empty (`if meta`), so an
     // ordinary result must not grow an empty one.
-    const mcp = new MCPClient({
+    const mcp = new McpClient({
       transport: new TestMcpServer([
         { name: 'plain', call: () => ({ content: [{ type: 'text', text: 'a' }], _meta: {} }) },
       ]),
@@ -287,7 +287,7 @@ describe('tool invocation', () => {
     // Python builds the structuredContent text *without* `**additional_kwargs` and the empty-result
     // "null" text *with* it. Mirror that split rather than tidying it up.
     const meta = { ifc: { label: 'confidential' } };
-    const mcp = new MCPClient({
+    const mcp = new McpClient({
       transport: new TestMcpServer([
         { name: 'structured', call: () => ({ content: [], structuredContent: { a: 1 }, _meta: meta }) },
         { name: 'silent', call: () => ({ content: [], _meta: meta }) },
@@ -309,7 +309,7 @@ describe('tool invocation', () => {
 
   it('returns a literal "null" text for an empty result', async () => {
     // Python parity: the model sees an answer instead of an absent one.
-    const mcp = new MCPClient({
+    const mcp = new McpClient({
       transport: new TestMcpServer([{ name: 'silent', call: () => ({ content: [] }) }]),
     });
     const [silent] = await mcp.getTools();
@@ -337,7 +337,7 @@ describe('connection recovery', () => {
 
   it('reconnects and retries once when the connection dies under a call', async () => {
     const transports: TestMcpServer[] = [];
-    const mcp = new MCPClient({
+    const mcp = new McpClient({
       transportFactory: () => {
         const transport = echoServer(transports.length === 0 ? [2] : []);
         transports.push(transport);
@@ -361,7 +361,7 @@ describe('connection recovery', () => {
 
   it('retries at most once, then recovers on the next call', async () => {
     const transports: TestMcpServer[] = [];
-    const mcp = new MCPClient({
+    const mcp = new McpClient({
       transportFactory: () => {
         const transport = echoServer(transports.length < 2 ? [1] : []);
         transports.push(transport);
@@ -386,7 +386,7 @@ describe('connection recovery', () => {
 
   it('does not restart a supplied one-shot transport after connection loss', async () => {
     const transport = echoServer([1]);
-    const mcp = new MCPClient({ transport });
+    const mcp = new McpClient({ transport });
     const [echo] = await mcp.getTools();
 
     await expect(echo?.execute?.({ value: 'one' }, { callId: 'call_1' })).rejects.toThrow(
@@ -398,7 +398,7 @@ describe('connection recovery', () => {
 
   it('does not treat a protocol error as a dead connection', async () => {
     const transport = server();
-    const mcp = new MCPClient({ transport });
+    const mcp = new McpClient({ transport });
     const crash = (await mcp.getTools()).find((t) => t.name === 'crash');
 
     await expect(crash?.execute?.({}, { callId: 'call_1' })).rejects.toThrow(/server exploded/);
@@ -412,7 +412,7 @@ describe('connection recovery', () => {
     const transport = new SlowStartServer([
       { name: 'echo', call: () => ({ content: [{ type: 'text', text: 'hi' }] }) },
     ]);
-    const mcp = new MCPClient({ transport });
+    const mcp = new McpClient({ transport });
 
     const pending = mcp.getTools();
     await transport.reached;
@@ -504,7 +504,7 @@ describe('cancellation', () => {
         return { content: [{ type: 'text', text: 'ok' }] };
       });
     try {
-      const mcp = new MCPClient({ transport: echoServer() });
+      const mcp = new McpClient({ transport: echoServer() });
       const [echo] = await mcp.getTools();
       const controller = new AbortController();
 
@@ -532,7 +532,7 @@ describe('cancellation', () => {
         return { content: [{ type: 'text', text: 'ok' }] };
       });
     try {
-      const mcp = new MCPClient({ transportFactory: echoServer });
+      const mcp = new McpClient({ transportFactory: echoServer });
       const [echo] = await mcp.getTools();
       const controller = new AbortController();
 
@@ -549,7 +549,7 @@ describe('cancellation', () => {
 
   it('never puts an already-aborted call on the wire', async () => {
     const transport = echoServer();
-    const mcp = new MCPClient({ transport });
+    const mcp = new McpClient({ transport });
     const [echo] = await mcp.getTools();
     const controller = new AbortController();
     controller.abort();
@@ -565,7 +565,7 @@ describe('cancellation', () => {
     const transport = new HangingCallServer([
       { name: 'slow', call: () => ({ content: [{ type: 'text', text: 'never' }] }) },
     ]);
-    const mcp = new MCPClient({ transport });
+    const mcp = new McpClient({ transport });
     const [slow] = await mcp.getTools();
     const controller = new AbortController();
 
@@ -734,7 +734,7 @@ describe('content conversion', () => {
 describe('through the agent', () => {
   it('runs a full tool round against the server', async () => {
     const transport = server();
-    const mcp = new MCPClient({ transport });
+    const mcp = new McpClient({ transport });
     const tools = await mcp.getTools();
     const client = new MockChatClient([
       { contents: [{ type: 'function_call', callId: 'call_1', name: 'echo', arguments: { value: 'hi' } }] },
@@ -757,7 +757,7 @@ describe('through the agent', () => {
   });
 
   it('reports a failing MCP tool to the model instead of failing the run', async () => {
-    const mcp = new MCPClient({ transport: server() });
+    const mcp = new McpClient({ transport: server() });
     const tools = await mcp.getTools();
     const client = new MockChatClient([
       { contents: [{ type: 'function_call', callId: 'call_1', name: 'explode', arguments: {} }] },
@@ -782,7 +782,7 @@ describe('telemetry', () => {
     const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
     trace.setGlobalTracerProvider(provider);
     try {
-      const mcp = new MCPClient({ transport: server() });
+      const mcp = new McpClient({ transport: server() });
       const [echo] = await mcp.getTools();
       await echo?.execute?.({ value: 'hi' }, { callId: 'call_1' });
       const tools = await mcp.getTools();

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -21,27 +21,27 @@ import { mcpSkillsSource } from './skills.js';
 /** How a tool's `approvalMode` is decided when its MCP server declares nothing. */
 export type ApprovalPolicy = ApprovalMode | ((toolName: string) => ApprovalMode);
 
-/** Construction options for {@link MCPClient}. */
-export interface MCPClientConfig {
+/** Construction options for {@link McpClient}. */
+export interface McpClientConfig {
   /**
    * The MCP server's Streamable HTTP endpoint.
    *
-   * Mutually exclusive with {@link MCPClientConfig.transport} and
-   * {@link MCPClientConfig.transportFactory}.
+   * Mutually exclusive with {@link McpClientConfig.transport} and
+   * {@link McpClientConfig.transportFactory}.
    */
   url?: string | URL;
   /**
    * One transport to use instead of Streamable HTTP — stdio, in-memory, or anything custom.
    *
    * A transport instance cannot be recreated after a lost connection, so automatic reconnect is
-   * disabled for this form. Use {@link MCPClientConfig.transportFactory} when the transport is
+   * disabled for this form. Use {@link McpClientConfig.transportFactory} when the transport is
    * one-shot and the connection should recover automatically.
    */
   transport?: Transport;
   /**
    * Creates a fresh custom transport for each connection attempt.
    *
-   * Mutually exclusive with {@link MCPClientConfig.url} and {@link MCPClientConfig.transport}.
+   * Mutually exclusive with {@link McpClientConfig.url} and {@link McpClientConfig.transport}.
    */
   transportFactory?: () => Transport;
   /** How this client identifies itself to the server. */
@@ -101,7 +101,7 @@ interface DeclaredTool {
  * Exposes an MCP server's tools as framework tools.
  *
  * ```ts
- * const mcp = new MCPClient({ url: 'https://mcp.example.com/mcp' });
+ * const mcp = new McpClient({ url: 'https://mcp.example.com/mcp' });
  * const agent = new Agent({ client, tools: await mcp.getTools() });
  * ```
  *
@@ -126,24 +126,24 @@ interface DeclaredTool {
  *
  * - **The server is remote code.** Its tool descriptions are read by the model and its results
  *   enter the context window — both are prompt-injection surfaces. See
- *   {@link MCPClientConfig.approvalMode}.
+ *   {@link McpClientConfig.approvalMode}.
  * - **`headers` is sent to that server on every request.** Anything in it is disclosed to it.
  * - **Tool names come from the server.** A server can rename its tools between connections, so a
  *   name-based allowlist is checked at enumeration time, not once at startup.
  */
-export class MCPClient {
-  readonly #config: MCPClientConfig;
+export class McpClient {
+  readonly #config: McpClientConfig;
   readonly #allowedTools: ReadonlySet<string> | undefined;
   readonly #target: string;
   readonly #connection: McpConnection;
 
-  constructor(config: MCPClientConfig) {
+  constructor(config: McpClientConfig) {
     const sources = [config.url, config.transport, config.transportFactory].filter(
       (value) => value !== undefined,
     );
     if (sources.length !== 1) {
       throw new ConfigurationError(
-        'MCPClient needs exactly one of `url`, `transport`, or `transportFactory`.',
+        'McpClient needs exactly one of `url`, `transport`, or `transportFactory`.',
       );
     }
     this.#config = config;
@@ -191,7 +191,7 @@ export class MCPClient {
    * Discovers the server's Agent Skills, for `skillsProvider`.
    *
    * Skills and tools are independent: a server may publish either, both or neither, and this
-   * shares the same connection as {@link MCPClient.getTools} rather than opening a second one.
+   * shares the same connection as {@link McpClient.getTools} rather than opening a second one.
    *
    * ```ts
    * const agent = new Agent({ client, contextProviders: [skillsProvider(mcp.skillsSource())] });

--- a/packages/mcp/src/connection.test.ts
+++ b/packages/mcp/src/connection.test.ts
@@ -166,7 +166,7 @@ describe('raw results', () => {
   });
 
   it('returns an isError result instead of raising it', async () => {
-    // Whether a declined tool call becomes an exception is the consumer's decision — MCPClient
+    // Whether a declined tool call becomes an exception is the consumer's decision — McpClient
     // raises, a host relaying raw MCP blocks does not — so the primitive hands the result back.
     const connection = connectionTo(
       new TestMcpServer([

--- a/packages/mcp/src/connection.ts
+++ b/packages/mcp/src/connection.ts
@@ -149,7 +149,7 @@ export interface McpCallToolOptions {
 /**
  * A lazily connected MCP session that survives a dropped connection.
  *
- * This is the connection-management layer {@link MCPClient} is built on, exposed for consumers
+ * This is the connection-management layer {@link McpClient} is built on, exposed for consumers
  * that speak MCP without the framework-tool packaging. Results come back as raw
  * `@modelcontextprotocol/client` types; converting them is the caller's responsibility.
  *

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -5,12 +5,12 @@
  * Built on `@modelcontextprotocol/client` v2 (protocol revision 2026-07-28).
  */
 
-export type { ApprovalPolicy, MCPClientConfig } from './client.js';
-export { MCPClient } from './client.js';
+export type { ApprovalPolicy, McpClientConfig } from './client.js';
+export { McpClient } from './client.js';
 export type { McpCallToolOptions, McpConnectionConfig } from './connection.js';
 export { McpConnection } from './connection.js';
 // headers.ts (origin-scoped header injection) is internal: consumers configure `headers` on
-// MCPClient or McpConnection rather than building the fetch wrapper themselves.
+// McpClient or McpConnection rather than building the fetch wrapper themselves.
 export type { McpHeaderProvider } from './headers.js';
 export type { McpResourceReader, McpSkillsSourceConfig } from './skills.js';
 export { mcpSkillsSource } from './skills.js';

--- a/packages/mcp/src/integration.test.ts
+++ b/packages/mcp/src/integration.test.ts
@@ -20,7 +20,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { describe, expect, it } from 'vitest';
-import { MCPClient } from './client.js';
+import { McpClient } from './client.js';
 
 const url = process.env.MCP_SERVER_URL;
 const authToken = process.env.MCP_AUTH_TOKEN;
@@ -34,8 +34,8 @@ function must<T>(value: T | null | undefined): T {
   return value;
 }
 
-function connect(): MCPClient {
-  return new MCPClient({
+function connect(): McpClient {
+  return new McpClient({
     url: must(url),
     ...(authToken === undefined ? {} : { headers: { authorization: `Bearer ${authToken}` } }),
   });
@@ -94,7 +94,7 @@ describe.runIf(url !== undefined && url !== '')('MCP client (integration)', () =
     // the wrong route. The connection must fail rather than hang, and it must fail on the first
     // `getTools()` rather than at construction, since the client is deliberately lazy.
     const origin = new URL(must(url)).origin;
-    const mcp = new MCPClient({ url: origin });
+    const mcp = new McpClient({ url: origin });
 
     expect(mcp.connected).toBe(false);
     await expect(mcp.getTools()).rejects.toBeInstanceOf(Error);

--- a/packages/openai/src/chat-client.ts
+++ b/packages/openai/src/chat-client.ts
@@ -9,11 +9,11 @@ import type {
   ContinuationToken,
   FileSearchToolOptions,
   HostedTool,
-  MCPToolOptions,
+  McpToolOptions,
   Message,
   SupportsCodeInterpreterTool,
   SupportsFileSearchTool,
-  SupportsMCPTool,
+  SupportsMcpTool,
   SupportsWebSearchTool,
   WebSearchToolOptions,
 } from '@polymind-inc/agent-framework-core';
@@ -218,7 +218,7 @@ export class OpenAIChatClient
     SupportsWebSearchTool,
     SupportsFileSearchTool,
     SupportsCodeInterpreterTool,
-    SupportsMCPTool
+    SupportsMcpTool
 {
   readonly metadata: ChatClientMetadata;
   readonly #client: OpenAI;
@@ -301,8 +301,8 @@ export class OpenAIChatClient
     return codeInterpreterTool(options);
   }
 
-  /** Declares a remote MCP server the provider calls directly. See {@link supportsMCP}. */
-  getMCPTool(options: MCPToolOptions): HostedTool {
+  /** Declares a remote MCP server the provider calls directly. See {@link supportsMcp}. */
+  getMcpTool(options: McpToolOptions): HostedTool {
     return mcpTool(options);
   }
 

--- a/packages/openai/src/hosted-tools.test.ts
+++ b/packages/openai/src/hosted-tools.test.ts
@@ -9,7 +9,7 @@ import type {
 import {
   supportsCodeInterpreter,
   supportsFileSearch,
-  supportsMCP,
+  supportsMcp,
   supportsWebSearch,
   textContent,
 } from '@polymind-inc/agent-framework-core';
@@ -41,13 +41,13 @@ describe('hosted tool capability protocol', () => {
     expect(supportsWebSearch(c)).toBe(true);
     expect(supportsFileSearch(c)).toBe(true);
     expect(supportsCodeInterpreter(c)).toBe(true);
-    expect(supportsMCP(c)).toBe(true);
+    expect(supportsMcp(c)).toBe(true);
   });
 
   it('does not claim capabilities for a client that has none', () => {
     const bare = { metadata: { providerName: 'x' }, getResponse: () => undefined as never };
     expect(supportsWebSearch(bare)).toBe(false);
-    expect(supportsMCP(bare)).toBe(false);
+    expect(supportsMcp(bare)).toBe(false);
   });
 
   it('maps hosted declarations onto the wire verbatim', () => {
@@ -56,7 +56,7 @@ describe('hosted tool capability protocol', () => {
       c.getWebSearchTool({ searchContextSize: 'high', userLocation: { country: 'JP' } }),
       c.getFileSearchTool({ vectorStoreIds: ['vs_1'], maxNumResults: 5 }),
       c.getCodeInterpreterTool({ fileIds: ['file_1'] }),
-      c.getMCPTool({ serverLabel: 'docs', serverUrl: 'https://mcp.example/sse', requireApproval: 'never' }),
+      c.getMcpTool({ serverLabel: 'docs', serverUrl: 'https://mcp.example/sse', requireApproval: 'never' }),
     ];
 
     expect(toResponsesTools(tools)).toEqual([
@@ -84,7 +84,7 @@ describe('hosted tool capability protocol', () => {
     // The API's object form is `{always: {tool_names}, never: {tool_names}}` (SDK
     // `Mcp.McpToolApprovalFilter`); bare arrays are rejected. Labels with spaces are
     // normalised the way Python's `get_mcp_tool` does.
-    const tool = client().getMCPTool({
+    const tool = client().getMcpTool({
       serverLabel: 'my docs',
       serverUrl: 'https://mcp.example/sse',
       requireApproval: { always: ['dangerous_tool'], never: ['safe_tool'] },
@@ -102,7 +102,7 @@ describe('hosted tool capability protocol', () => {
   });
 
   it('keeps a one-sided MCP approval filter one-sided', () => {
-    const tool = client().getMCPTool({
+    const tool = client().getMcpTool({
       serverLabel: 'docs',
       serverUrl: 'https://mcp.example/sse',
       requireApproval: { always: ['dangerous_tool'] },

--- a/packages/openai/src/hosted-tools.ts
+++ b/packages/openai/src/hosted-tools.ts
@@ -2,7 +2,7 @@ import type {
   CodeInterpreterToolOptions,
   FileSearchToolOptions,
   HostedTool,
-  MCPToolOptions,
+  McpToolOptions,
   WebSearchToolOptions,
 } from '@polymind-inc/agent-framework-core';
 import { ConfigurationError, hostedTool, withoutUndefined } from '@polymind-inc/agent-framework-core';
@@ -65,7 +65,7 @@ export function codeInterpreterTool(options: CodeInterpreterToolOptions = {}): H
  * and the server is chosen by URL — a compromised or hostile one runs with whatever the tools can
  * reach. `headers` is sent to that server on every call, so anything in it is disclosed to it.
  */
-export function mcpTool(options: MCPToolOptions): HostedTool {
+export function mcpTool(options: McpToolOptions): HostedTool {
   if (options.serverLabel.trim() === '') {
     throw new ConfigurationError('mcpTool requires a non-empty serverLabel.');
   }


### PR DESCRIPTION
**Breaking**: six public identifiers change their casing of the MCP acronym — `MCPClient` → `McpClient`, `MCPClientConfig` → `McpClientConfig`, `MCPToolOptions` → `McpToolOptions`, `SupportsMCPTool` → `SupportsMcpTool`, `supportsMCP` → `supportsMcp`, and the capability method `getMCPTool` → `getMcpTool` (the OpenAI, Anthropic and Foundry clients implement the renamed method; any custom `ChatClient` declaring the MCP capability must rename it too).

The official `@modelcontextprotocol` TypeScript SDK spells the acronym `Mcp` throughout (`McpServer`, `McpSubscription` — its declarations contain no upper-cased `MCP` identifier), and so does every newer MCP-adjacent API in this framework (`McpConnection`, `McpResourceReader`, `mcpSkillsSource`, `withMcpClientSpan`). Only the earliest identifiers used the upper-cased form, which left every new API choosing between two conventions. The all-caps `MCP` attribute-constant namespace keeps its name — constants are all-caps like `GEN_AI`.

The wire format is unaffected; none of these names are serialized. There are no deprecated aliases — during 0.x, with the surface this young, a clean cut with a CHANGELOG mapping is cheaper for everyone than a release of aliases. The full gate passes; the two Foundry live-integration tests that require project credentials fail identically on master (a service-side DNS issue in the test project) and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)