### PR TITLE
Rename OpenAIChatClientOptions to OpenAIChatClientConfigBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **BREAKING** — **`@polymind-inc/agent-framework-openai`** — the `OpenAIChatClientOptions`
+  interface is renamed `OpenAIChatClientConfigBase`. It is the construction-time half of
+  `OpenAIChatClientConfig`, and the package convention names construction types `*Config` and
+  per-call types `*Options` (`OpenAIChatOptions` is unchanged); OpenAI was the one provider whose
+  construction type broke that rule. `OpenAIChatClientConfig` itself — what `new OpenAIChatClient(…)`
+  accepts — is unchanged, so only code that names the base interface directly is affected.
 - **`@polymind-inc/agent-framework-core`** — new **Agent Skills** support
   ([#21](https://github.com/polymind-inc/agent-framework-js/issues/21)): `skillsProvider()` is a
   `ContextProvider` that advertises each available skill's name and description in the system

--- a/packages/openai/src/chat-client.test.ts
+++ b/packages/openai/src/chat-client.test.ts
@@ -735,7 +735,7 @@ describe('OpenAIChatClient configuration', () => {
     expect(stable?.('resp_123')).toBe(false);
   });
 
-  // Not a deferral: Chat Completions is out of scope for good (see `OpenAIChatClientOptions.api`).
+  // Not a deferral: Chat Completions is out of scope for good (see `OpenAIChatClientConfigBase.api`).
   it('rejects the chat completions API', () => {
     expect(
       () => new OpenAIChatClient({ client: fakeClient(vi.fn()), model: 'm', api: 'chat_completions' }),

--- a/packages/openai/src/chat-client.ts
+++ b/packages/openai/src/chat-client.ts
@@ -47,8 +47,8 @@ import {
   toResponsesTools,
 } from './to-openai.js';
 
-/** The options {@link OpenAIChatClient} takes regardless of how the model is decided. */
-export interface OpenAIChatClientOptions {
+/** The construction options {@link OpenAIChatClient} takes regardless of how the model is decided. */
+export interface OpenAIChatClientConfigBase {
   /**
    * A configured SDK client. Omit to build one from the environment (`OPENAI_API_KEY`).
    *
@@ -87,7 +87,7 @@ export interface OpenAIChatClientOptions {
  * `model` is required, except behind the explicit {@link EndpointNamedModel} opt-in: forgetting it
  * is a misconfiguration worth catching at compile time rather than as a service 400.
  */
-export type OpenAIChatClientConfig = OpenAIChatClientOptions & (NamedModel | EndpointNamedModel);
+export type OpenAIChatClientConfig = OpenAIChatClientConfigBase & (NamedModel | EndpointNamedModel);
 
 /** The ordinary case: the caller names the model or Azure deployment. */
 export interface NamedModel {

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -8,7 +8,7 @@ export type {
   EndpointNamedModel,
   NamedModel,
   OpenAIChatClientConfig,
-  OpenAIChatClientOptions,
+  OpenAIChatClientConfigBase,
 } from './chat-client.js';
 export { OpenAIChatClient } from './chat-client.js';
 // The to-openai.ts / from-openai.ts wire converters are internal (the Python reference


### PR DESCRIPTION
**Breaking**: the `OpenAIChatClientOptions` interface is renamed `OpenAIChatClientConfigBase`.

Construction types are named `*Config` and per-call types `*Options` throughout the packages (`AnthropicChatClientConfig`, `FoundryChatClientConfig`, `McpClientConfig` vs `ChatOptions`, `OpenAIChatOptions`, `AgentRunOptions`). The OpenAI client's construction options were the one exception, and OpenAI was the only provider whose construction type came in two differently-suffixed halves. The interface is the construction-time base of the `OpenAIChatClientConfig` union — hence the name — and `OpenAIChatClientConfig` itself, what `new OpenAIChatClient(…)` accepts, is unchanged: only code naming the base interface directly is affected. `OpenAIChatOptions` (the per-call options) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)