### PR TITLE
Harden runtime safety, provider fidelity, and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '17 3 * * 1'
 
 permissions:
   contents: read
@@ -48,9 +50,49 @@ jobs:
 
       - run: pnpm typecheck
 
-      - run: pnpm test
+      - name: Test with coverage gate
+        if: runner.os == 'Linux'
+        run: pnpm test:coverage
+
+      - name: Test
+        if: runner.os != 'Linux'
+        run: pnpm test
 
       # Catches manifest mistakes that would otherwise only surface after publishing: an
       # `exports` entry pointing at a file the tarball does not carry, a missing LICENSE or
       # README, or a workspace: range that cannot be resolved to a published version.
       - run: pnpm run pack:check
+
+      - name: Audit dependencies
+        if: runner.os == 'Linux'
+        run: pnpm audit --audit-level high
+
+  integration:
+    name: live protocol smoke tests
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: integration
+    env:
+      RUN_INTEGRATION_TESTS: '1'
+      MCP_SERVER_URL: https://learn.microsoft.com/api/mcp
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Run live integration suites
+        run: >-
+          pnpm exec vitest run
+          packages/openai/src/integration.test.ts
+          packages/anthropic/src/integration.test.ts
+          packages/mcp/src/integration.test.ts
+          packages/foundry/src/integration.test.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ name: Release
 on:
   push:
     tags: ['v*']
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -39,16 +38,11 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # All packages ship in lockstep, so one version check covers the set. GITHUB_REF_NAME is a
-      # real environment variable, so the tag never gets interpolated into the script text.
-      - name: Verify the tag matches the package version
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          version="$(node -p "require('./packages/core/package.json').version")"
-          if [ "${GITHUB_REF_NAME#v}" != "$version" ]; then
-            echo "Tag $GITHUB_REF_NAME does not match package version $version" >&2
-            exit 1
-          fi
+      # Fails closed unless this is a tag run and every publishable package has exactly the
+      # version named by that tag. Keep this check unconditional so a future trigger cannot
+      # accidentally bypass the release invariant.
+      - name: Verify release tag and package versions
+        run: node scripts/release-check.mjs
 
       - run: pnpm lint
 
@@ -72,7 +66,11 @@ jobs:
             *)   echo "tag=latest" >> "$GITHUB_OUTPUT" ;;
           esac
 
-      # Publishes with trusted publishing when the npm packages have this workflow configured as
+      # Publishes one package at a time in dependency order. The script checks the registry before
+      # the first mutation and skips versions already present, so a retry can safely finish a
+      # partially published release instead of failing on the first immutable npm version.
+      #
+      # Uses trusted publishing when the npm packages have this workflow configured as
       # a trusted publisher; falls back to NPM_TOKEN otherwise, which is what the very first
       # publish of a package has to use — a trusted publisher cannot be configured before the
       # package exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,70 @@ The umbrella `@polymind-inc/agent-framework` package and all `@polymind-inc/agen
 packages are versioned in lockstep; one entry here covers the set. During 0.x, **minor releases may
 contain breaking changes**; patch releases are fixes only.
 
+## Unreleased
+
+- **[BREAKING] `@polymind-inc/agent-framework-core`** — `ResponseBase<T>.value` is now
+  `T | undefined`. A suspended run (for example, one waiting for tool approval) and a response
+  created without a structured-output value have always carried `undefined` at runtime; callers
+  must now narrow `response.value` before reading it. The response factories and update-folding
+  helpers no longer claim a value exists when none was supplied.
+- **[BREAKING] `@polymind-inc/agent-framework-core`** — a raw JSON Schema whose root is not an
+  object no longer types a tool or skill-script input as `Record<string, unknown>`; its input is
+  `unknown`. Object-root schemas retain the existing record inference. Raw schemas are now
+  validated locally before executable tools and skill scripts run, rather than relying on a model
+  provider to enforce them.
+- **[BREAKING] `@polymind-inc/agent-framework-anthropic`** — `thinking` is a discriminated union:
+  `{ type: 'enabled', budgetTokens }` requires a safe-integer budget of at least 1024, while
+  `{ type: 'disabled' }` cannot carry a budget. Invalid configurations now fail at construction
+  instead of reaching Anthropic as an invalid request.
+- **[BREAKING] `@polymind-inc/agent-framework-foundry`** — `FoundryTarget` now enforces exactly one
+  of `modelDeployment` and `serverAgent`. When an already-configured SDK `client` is supplied,
+  `projectEndpoint` is optional and `baseURL` reports the client's actual URL; configurations
+  without a client still require a project endpoint.
+- **Security:** approval requests are immutable snapshots before they reach callers, so mutating a
+  streamed or awaited request cannot change the arguments later executed after approval. Raw JSON
+  Schema arguments are checked locally, executable-only approval bypassing no longer consumes
+  declaration-only calls, and reused function call ids are correlated by logical occurrence.
+- `ResponseStream.finalResponse()` now shares concurrent source initialization and draining, so
+  repeated concurrent calls cannot duplicate model/tool work or leak an iterator. Middleware
+  cancellation before the first pull and update-hook failures now finalize the run consistently.
+- Serializing content now sanitizes `Content` values nested in function `result` fields, while
+  deserialization leaves plain tool-result JSON untouched so it round-trips exactly. Future content types that
+  carry the `userInputRequest` marker suspend structured-output parsing without requiring a core
+  release for each new discriminator.
+- OpenAI stream error events and incomplete terminal errors are surfaced as error content, unknown
+  message parts survive awaited and streamed session round trips, and the final transformed
+  `store` request option is the value retained for follow-up requests.
+- Anthropic streaming drops unknown delta fragments that cannot be replayed as content blocks,
+  preserves unknown complete blocks, maps citations to framework annotations, and treats MCP
+  authorization headers case-insensitively.
+- A2A task conversion now preserves terminal status messages, falls back to the agent history only
+  for a terminal task that produced no artifacts (never duplicating a message the status already
+  carries), and de-duplicates artifacts already emitted by the stream. Resuming with a
+  continuation token needs the token alone; a session passed alongside is updated from the
+  resumed task.
+- Agent Server and Foundry hosting now bound request bodies (one `AGENTSERVER_MAX_BODY_BYTES`
+  override governs the Responses and Invocations endpoints alike), stream-event retention and in-memory
+  sessions; serialize concurrent turns for one Invocations session; reject duplicate foreground
+  response ids, releasing the in-flight hold when the request aborts even if the response body was
+  never consumed; and keep response aliases outside the primary retention quota. The Foundry
+  container examples run as the unprivileged `node` user. SSE keep-alives obey backpressure,
+  abandoned telemetry spans no longer remain strongly retained, storage credential acquisition is
+  included in bounded retries, and structured custom-tool outputs retain their JSON shape.
+- MCP rejects headers or custom fetch options that a custom transport cannot consume, and skill
+  resource names reject encoded and repeatedly encoded traversal segments.
+- Release automation now runs only from version tags, verifies all package versions in lockstep,
+  validates packed versions, and publishes sequentially in dependency order after a complete
+  registry preflight. Retries skip immutable versions that were already published.
+- CI now enforces coverage (95% statements/lines, 90% functions/branches), audits High-severity
+  dependency advisories, separates opt-in live integration tests from deterministic unit tests,
+  and schedules protocol smoke tests. The vulnerable transitive `nanoid` version is overridden to
+  a patched release.
+- Agent Skills documentation and examples now use the hardened `directorySkillsSource` from the
+  documented `/node` entry point instead of a custom filesystem walker.
+- Core base64 conversion now writes pre-sized typed arrays, avoiding per-byte boxed allocations for
+  large attachments while retaining the runtime-neutral implementation.
+
 ## 0.3.0
 
 The first minor since 0.2, and the first release after the public-API surface freeze was lifted:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ bundler tree-shakes whatever you do not import.
 | Import                                            | Provides                                                                                                                            |
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `@polymind-inc/agent-framework`                   | `Agent`, `AgentSession`, the `Message`/`Content` model, `tool()`, middleware, and the `ChatClient` seam                              |
+| `@polymind-inc/agent-framework/node`              | Node-only adapters, including `directorySkillsSource` and file-backed history                                                       |
 | `@polymind-inc/agent-framework/openai`            | OpenAI and Azure OpenAI chat client (Responses API)                                                                                  |
 | `@polymind-inc/agent-framework/anthropic`         | Anthropic chat client (Messages API)                                                                                                 |
 | `@polymind-inc/agent-framework/mcp`               | Model Context Protocol client integration — MCP server tools as framework tools                                                      |
@@ -206,10 +207,9 @@ environment variables each one needs.
   implement the `ChatClient` interface directly.
 - The MCP integration covers **tools, and resources for skill discovery** — no sampling,
   elicitation or prompts.
-- Agent Skills are served from code, from a `SKILL.md` document you supply, or over MCP. Walking a
-  directory of `SKILL.md` files is a recipe in the examples rather than an API, because the core
-  has no filesystem; MCP `archive` skills, resource templates and direct `skill://` references are
-  not implemented.
+- Agent Skills are served from code, from a `SKILL.md` document you supply, over MCP, or from a
+  local directory through the Node-only `directorySkillsSource`. MCP `archive` skills, resource
+  templates and direct `skill://` references are not implemented.
 - The A2A package is a **client**. Serving a framework agent over A2A, push notifications, task
   listing and cancellation are not covered; use [`@a2a-js/sdk`][a2a-sdk] directly for those.
 - A hosted container persists responses in the Foundry storage service by default (matching the

--- a/examples/01-get-started/04-structured-output.ts
+++ b/examples/01-get-started/04-structured-output.ts
@@ -26,7 +26,10 @@ const response = await agent.run('Taro Tanaka is 30 years old and enjoys hiking 
   responseFormat: Person,
 });
 
-// `response.value` is typed as { name: string; age: number; hobbies: string[] }.
+// A suspended response has no value yet, so narrow it before use.
+if (response.value === undefined) {
+  throw new Error('The run stopped before producing its structured output.');
+}
 console.log('name:   ', response.value.name);
 console.log('age:    ', response.value.age);
 console.log('hobbies:', response.value.hobbies.join(', '));

--- a/examples/02-foundry/02-hosted-agent/Dockerfile
+++ b/examples/02-foundry/02-hosted-agent/Dockerfile
@@ -6,6 +6,9 @@ ENV NODE_ENV=production
 # Build the self-contained ESM bundle before building this image.
 COPY dist/main.mjs ./main.mjs
 COPY dist/main.mjs.map ./main.mjs.map
+RUN mkdir -p /app/state && chown -R node:node /app
+ENV AGENTSERVER_STATE_ROOT=/app/state
+USER node
 
 # Foundry probes this port; binding elsewhere makes every invocation fail with session_not_ready.
 EXPOSE 8088

--- a/examples/02-foundry/05-invocations-agent/Dockerfile
+++ b/examples/02-foundry/05-invocations-agent/Dockerfile
@@ -6,6 +6,9 @@ ENV NODE_ENV=production
 # Build the self-contained ESM bundle before building this image.
 COPY dist/main.mjs ./main.mjs
 COPY dist/main.mjs.map ./main.mjs.map
+RUN mkdir -p /app/state && chown -R node:node /app
+ENV AGENTSERVER_STATE_ROOT=/app/state
+USER node
 
 # Foundry probes this port; binding elsewhere makes every invocation fail with session_not_ready.
 EXPOSE 8088

--- a/examples/02-foundry/06-memory-agent/Dockerfile
+++ b/examples/02-foundry/06-memory-agent/Dockerfile
@@ -6,6 +6,9 @@ ENV NODE_ENV=production
 # Build the self-contained ESM bundle before building this image.
 COPY dist/main.mjs ./main.mjs
 COPY dist/main.mjs.map ./main.mjs.map
+RUN mkdir -p /app/state && chown -R node:node /app
+ENV AGENTSERVER_STATE_ROOT=/app/state
+USER node
 
 # Foundry probes this port; binding elsewhere makes every invocation fail with session_not_ready.
 EXPOSE 8088

--- a/examples/02-foundry/07-toolbox-skills/Dockerfile
+++ b/examples/02-foundry/07-toolbox-skills/Dockerfile
@@ -6,6 +6,9 @@ ENV NODE_ENV=production
 # Build the self-contained ESM bundle before building this image.
 COPY dist/main.mjs ./main.mjs
 COPY dist/main.mjs.map ./main.mjs.map
+RUN mkdir -p /app/state && chown -R node:node /app
+ENV AGENTSERVER_STATE_ROOT=/app/state
+USER node
 
 # Foundry probes this port; binding elsewhere makes every invocation fail with session_not_ready.
 EXPOSE 8088

--- a/examples/03-extensibility/06-agent-skills.ts
+++ b/examples/03-extensibility/06-agent-skills.ts
@@ -8,74 +8,30 @@
  *
  * Two ways of authoring one are shown: `SKILL.md` files on disk, and a skill defined in code.
  *
- * The core has no filesystem — it runs in browsers and on edge runtimes — so walking a directory
- * of `SKILL.md` files is a few lines of `node:fs` here rather than an API. `parseSkillMarkdown`
- * and `markdownSkill` are the parts worth sharing.
+ * The runtime-agnostic root has no filesystem — it runs in browsers and on edge runtimes. Node
+ * applications use the hardened `directorySkillsSource` from the `/node` subpath instead.
  *
  * Run: `OPENAI_API_KEY=... pnpm --filter example-03-extensibility skills`
  */
-import { readdir, readFile } from 'node:fs/promises';
-import { dirname, isAbsolute, join, relative, sep } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { Skill } from '@polymind-inc/agent-framework';
 import {
   Agent,
+  aggregateSkills,
+  cacheSkills,
   inlineSkill,
-  markdownSkill,
+  inMemorySkillsSource,
   SKILL_TOOL_NAMES,
   skillResource,
   skillScript,
   skillsProvider,
   toolApprovalMiddleware,
 } from '@polymind-inc/agent-framework';
+import { directorySkillsSource } from '@polymind-inc/agent-framework/node';
 import { OpenAIChatClient } from '@polymind-inc/agent-framework/openai';
 import { z } from 'zod';
 
 const here = dirname(fileURLToPath(import.meta.url));
-
-/**
- * Loads every `SKILL.md` directory under `root`.
- *
- * Each skill's other files become resources, named by their path relative to the skill directory —
- * exactly the names the body refers to, so `references/factors.md` in the prose is the name the
- * model passes to `read_skill_resource`.
- *
- * ## Security considerations
- *
- * The resource name comes from the model, so it is joined and then checked to still be inside the
- * skill directory. Without that, `../../.env` is a readable path.
- */
-async function skillsFromDirectory(root: string): Promise<Skill[]> {
-  const skills: Skill[] = [];
-  for (const entry of await readdir(root, { withFileTypes: true })) {
-    if (!entry.isDirectory()) {
-      continue;
-    }
-    const directory = join(root, entry.name);
-    const files = await readdir(directory, { recursive: true, withFileTypes: true });
-    const resources = files
-      .filter((file) => file.isFile() && file.name !== 'SKILL.md')
-      .map((file) => {
-        // Posix-style, because that is how a Markdown body refers to a sibling file.
-        const name = relative(directory, join(file.parentPath, file.name)).split(sep).join('/');
-        return skillResource({
-          name,
-          read: async () => {
-            const path = join(directory, name);
-            // A `..` *segment* is the escape; a filename that merely starts with dots is fine.
-            const inside = relative(directory, path);
-            if (isAbsolute(inside) || inside === '..' || inside.startsWith(`..${sep}`)) {
-              throw new Error(`Refusing to read '${name}': outside the skill directory.`);
-            }
-            return await readFile(path, 'utf8');
-          },
-        });
-      });
-
-    skills.push(markdownSkill({ markdown: await readFile(join(directory, 'SKILL.md'), 'utf8'), resources }));
-  }
-  return skills;
-}
 
 /** A skill defined in code, with an action the model can run rather than reason through. */
 const roundTrip = inlineSkill({
@@ -109,8 +65,10 @@ const roundTrip = inlineSkill({
   ],
 });
 
-const skills = [...(await skillsFromDirectory(join(here, 'skills'))), roundTrip];
-console.log('[skills]', skills.map((skill) => skill.frontmatter.name).join(', '));
+const skills = aggregateSkills([
+  cacheSkills(directorySkillsSource({ paths: [join(here, 'skills')] })),
+  inMemorySkillsSource([roundTrip]),
+]);
 
 const agent = new Agent({
   client: new OpenAIChatClient({ model: 'gpt-4o-mini' }),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "build": "pnpm -r build",
-    "test": "pnpm -r test",
+    "test": "pnpm -r test && pnpm test:scripts",
+    "test:scripts": "node --test scripts/workspace.test.mjs",
     "test:coverage": "vitest run --coverage --testTimeout=30000",
     "typecheck": "pnpm -r typecheck && pnpm run typecheck:resolution",
     "typecheck:resolution": "tsc -p scripts/type-resolution/tsconfig.json --module nodenext --moduleResolution nodenext",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "pack:check": "node scripts/pack-check.mjs",
     "check": "pnpm lint && pnpm build && pnpm typecheck && pnpm test && pnpm run pack:check",
     "version:set": "node scripts/set-version.mjs",
-    "publish:packages": "pnpm -r --filter \"./packages/*\" publish --access public --provenance --no-git-checks"
+    "publish:packages": "node scripts/publish-packages.mjs"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.7",

--- a/packages/a2a/README.md
+++ b/packages/a2a/README.md
@@ -137,7 +137,8 @@ const done = await agent.run(undefined, { session, continuationToken: accepted.c
 ```
 
 A token is `{"taskId": "..."}` and is JSON-serializable, so a resume can happen in another process.
-Tokens are parsed strictly: anything that is not one this package issued is refused.
+Tokens are parsed strictly. The token alone identifies the task to resume; when a session is also
+passed, its recorded task state is updated from the resumed task.
 
 Tokens are issued only while a task is still going to produce something (`submitted`, `working`). A
 task that stopped to ask a question (`input-required`) is continued by sending the next message, not

--- a/packages/a2a/src/agent.test.ts
+++ b/packages/a2a/src/agent.test.ts
@@ -228,6 +228,43 @@ describe('a streamed turn', () => {
     expect(streamed.finishReason).toBe(awaited.finishReason);
   });
 
+  it('does not repeat a streamed artifact when the final task snapshot carries it again', async () => {
+    const { client } = fakeClient({
+      sendMessageStream: [
+        streamEvent({
+          artifactUpdate: {
+            taskId: 'task-1',
+            contextId: 'ctx-1',
+            artifact: { artifactId: 'a1', parts: [{ text: 'Invoice 42 is paid.' }] },
+          },
+        }),
+        // Some agents close a stream with a full task snapshot whose artifacts were already
+        // streamed one by one. That snapshot must contribute its state, not its content.
+        streamEvent({
+          task: {
+            id: 'task-1',
+            contextId: 'ctx-1',
+            status: { state: 'TASK_STATE_COMPLETED' },
+            artifacts: [{ artifactId: 'a1', parts: [{ text: 'Invoice 42 is paid.' }] }],
+          },
+        }),
+      ],
+    });
+    const agent = new A2AAgent({ client });
+    const session = agent.createSession();
+
+    const stream = agent.run('Is invoice 42 paid?', { session });
+    for await (const _ of stream) {
+      // Drain.
+    }
+    const response = await stream.finalResponse();
+
+    expect(response.text).toBe('Invoice 42 is paid.');
+    expect(readA2ASessionState(session)).toEqual({ taskId: 'task-1', taskState: 'TASK_STATE_COMPLETED' });
+    // The dedup bookkeeping is per-run state; a serialized session carries none of it.
+    expect(JSON.stringify(session)).not.toContain('streamedArtifacts');
+  });
+
   it('keeps progress commentary out of the folded transcript', async () => {
     const { client } = fakeClient({
       sendMessageStream: [
@@ -505,6 +542,45 @@ describe('resuming a background turn', () => {
     expect(must(transport.calls[0]).params).toMatchObject({ id: 'task-1' });
     expect(response.text).toBe('done');
     expect(response.continuationToken).toBeUndefined();
+  });
+
+  it('resumes from the token alone, without a session', async () => {
+    const { client, transport } = fakeClient({
+      getTask: task({
+        id: 'task-1',
+        contextId: 'ctx-1',
+        status: { state: 'TASK_STATE_COMPLETED' },
+        artifacts: [{ artifactId: 'a1', parts: [{ text: 'done' }] }],
+      }),
+    });
+
+    // The task is server-side state: its id is all a resumed run needs.
+    const response = await new A2AAgent({ client }).run(undefined, {
+      continuationToken: { taskId: 'task-1' },
+    });
+
+    expect(must(transport.calls[0]).method).toBe('getTask');
+    expect(response.text).toBe('done');
+  });
+
+  it('updates a session from the resumed task rather than gating on its recorded state', async () => {
+    const { client } = fakeClient({
+      getTask: task({
+        id: 'task-1',
+        contextId: 'ctx-1',
+        status: { state: 'TASK_STATE_COMPLETED' },
+        artifacts: [{ artifactId: 'a1', parts: [{ text: 'done' }] }],
+      }),
+    });
+    const agent = new A2AAgent({ client });
+    // The session recorded another task — a later turn moved on while the background run was out.
+    // The resumed task is what the remote side reports, and the session follows it.
+    const session = agent.createSession({ serviceSessionId: 'ctx-1', taskId: 'task-other' });
+
+    const response = await agent.run(undefined, { session, continuationToken: { taskId: 'task-1' } });
+
+    expect(response.text).toBe('done');
+    expect(readA2ASessionState(session)).toEqual({ taskId: 'task-1', taskState: 'TASK_STATE_COMPLETED' });
   });
 
   it('re-subscribes when iterated', async () => {

--- a/packages/a2a/src/agent.ts
+++ b/packages/a2a/src/agent.ts
@@ -58,17 +58,22 @@ export interface A2AAgentConfig {
 
 /** Per-run options for {@link A2AAgent.run}. */
 export interface A2ARunOptions {
-  /** Continues an existing conversation; required to resume a background run later. */
+  /** Continues an existing conversation; required to start a background run. */
   session?: AgentSession;
   /** Sent as the request's `metadata`, for context the protocol does not model. */
   metadata?: Record<string, unknown>;
-  /** Resumes a task the agent is still working on. Pass no input alongside it. */
+  /**
+   * Resumes a task the agent is still working on. Pass no input alongside it.
+   *
+   * The token alone identifies the task; a `session` passed with it is updated from the resumed
+   * task's state.
+   */
   continuationToken?: ContinuationToken;
   /**
    * Returns as soon as the task is accepted, with a `continuationToken` to resume from.
    *
-   * Requires an explicit `session`: an auto-created session cannot be reached again, so the token
-   * would have nothing to resume into.
+   * Requires an explicit `session`: an auto-created session would be discarded with the response,
+   * and with it the conversation the background task belongs to.
    */
   allowBackgroundResponses?: boolean;
   signal?: AbortSignal;
@@ -253,6 +258,9 @@ export class A2AAgent implements AgentLike {
     if (background && session === undefined) {
       throw new ConfigurationError('A session must be provided when allowBackgroundResponses is enabled.');
     }
+    // A token alone identifies the task to resume: the task is server-side state, so no session is
+    // needed. When one is passed anyway, it is brought up to date from the resumed task at the end
+    // of the run, whatever it recorded before.
     const resumeTaskId =
       options?.continuationToken === undefined
         ? undefined

--- a/packages/a2a/src/convert.test.ts
+++ b/packages/a2a/src/convert.test.ts
@@ -295,6 +295,145 @@ describe('payloads to response updates', () => {
     expect(must(updates[1]).continuationToken).toBeUndefined();
   });
 
+  it('surfaces a terminal status message, including a failure reason', () => {
+    const updates = updatesFromPayload(
+      {
+        $case: 'task',
+        value: task({
+          id: 'task-1',
+          contextId: 'ctx-1',
+          status: {
+            state: 'TASK_STATE_FAILED',
+            message: {
+              messageId: 'failure-1',
+              role: 'ROLE_AGENT',
+              parts: [{ text: 'invoice service failed' }],
+            },
+          },
+        }),
+      },
+      {},
+    );
+
+    expect(updates.map((update) => update.text)).toContain('invoice service failed');
+  });
+
+  it('falls back to the last agent history message when a task has no artifacts', () => {
+    const updates = updatesFromPayload(
+      {
+        $case: 'task',
+        value: task({
+          id: 'task-1',
+          contextId: 'ctx-1',
+          status: { state: 'TASK_STATE_COMPLETED' },
+          history: [
+            { messageId: 'u1', role: 'ROLE_USER', parts: [{ text: 'question' }] },
+            { messageId: 'a1', role: 'ROLE_AGENT', parts: [{ text: 'answer from history' }] },
+          ],
+        }),
+      },
+      {},
+    );
+
+    expect(updates.map((update) => update.text)).toContain('answer from history');
+  });
+
+  it('does not replay a history message while a task is still working', () => {
+    const working = task({
+      id: 'task-1',
+      contextId: 'ctx-1',
+      status: { state: 'TASK_STATE_WORKING' },
+      history: [
+        { messageId: 'u1', role: 'ROLE_USER', parts: [{ text: 'question' }] },
+        { messageId: 'a1', role: 'ROLE_AGENT', parts: [{ text: 'stale answer' }] },
+      ],
+    });
+
+    // Two polls of the same unfinished task, as resuming produces: neither may present the
+    // history as fresh output, or every poll would repeat it.
+    for (let poll = 0; poll < 2; poll += 1) {
+      const updates = updatesFromPayload({ $case: 'task', value: working }, {});
+
+      expect(updates.map((update) => update.text)).not.toContain('stale answer');
+      expect(must(updates.at(-1)).continuationToken).toEqual({ taskId: 'task-1' });
+    }
+  });
+
+  it('does not fall back to history when the terminal task repeats only streamed artifacts', () => {
+    const observed: ObservedTaskState = {};
+    const streamed = streamEvent({
+      artifactUpdate: {
+        taskId: 'task-1',
+        contextId: 'ctx-1',
+        artifact: { artifactId: 'a1', parts: [{ text: 'the answer' }] },
+      },
+    });
+    updatesFromPayload(must(streamed.payload), observed);
+
+    const terminal = updatesFromPayload(
+      {
+        $case: 'task',
+        value: task({
+          id: 'task-1',
+          contextId: 'ctx-1',
+          status: { state: 'TASK_STATE_COMPLETED' },
+          artifacts: [{ artifactId: 'a1', parts: [{ text: 'the answer' }] }],
+          history: [{ messageId: 'h1', role: 'ROLE_AGENT', parts: [{ text: 'the answer' }] }],
+        }),
+      },
+      observed,
+    );
+
+    // The artifact already delivered the answer; the history copy of it must not bring it back.
+    expect(terminal.flatMap((update) => update.contents)).toEqual([]);
+  });
+
+  it('emits a message mirrored in both the status and the history exactly once', () => {
+    const finalMessage = { messageId: 'final-1', role: 'ROLE_AGENT', parts: [{ text: 'the answer' }] };
+
+    const updates = updatesFromPayload(
+      {
+        $case: 'task',
+        value: task({
+          id: 'task-1',
+          contextId: 'ctx-1',
+          status: { state: 'TASK_STATE_COMPLETED', message: finalMessage },
+          history: [finalMessage],
+        }),
+      },
+      {},
+    );
+
+    expect(updates.map((update) => update.text).filter((text) => text === 'the answer')).toHaveLength(1);
+  });
+
+  it('does not emit an artifact again when the terminal task repeats a streamed artifact', () => {
+    const observed: ObservedTaskState = {};
+    const streamed = streamEvent({
+      artifactUpdate: {
+        taskId: 'task-1',
+        contextId: 'ctx-1',
+        artifact: { artifactId: 'a1', parts: [{ text: 'once' }] },
+      },
+    });
+    const first = updatesFromPayload(must(streamed.payload), observed);
+    const terminal = updatesFromPayload(
+      {
+        $case: 'task',
+        value: task({
+          id: 'task-1',
+          contextId: 'ctx-1',
+          status: { state: 'TASK_STATE_COMPLETED' },
+          artifacts: [{ artifactId: 'a1', parts: [{ text: 'once' }] }],
+        }),
+      },
+      observed,
+    );
+
+    expect(first.map((update) => update.text)).toEqual(['once']);
+    expect(terminal.map((update) => update.text)).not.toContain('once');
+  });
+
   it.each([
     ['TASK_STATE_SUBMITTED', true, undefined],
     ['TASK_STATE_WORKING', true, undefined],

--- a/packages/a2a/src/convert.ts
+++ b/packages/a2a/src/convert.ts
@@ -35,14 +35,25 @@ export type A2APayload = NonNullable<StreamResponse['payload']>;
 /**
  * What a run learned about the remote conversation while its events went by.
  *
- * Every field is explicitly resettable: a turn that came back as a plain message ended on no task,
- * and the session has to record that rather than keep the previous turn's.
+ * Every identity field is explicitly resettable: a turn that came back as a plain message ended on
+ * no task, and the session has to record that rather than keep the previous turn's.
  */
 export interface ObservedTaskState {
   contextId?: string | undefined;
   taskId?: string | undefined;
   /** The protocol spelling, e.g. `TASK_STATE_WORKING`. */
   taskState?: string | undefined;
+  /**
+   * Keys of artifacts already surfaced by streamed artifact-update events, so a terminal task
+   * snapshot repeating them does not emit them twice. Per-run bookkeeping, never persisted: the
+   * session writer copies the identity fields one by one and leaves this behind.
+   */
+  streamedArtifacts?: Set<string>;
+}
+
+/** An artifact id is only unique within its task, so the dedup key carries both. */
+function artifactKey(taskId: string, artifactId: string): string {
+  return `${taskId}\u0000${artifactId}`;
 }
 
 function omitEmpty(value: string | undefined): string | undefined {
@@ -264,6 +275,15 @@ function artifactUpdate(
   });
 }
 
+function isTerminalState(state: TaskState | undefined): boolean {
+  return (
+    state === TaskState.TASK_STATE_COMPLETED ||
+    state === TaskState.TASK_STATE_FAILED ||
+    state === TaskState.TASK_STATE_CANCELED ||
+    state === TaskState.TASK_STATE_REJECTED
+  );
+}
+
 /**
  * Turns a whole task into updates: one per artifact, plus the question it is waiting on.
  *
@@ -271,13 +291,41 @@ function artifactUpdate(
  * progress commentary the agent may or may not send, and folding it into the transcript would put
  * "working on it" in front of the answer.
  */
-function updatesFromTask(task: Task): AgentResponseUpdate[] {
+function updatesFromTask(task: Task, observed: ObservedTaskState): AgentResponseUpdate[] {
   const state = task.status?.state;
-  const updates: AgentResponseUpdate[] = task.artifacts.map((artifact) =>
-    artifactUpdate(artifact, task.id, mergeMetadata(artifact.metadata, task.metadata), task),
-  );
+  const alreadyStreamed = observed.streamedArtifacts;
+  const updates: AgentResponseUpdate[] = (task.artifacts ?? [])
+    .filter((artifact) => !alreadyStreamed?.has(artifactKey(task.id, artifact.artifactId)))
+    .map((artifact) =>
+      artifactUpdate(artifact, task.id, mergeMetadata(artifact.metadata, task.metadata), task),
+    );
+
   const statusMessage = task.status?.message;
-  if (state === TaskState.TASK_STATE_INPUT_REQUIRED && statusMessage !== undefined) {
+  if (isTerminalState(state) && (task.artifacts ?? []).length === 0) {
+    // A finished task that produced no artifacts at all may still have answered as a plain
+    // message, kept in its history. Only that case falls back to the history: an unfinished
+    // task's history would be replayed by every poll, a task whose artifacts were merely
+    // filtered as already streamed has delivered its answer, and a history message the status
+    // branch below is about to surface would arrive twice.
+    const historyAnswer = [...(task.history ?? [])]
+      .reverse()
+      .find((message) => message.role === Role.ROLE_AGENT);
+    if (historyAnswer !== undefined && historyAnswer.messageId !== statusMessage?.messageId) {
+      updates.push(
+        update({
+          contents: fromA2AParts(historyAnswer.parts),
+          responseId: task.id,
+          messageId: historyAnswer.messageId,
+          additionalProperties: mergeMetadata(historyAnswer.metadata, task.metadata),
+          rawRepresentation: task,
+        }),
+      );
+    }
+  }
+  if (
+    (state === TaskState.TASK_STATE_INPUT_REQUIRED || isTerminalState(state)) &&
+    statusMessage !== undefined
+  ) {
     updates.push(
       update({
         contents: fromA2AParts(statusMessage.parts),
@@ -393,7 +441,7 @@ export function updatesFromPayload(payload: A2APayload, observed: ObservedTaskSt
     case 'task': {
       const task = payload.value;
       observeTaskStatus(observed, task.contextId, task.id, task.status?.state);
-      return updatesFromTask(task);
+      return updatesFromTask(task, observed);
     }
     case 'statusUpdate': {
       const event = payload.value;
@@ -407,6 +455,8 @@ export function updatesFromPayload(payload: A2APayload, observed: ObservedTaskSt
       if (artifact === undefined) {
         throw new A2AAgentError('The A2A agent sent an artifact update with no artifact.');
       }
+      observed.streamedArtifacts ??= new Set();
+      observed.streamedArtifacts.add(artifactKey(event.taskId, artifact.artifactId));
       // The event's own metadata wins over the artifact's, and neither is dropped: a streamed
       // artifact has to fold into the same content an awaited run would have returned whole.
       return [

--- a/packages/agentserver/src/background-run.test.ts
+++ b/packages/agentserver/src/background-run.test.ts
@@ -30,6 +30,10 @@ function event(sequenceNumber: number, type = 'response.output_text.delta'): Res
 }
 
 describe('BackgroundRun retention', () => {
+  it('rejects a zero-sized retention window instead of breaking live delivery', () => {
+    expect(() => backgroundRun(0)).toThrow(/maxEvents.*at least 1/i);
+  });
+
   it('keeps the complete replay log until the cap is crossed', () => {
     const run = backgroundRun(3);
     const events = [event(0), event(1), event(2)];

--- a/packages/agentserver/src/background-run.ts
+++ b/packages/agentserver/src/background-run.ts
@@ -1,5 +1,6 @@
 import type { ResponseTracker } from './lifecycle.js';
 import type { ResponseGeneration, ResponseOwner } from './store/provider.js';
+import { positiveLimit } from './validation.js';
 import type { OutputItem, ResponseEvent, ResponseObject } from './wire.js';
 
 /** The event's replay cursor position. Events this server persists are always stamped. */
@@ -63,7 +64,7 @@ export class BackgroundRun {
     this.inputItems = options.inputItems;
     this.abort = options.abort;
     this.persistSnapshot = options.persistSnapshot;
-    this.#maxEvents = options.maxEvents;
+    this.#maxEvents = positiveLimit('maxEvents', options.maxEvents);
     const { promise, resolve } = Promise.withResolvers<void>();
     this.firstEvent = promise;
     this.#firstEventSeen = resolve;
@@ -214,8 +215,9 @@ export interface IdClaim {
    */
   readonly done: Promise<void>;
   /**
-   * Ends the wait, optionally by adopting the work that replaces it. Called exactly once — either
-   * with the run's completion, or bare when the create failed before there was a run.
+   * Ends the wait, optionally by adopting the work that replaces it — with the run's completion,
+   * or bare when the turn ended without a run taking over. First call wins: a settled claim stays
+   * settled, so the teardown paths that share a claim may each settle it without coordinating.
    */
   readonly settle: (work?: Promise<void>) => void;
 }

--- a/packages/agentserver/src/foreground.ts
+++ b/packages/agentserver/src/foreground.ts
@@ -49,6 +49,7 @@ export async function streamResponse(
   persist: () => Promise<void>,
   sessionId: string,
   releaseSignals: () => void,
+  signal: AbortSignal,
 ): Promise<Response> {
   // The first event is pulled *before* the 200 and the SSE headers go out. A handler that fails
   // during setup — an unauthorized session, a missing agent — therefore still reaches the
@@ -67,6 +68,26 @@ export async function streamResponse(
 
   const sequence = new SequenceNumberWriter();
   const persister = new TerminalPersister(persist, tracker);
+  // The whole teardown of one committed stream, run at most once: close the handler chain first
+  // so its own `finally` blocks run, then record the partial turn (a stream torn down before its
+  // terminal is resumable with `previous_response_id`), release the turn's claim and listeners,
+  // and flush before the platform freezes the sandbox (the reference's `trace_stream` flushes in
+  // its own `finally` the same way).
+  let torndown = false;
+  const windDown = async (): Promise<void> => {
+    if (torndown) {
+      return;
+    }
+    torndown = true;
+    try {
+      await iterator.return?.();
+    } catch {
+      // The generator's own failure must not mask the teardown.
+    }
+    await persister.ensureAttempted();
+    releaseSignals();
+    await flushTelemetry();
+  };
   const numbered = async function* (): AsyncGenerator<ResponseEvent> {
     try {
       let pending = first;
@@ -79,21 +100,24 @@ export async function streamResponse(
         pending = await iterator.next();
       }
     } finally {
-      // The client-disconnect path: the stream was torn down before the terminal event came
-      // through. Close the handler chain first so its own `finally` blocks run, then record the
-      // partial turn.
-      try {
-        await iterator.return?.();
-      } catch {
-        // The generator's own failure must not mask the teardown.
-      }
-      await persister.ensureAttempted();
-      releaseSignals();
-      // Stream over — flush before the platform freezes the sandbox (the reference's
-      // `trace_stream` flushes in its own `finally` the same way).
-      await flushTelemetry();
+      // The consumer-driven path: the stream ran to completion, or a cancel tore it down early.
+      await windDown();
     }
   };
+  // The consumer is not guaranteed: a host that mounts `fetch` directly may abandon the body
+  // without cancelling it, leaving the generator above parked at a `yield` where its `finally`
+  // can never run — and with it the claim on the response id, which would answer 409 and hold
+  // `drain()` open for the life of the process. The turn's abort signal fires for exactly the
+  // two ways such a stream dies — the client disconnecting, the container shutting down — so it
+  // triggers the same teardown directly. A stream with a live consumer is unharmed: closing the
+  // source lets a pending pull deliver what the handler winds down with, and whichever of the
+  // two paths gets there second is a no-op.
+  signal.addEventListener('abort', () => void windDown(), { once: true });
+  // A signal that aborted before the listener went up never fires it; re-read the state after
+  // registering so neither the edge nor the state can be missed.
+  if (signal.aborted) {
+    void windDown();
+  }
 
   const keepAliveMs = sseKeepAliveSeconds() * 1000;
   return new Response(toSseStream(numbered(), { keepAliveMs }), {

--- a/packages/agentserver/src/index.ts
+++ b/packages/agentserver/src/index.ts
@@ -10,7 +10,8 @@
  * The Node adapter is in the `./node` subpath, so the protocol itself stays on Web standards.
  */
 
-export { isHosted, projectEndpoint, stateRoot } from './config.js';
+export { readJsonBody } from './body.js';
+export { isHosted, maxBodyBytes, projectEndpoint, stateRoot } from './config.js';
 export type { RequestContext } from './context.js';
 export {
   createRequestContext,

--- a/packages/agentserver/src/invocations.test.ts
+++ b/packages/agentserver/src/invocations.test.ts
@@ -590,6 +590,37 @@ describe('SSE keep-alive', () => {
     }
   });
 
+  it('does not queue an unbounded number of keep-alives for a slow reader', async () => {
+    vi.stubEnv('SSE_KEEPALIVE_INTERVAL', '1');
+    vi.useFakeTimers();
+    try {
+      const gate = deferred<void>();
+      const server = makeServer({ handler: sseHandler(gate.promise) });
+      const response = await server.handle(invoke());
+      const reader = must(response.body).getReader();
+      const decoder = new TextDecoder();
+
+      expect(decoder.decode((await reader.read()).value)).toBe('data: first\n\n');
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(decoder.decode((await reader.read()).value)).toBe(': keep-alive\n\n');
+
+      let resolved = false;
+      const next = reader.read().then((result) => {
+        resolved = true;
+        return result;
+      });
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(decoder.decode((await next).value)).toBe(': keep-alive\n\n');
+
+      gate.resolve();
+      await reader.cancel();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('propagates a stream failure that lands after keep-alives', async () => {
     vi.stubEnv('SSE_KEEPALIVE_INTERVAL', '1');
     vi.useFakeTimers();

--- a/packages/agentserver/src/observability/main-agent.ts
+++ b/packages/agentserver/src/observability/main-agent.ts
@@ -42,28 +42,20 @@ function attributesOf(span: ApiSpan): Record<string, unknown> {
   return typeof attributes === 'object' && attributes !== null ? (attributes as Record<string, unknown>) : {};
 }
 
-/**
- * The map key for one span. Span ids are unique only within a trace, so the trace id has to be
- * part of the key — two concurrent traces may legally carry the same span id.
- */
-function spanKey(span: { spanContext(): { traceId: string; spanId: string } }): string {
-  const { traceId, spanId } = span.spanContext();
-  return `${traceId}-${spanId}`;
-}
-
 export class GenAIMainAgentSpanProcessor implements SpanProcessor {
   /**
-   * trace+span id → parent span, so {@link onEnd} can retry the copy for children whose parent
-   * attributes were not yet written when the child started. Entries leave when the span ends.
+   * child span → parent span, so {@link onEnd} can retry the copy for children whose parent
+   * attributes were not yet written when the child started. Weak keys also release an abandoned
+   * child that is never ended, instead of retaining it for the lifetime of the process.
    */
-  readonly #parents = new Map<string, ApiSpan>();
+  readonly #parents = new WeakMap<object, ApiSpan>();
 
   onStart(span: Span, parentContext: Context): void {
     const parent = trace.getSpan(parentContext);
     if (parent === undefined || !trace.isSpanContextValid(parent.spanContext())) {
       return;
     }
-    this.#parents.set(spanKey(span), parent);
+    this.#parents.set(span, parent);
 
     const parentAttributes = attributesOf(parent);
     for (const [target, fallback] of PROPAGATION) {
@@ -81,9 +73,8 @@ export class GenAIMainAgentSpanProcessor implements SpanProcessor {
   }
 
   onEnd(span: ReadableSpan): void {
-    const key = spanKey(span);
-    const parent = this.#parents.get(key);
-    this.#parents.delete(key);
+    const parent = this.#parents.get(span);
+    this.#parents.delete(span);
 
     const attributes = span.attributes as Record<string, unknown>;
     const parentAttributes = parent === undefined ? {} : attributesOf(parent);
@@ -137,7 +128,6 @@ export class GenAIMainAgentSpanProcessor implements SpanProcessor {
   }
 
   shutdown(): Promise<void> {
-    this.#parents.clear();
     return Promise.resolve();
   }
 }

--- a/packages/agentserver/src/server.test.ts
+++ b/packages/agentserver/src/server.test.ts
@@ -1,5 +1,5 @@
 import { getEventListeners } from 'node:events';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HEADERS } from './context.js';
 import { ProtocolError } from './errors.js';
 import { partitionKeyOf } from './ids.js';
@@ -99,6 +99,20 @@ describe('routes', () => {
     expect(body.status).toBe('completed');
     expect(body.output).toHaveLength(1);
     expect(JSON.stringify(body.output[0])).toContain('Echo: Hi');
+  });
+
+  it('keeps the response addressable when a conversation alias is stored at capacity one', async () => {
+    const store = new InMemoryResponseProvider({ maxResponses: 1 });
+    const server = new ResponsesServer({ handler: echoHandler(), store, hosted: false });
+    const conversationId = `caresp_${'c'.repeat(18)}${'d'.repeat(32)}`;
+
+    const created = (await (
+      await server.handle(post({ input: 'Hi', conversation: { id: conversationId } }))
+    ).json()) as ResponseObject;
+    const fetched = await server.handle(new Request(`http://localhost:8088/responses/${created.id}`));
+
+    expect(fetched.status).toBe(200);
+    expect(store.size).toBe(1);
   });
 
   it('stamps the agent identity onto every response resource', async () => {
@@ -476,6 +490,30 @@ describe('cross-user isolation', () => {
     ).json()) as ResponseObject;
     expect(JSON.stringify(own.output)).toContain('Echo: mine');
   });
+
+  it('admits only one foreground create for the same response_id', async () => {
+    const gate = Promise.withResolvers<void>();
+    const entered = Promise.withResolvers<void>();
+    let handlerCalls = 0;
+    const server = makeServer(async function* (_request, context) {
+      handlerCalls += 1;
+      entered.resolve();
+      await gate.promise;
+      yield { type: 'response.created', response: context.response };
+      yield { type: 'response.completed', response: { ...context.response, status: 'completed' } };
+    });
+    const id = `caresp_${'a'.repeat(18)}${'b'.repeat(32)}`;
+
+    const first = server.handle(post({ input: 'one', response_id: id }));
+    await entered.promise;
+    const second = server.handle(post({ input: 'two', response_id: id }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    gate.resolve();
+    const responses = await Promise.all([first, second]);
+
+    expect(responses.map((response) => response.status).sort((a, b) => a - b)).toEqual([200, 409]);
+    expect(handlerCalls).toBe(1);
+  });
 });
 
 describe('route-level errors', () => {
@@ -702,6 +740,19 @@ describe('validation', () => {
 });
 
 describe('request limits', () => {
+  it.each([
+    ['maxBodyBytes', 0],
+    ['maxInputItems', Number.NaN],
+  ] as const)('rejects an invalid explicit %s at construction', (name, value) => {
+    expect(
+      () =>
+        new ResponsesServer({
+          handler: echoHandler(),
+          limits: { [name]: value },
+        }),
+    ).toThrow(`${name} must be a safe integer of at least 1`);
+  });
+
   it('answers 413 for a body over the configured bound, before the handler runs', async () => {
     let ran = false;
     const server = new ResponsesServer({
@@ -1487,5 +1538,52 @@ describe('draining', () => {
 
     const probe = await server.handle(new Request('http://localhost:8088/readiness'));
     expect(probe.status).toBe(200);
+  });
+
+  it('releases a committed SSE turn whose body was abandoned without being cancelled', async () => {
+    // `ResponsesServer.fetch` is documented to run on any Web-standard host, and not every host
+    // cancels an abandoned response body: some simply stop reading and abort the request signal.
+    // The stream generator is then parked at a `yield` forever — its `finally` never runs — so the
+    // abort signal, not stream consumption, must be what frees the id and settles the shutdown
+    // wait.
+    const responseId = `caresp_${'a'.repeat(18)}${'b'.repeat(32)}`;
+    const controller = new AbortController();
+    const response = await server.handle(
+      new Request('http://localhost:8088/responses', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ input: 'x', stream: true, store: false, response_id: responseId }),
+        signal: controller.signal,
+      }),
+    );
+    expect(response.status).toBe(200);
+
+    // Pull one chunk so the generator is genuinely parked at a `yield` past the committed 200,
+    // then walk away from the body: no further reads, and — the crux — no cancel.
+    const reader = must(response.body).getReader();
+    await reader.read();
+    reader.releaseLock();
+
+    // While the claim lives, the id answers 409 to its own owner.
+    const conflicted = await server.handle(post({ input: 'y', store: false, response_id: responseId }));
+    expect(conflicted.status).toBe(409);
+    expect(((await conflicted.json()) as { error: { code: string } }).error.code).toBe('response_in_flight');
+
+    controller.abort();
+
+    // The abort alone must free the id: a follow-up create for it stops conflicting …
+    await vi.waitFor(
+      async () => {
+        const retry = await server.handle(post({ input: 'y', store: false, response_id: responseId }));
+        expect(retry.status).toBe(200);
+      },
+      { timeout: 2000, interval: 20 },
+    );
+
+    // … and the shutdown wait settles without anyone ever finishing the stream.
+    await Promise.race([
+      server.drain(),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('drain hung')), 2000)),
+    ]);
   });
 });

--- a/packages/agentserver/src/server.ts
+++ b/packages/agentserver/src/server.ts
@@ -41,7 +41,7 @@ import { resolveAgentReference, resolveAgentSessionId } from './session-id.js';
 import { InMemoryResponseProvider } from './store/memory.js';
 import type { ResponseGeneration, ResponseProvider } from './store/provider.js';
 import { sameOwner } from './store/provider.js';
-import { conversationIdOf, parseCreateRequest, validateResponseId } from './validation.js';
+import { conversationIdOf, parseCreateRequest, positiveLimit, validateResponseId } from './validation.js';
 import type {
   AgentReference,
   CreateResponseRequest,
@@ -180,9 +180,9 @@ export class ResponsesServer {
     this.#onViolation = options.onViolation;
     this.#hosted = options.hosted ?? isHosted();
     this.#limits = {
-      maxBodyBytes: options.limits?.maxBodyBytes ?? maxBodyBytes(),
-      maxInputItems: options.limits?.maxInputItems ?? maxInputItems(),
-      maxStreamEvents: options.limits?.maxStreamEvents ?? maxStreamEvents(),
+      maxBodyBytes: positiveLimit('maxBodyBytes', options.limits?.maxBodyBytes ?? maxBodyBytes()),
+      maxInputItems: positiveLimit('maxInputItems', options.limits?.maxInputItems ?? maxInputItems()),
+      maxStreamEvents: positiveLimit('maxStreamEvents', options.limits?.maxStreamEvents ?? maxStreamEvents()),
     };
     this.#resources = { store: this.#store, claims: this.#claims };
   }
@@ -214,16 +214,16 @@ export class ResponsesServer {
   /**
    * Whether `claim` is still the current holder of `id` — the guard on every deferred write.
    *
-   * `undefined` means the turn never took a claim (a foreground turn), which is always allowed to
-   * write: nothing else can be holding an id it never registered.
+   * Every create takes a claim, foreground turns included: they need the same exclusion as
+   * detached ones or two model/tool runs can share one id.
    */
-  #holds(id: string, claim: IdClaim | undefined): boolean {
-    return claim === undefined || this.#claims.get(id) === claim;
+  #holds(id: string, claim: IdClaim): boolean {
+    return this.#claims.get(id) === claim;
   }
 
   /** Drops `claim`, and only `claim`: whoever holds the id now keeps it. */
-  #releaseClaim(id: string, claim: IdClaim | undefined): void {
-    if (claim !== undefined && this.#claims.get(id) === claim) {
+  #releaseClaim(id: string, claim: IdClaim): void {
+    if (this.#claims.get(id) === claim) {
       this.#claims.delete(id);
     }
   }
@@ -438,10 +438,8 @@ export class ResponsesServer {
     // safe fence: two writers could both call their first turn generation 1. A UUID identifies the
     // turn globally and is round-tripped through both the response and its replay log.
     const generation = crypto.randomUUID();
-    const claim: IdClaim | undefined = background ? newClaim(context.userId, generation) : undefined;
-    if (claim !== undefined) {
-      this.#claims.set(responseId, claim);
-    }
+    const claim = newClaim(context.userId, generation);
+    this.#claims.set(responseId, claim);
 
     try {
       return await this.#createClaimed({
@@ -462,7 +460,7 @@ export class ResponsesServer {
       // run has taken it over the release belongs to that run's teardown, and only to the claim it
       // was given — whoever holds the id now keeps it. The wait goes with it: a claim that never
       // became a run owes nothing, and a `drain()` already holding its promise must not hang on it.
-      if (claim !== undefined && claim.run === undefined) {
+      if (claim.run === undefined) {
         this.#releaseClaim(responseId, claim);
         claim.settle();
       }
@@ -489,7 +487,7 @@ export class ResponsesServer {
     background: boolean;
     responseId: string;
     generation: ResponseGeneration;
-    claim: IdClaim | undefined;
+    claim: IdClaim;
   }): Promise<Response> {
     const { request, context, telemetry, created, conversationId, previousResponseId } = args;
     const { history, background, responseId, generation, claim } = args;
@@ -539,10 +537,17 @@ export class ResponsesServer {
       request.signal.addEventListener('abort', onShutdown, { once: true });
     }
     // `#shutdown.signal` lives as long as the server; a listener left on it after the turn ends
-    // is a leak that grows with every request served. Every exit path below releases both.
+    // is a leak that grows with every request served. Every exit path below releases both. The
+    // paths that share this teardown can each reach it, so every step is idempotent: removing a
+    // removed listener is a no-op, `#releaseClaim` only drops the claim it is given, and a
+    // settled claim stays settled.
     const releaseSignals = (): void => {
       this.#shutdown.signal.removeEventListener('abort', onShutdown);
       request.signal.removeEventListener('abort', onShutdown);
+      if (!background) {
+        this.#releaseClaim(responseId, claim);
+        claim.settle();
+      }
     };
     // `addEventListener` is not a subscription to *state*: an `AbortSignal` that was already
     // aborted never fires again, so a request whose client hung up before this turn was routed —
@@ -678,7 +683,11 @@ export class ResponsesServer {
             // request can resolve it without knowing the response id. Local stores get that from
             // this alias record; a service-linked store resolves the conversation itself (and its
             // alias create would collide with the item ids the service already holds).
-            await this.#store.put({ ...stored, response: { ...response, id: conversationId } });
+            await this.#store.put({
+              ...stored,
+              response: { ...response, id: conversationId },
+              aliasOf: response.id,
+            });
           }
         });
       const persist = async (): Promise<void> => {
@@ -688,9 +697,9 @@ export class ResponsesServer {
         await persistSnapshot(tracker.response);
       };
 
-      // A claim is taken for exactly the background creates, so this *is* the background branch —
-      // written against `claim` rather than `background` because the run it starts needs it.
-      if (claim !== undefined) {
+      // A background run takes ownership of its claim until detached winddown. Foreground turns
+      // release the same kind of claim through `releaseSignals` when collection or SSE ends.
+      if (background) {
         const answer = await startBackground({
           responseId,
           claim,
@@ -719,7 +728,14 @@ export class ResponsesServer {
       if (created.stream === true) {
         // Set only once the 200 is real: a failure before the commit is answered by this request,
         // so this request is what has to flush the spans it produced.
-        const answer = await streamResponse(events, tracker, persist, sessionId, releaseSignals);
+        const answer = await streamResponse(
+          events,
+          tracker,
+          persist,
+          sessionId,
+          releaseSignals,
+          abort.signal,
+        );
         telemetry.deferred = true;
         return answer;
       }

--- a/packages/agentserver/src/sse.ts
+++ b/packages/agentserver/src/sse.ts
@@ -68,7 +68,11 @@ export function toSseStream(
       if (keepAliveMs > 0) {
         keepAlive = setInterval(() => {
           try {
-            controller.enqueue(encoder.encode(SSE_KEEPALIVE));
+            // Keep at most one comment queued. A disconnected or slow client must not turn the
+            // timer into an unbounded memory queue while the source is silent.
+            if ((controller.desiredSize ?? 0) > 0) {
+              controller.enqueue(encoder.encode(SSE_KEEPALIVE));
+            }
           } catch {
             // The stream is already closed; the pull loop will clean up.
           }

--- a/packages/agentserver/src/store/memory.ts
+++ b/packages/agentserver/src/store/memory.ts
@@ -1,4 +1,5 @@
 import { notFound } from '../errors.js';
+import { positiveLimit } from '../validation.js';
 import type { OutputItem, ResponseEvent } from '../wire.js';
 import type { ResponseGeneration, ResponseOwner, ResponseProvider, StoredResponse } from './provider.js';
 import {
@@ -41,21 +42,74 @@ interface StoredEvents {
  */
 export class InMemoryResponseProvider implements ResponseProvider {
   readonly #responses = new Map<string, StoredResponse>();
+  /** Conversation ids are indexes over responses, not responses in the retention budget. */
+  readonly #aliases = new Map<string, StoredResponse>();
+  /**
+   * Which alias ids point at each response — the reverse of `#aliases`' `aliasOf` edges, kept in
+   * step by every write to that map. It is what makes dropping one response's aliases cost only
+   * those aliases: a scan of `#aliases` instead would run on every delete and, once the store
+   * sits at its cap, on every insert.
+   */
+  readonly #aliasIdsFor = new Map<string, Set<string>>();
   /** Replayable background streams, keyed by response id. Bounded by the same cap as responses. */
   readonly #events = new Map<string, StoredEvents>();
   readonly #maxResponses: number;
 
   constructor(options: InMemoryResponseProviderConfig = {}) {
-    this.#maxResponses = options.maxResponses ?? 10_000;
+    this.#maxResponses = positiveLimit('maxResponses', options.maxResponses ?? 10_000);
+  }
+
+  #lookup(id: string): StoredResponse | undefined {
+    return this.#responses.get(id) ?? this.#aliases.get(id);
+  }
+
+  /** Stores `stored` as an alias of `target`, moving the reverse edge when the id is re-pointed. */
+  #setAlias(id: string, stored: StoredResponse, target: string): void {
+    const previous = this.#aliases.get(id)?.aliasOf;
+    if (previous !== undefined && previous !== target) {
+      // The id no longer speaks for its old target; left indexed, dropping that target's aliases
+      // would take this one along even though it points somewhere else now.
+      this.#unindexAlias(id, previous);
+    }
+    this.#aliases.set(id, stored);
+    let ids = this.#aliasIdsFor.get(target);
+    if (ids === undefined) {
+      ids = new Set();
+      this.#aliasIdsFor.set(target, ids);
+    }
+    ids.add(id);
+  }
+
+  /** Removes one reverse edge, and the target's whole entry once no alias points at it. */
+  #unindexAlias(id: string, target: string): void {
+    const ids = this.#aliasIdsFor.get(target);
+    if (ids === undefined) {
+      return;
+    }
+    ids.delete(id);
+    if (ids.size === 0) {
+      this.#aliasIdsFor.delete(target);
+    }
+  }
+
+  #dropAliasesFor(responseId: string): void {
+    const ids = this.#aliasIdsFor.get(responseId);
+    if (ids === undefined) {
+      return;
+    }
+    this.#aliasIdsFor.delete(responseId);
+    for (const id of ids) {
+      this.#aliases.delete(id);
+    }
   }
 
   async get(id: string, owner: ResponseOwner): Promise<StoredResponse | undefined> {
-    return ownedOrUndefined(this.#responses.get(id), owner);
+    return ownedOrUndefined(this.#lookup(id), owner);
   }
 
   async assertWritable(id: string, owner: ResponseOwner): Promise<void> {
     // The same rule `put` applies, run before the turn does any work.
-    assertOwnerCanWrite(this.#responses.get(id), id, owner);
+    assertOwnerCanWrite(this.#lookup(id), id, owner);
   }
 
   /**
@@ -71,12 +125,21 @@ export class InMemoryResponseProvider implements ResponseProvider {
       }
       map.delete(oldest);
       alsoDrop?.delete(oldest);
+      if (map === this.#responses) this.#dropAliasesFor(oldest);
     }
   }
 
   async put(stored: StoredResponse): Promise<void> {
     const id = stored.response.id;
-    assertWritable(this.#responses.get(id), stored);
+    assertWritable(this.#lookup(id), stored);
+    if (stored.aliasOf !== undefined) {
+      this.#setAlias(id, stored, stored.aliasOf);
+      return;
+    }
+    const existing = this.#responses.get(id);
+    if (existing !== undefined && existing.generation !== stored.generation) {
+      this.#dropAliasesFor(id);
+    }
     // Overwriting an existing id does not grow the map, so only a genuinely new entry evicts.
     if (!this.#responses.has(id)) {
       this.#evictOldest(this.#responses, this.#events);
@@ -122,11 +185,21 @@ export class InMemoryResponseProvider implements ResponseProvider {
   }
 
   async delete(id: string, owner: ResponseOwner): Promise<boolean> {
-    if (ownedOrUndefined(this.#responses.get(id), owner) === undefined) {
+    const stored = ownedOrUndefined(this.#lookup(id), owner);
+    if (stored === undefined) {
       return false;
+    }
+    const alias = this.#aliases.get(id);
+    if (alias !== undefined) {
+      if (alias.aliasOf !== undefined) {
+        // Only `#setAlias` writes this map, so the edge is always there; the guard is for the type.
+        this.#unindexAlias(id, alias.aliasOf);
+      }
+      return this.#aliases.delete(id);
     }
     // The replay log is part of the response; a deleted response must not remain replayable.
     this.#events.delete(id);
+    this.#dropAliasesFor(id);
     return this.#responses.delete(id);
   }
 

--- a/packages/agentserver/src/store/provider.ts
+++ b/packages/agentserver/src/store/provider.ts
@@ -7,6 +7,8 @@ export type ResponseGeneration = string;
 /** A stored response plus what the protocol needs that is not on the resource itself. */
 export interface StoredResponse {
   response: ResponseObject;
+  /** Local-store alias target when this record is addressed by a conversation id. */
+  aliasOf?: string;
   /** The request's input items, for `GET /responses/{id}/input_items`. */
   inputItems?: OutputItem[];
   /** The user this response belongs to, for cross-user isolation. */

--- a/packages/agentserver/src/store/store.test.ts
+++ b/packages/agentserver/src/store/store.test.ts
@@ -34,6 +34,13 @@ function stored(id: string, userId?: string, generation: ResponseGeneration = GE
 }
 
 describe('InMemoryResponseProvider eviction', () => {
+  it('rejects a non-positive or non-integral response cap', () => {
+    expect(() => new InMemoryResponseProvider({ maxResponses: 0 })).toThrow(/maxResponses.*at least 1/i);
+    expect(() => new InMemoryResponseProvider({ maxResponses: Number.NaN })).toThrow(
+      /maxResponses.*integer/i,
+    );
+  });
+
   it('evicts the oldest response once the cap is reached', async () => {
     const provider = new InMemoryResponseProvider({ maxResponses: 2 });
 
@@ -68,6 +75,43 @@ describe('InMemoryResponseProvider eviction', () => {
     await provider.put(stored('caresp_b'));
 
     expect(await provider.getEvents('caresp_a', undefined, GENERATION)).toBeUndefined();
+  });
+
+  it('keeps an alias that moved to a new response when its old target goes away', async () => {
+    const provider = new InMemoryResponseProvider({ maxResponses: 2 });
+    const conversationId = 'caconv_moved';
+
+    // The alias points at turn one, then at turn two — what every follow-up turn of one
+    // conversation does to the conversation-id alias.
+    await provider.put(stored('caresp_one'));
+    await provider.put({ ...stored(conversationId), aliasOf: 'caresp_one' });
+    await provider.put(stored('caresp_two'));
+    await provider.put({ ...stored(conversationId), aliasOf: 'caresp_two' });
+
+    // A third response evicts turn one. The alias left it before the eviction, so dropping turn
+    // one's aliases must not take it along.
+    await provider.put(stored('caresp_three'));
+    expect(await provider.get('caresp_one', undefined)).toBeUndefined();
+    expect((await provider.get(conversationId, undefined))?.aliasOf).toBe('caresp_two');
+
+    // Its *current* target still owns it: deleting turn two takes the alias with it.
+    expect(await provider.delete('caresp_two', undefined)).toBe(true);
+    expect(await provider.get(conversationId, undefined)).toBeUndefined();
+  });
+
+  it('detaches a directly deleted alias from its target', async () => {
+    const provider = new InMemoryResponseProvider();
+
+    await provider.put(stored('caresp_kept'));
+    await provider.put({ ...stored('caconv_gone'), aliasOf: 'caresp_kept' });
+    expect(await provider.delete('caconv_gone', undefined)).toBe(true);
+
+    // Re-pointing the freed alias id elsewhere must survive the old target's departure: the
+    // deleted alias record no longer speaks for it.
+    await provider.put(stored('caresp_other'));
+    await provider.put({ ...stored('caconv_gone'), aliasOf: 'caresp_other' });
+    expect(await provider.delete('caresp_kept', undefined)).toBe(true);
+    expect((await provider.get('caconv_gone', undefined))?.aliasOf).toBe('caresp_other');
   });
 });
 

--- a/packages/agentserver/src/validation.ts
+++ b/packages/agentserver/src/validation.ts
@@ -18,6 +18,22 @@ const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
 /** `agent_session_id` is answered on the `x-agent-session-id` header, so it must be a header-safe token. */
 const SESSION_ID_SHAPE = /^[ -~]+$/;
 
+/**
+ * Validates a configured capacity bound and hands it back.
+ *
+ * Every limit this server enforces — event retention, response retention, body size overrides —
+ * is a count that bounds memory, so a zero, negative, fractional or unsafe value is a
+ * misconfiguration to refuse at construction, not a setting to serve under.
+ *
+ * @throws {RangeError} When `value` is not a safe integer of at least 1.
+ */
+export function positiveLimit(name: string, value: number): number {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new RangeError(`${name} must be a safe integer of at least 1.`);
+  }
+  return value;
+}
+
 /** The conversation id a request refers to, in either of the two shapes the field allows. */
 export function conversationIdOf(request: CreateResponseRequest): string | undefined {
   const conversation = request.conversation;

--- a/packages/anthropic/src/chat-client.test.ts
+++ b/packages/anthropic/src/chat-client.test.ts
@@ -132,6 +132,21 @@ describe('request mapping', () => {
     expect(request.max_tokens).toBe(1024);
   });
 
+  it.each([
+    { type: 'enabled' },
+    { type: 'enabled', budgetTokens: 1023 },
+    { type: 'enabled', budgetTokens: 2048.5 },
+    { type: 'enabled', budgetTokens: Number.POSITIVE_INFINITY },
+    { type: 'disabled', budgetTokens: 2048 },
+  ])('rejects an invalid thinking configuration ($type, $budgetTokens)', (thinking) => {
+    const { client } = clientWith([message('hi')]);
+    expect(() =>
+      client.buildRequest([{ role: 'user', contents: [textContent('hello')] }], {
+        thinking: thinking as never,
+      }),
+    ).toThrow(ConfigurationError);
+  });
+
   it('drops options the Messages API has no equivalent for', () => {
     const { client } = clientWith([message('hi')]);
     const request = client.buildRequest([{ role: 'user', contents: [textContent('hello')] }], {
@@ -520,6 +535,51 @@ describe('response parsing', () => {
     expect(contents[1]).toMatchObject({ type: 'function_call', callId: 'call_1', name: 'search' });
     expect(contents[2]).toMatchObject({ type: 'function_call', informationalOnly: true });
     expect(contents[3]).toMatchObject({ type: 'unknown', unknownType: 'future_block' });
+  });
+
+  it('maps Anthropic text citations to framework annotations', () => {
+    const response = parseMessage({
+      id: 'msg_citations',
+      role: 'assistant',
+      content: [
+        {
+          type: 'text',
+          text: 'Cited answer',
+          citations: [
+            {
+              type: 'char_location',
+              title: 'Source document',
+              cited_text: 'supporting text',
+              file_id: 'file-1',
+              start_char_index: 4,
+              end_char_index: 19,
+            },
+            {
+              type: 'web_search_result_location',
+              title: 'Web source',
+              cited_text: 'web snippet',
+              url: 'https://example.test/source',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(response.messages[0]?.contents[0]?.annotations).toEqual([
+      expect.objectContaining({
+        type: 'citation',
+        title: 'Source document',
+        snippet: 'supporting text',
+        fileId: 'file-1',
+        annotatedRegions: [{ type: 'text_span', startIndex: 4, endIndex: 19 }],
+      }),
+      expect.objectContaining({
+        type: 'citation',
+        title: 'Web source',
+        snippet: 'web snippet',
+        url: 'https://example.test/source',
+      }),
+    ]);
   });
 
   it('parses an MCP call and its result', () => {

--- a/packages/anthropic/src/chat-client.ts
+++ b/packages/anthropic/src/chat-client.ts
@@ -189,6 +189,26 @@ export class AnthropicChatClient
     // Framework option names are camelCase; rebuild the snake_case wire form here.
     const thinking = options?.thinking;
     if (thinking !== undefined) {
+      // Re-read through an unknown-shaped view: JavaScript callers and deserialized config can
+      // violate the public discriminated union, and must still fail locally rather than at HTTP.
+      const rawThinking = thinking as { type?: unknown; budgetTokens?: unknown };
+      if (rawThinking.type === 'enabled') {
+        if (
+          typeof rawThinking.budgetTokens !== 'number' ||
+          !Number.isSafeInteger(rawThinking.budgetTokens) ||
+          rawThinking.budgetTokens < 1024
+        ) {
+          throw new ConfigurationError(
+            'thinking.budgetTokens must be a safe integer of at least 1024 when thinking is enabled.',
+          );
+        }
+      } else if (rawThinking.type === 'disabled') {
+        if (rawThinking.budgetTokens !== undefined) {
+          throw new ConfigurationError('thinking.budgetTokens must be omitted when thinking is disabled.');
+        }
+      } else {
+        throw new ConfigurationError(`Unsupported Anthropic thinking type '${String(rawThinking.type)}'.`);
+      }
       const { budgetTokens, ...thinkingRest } = thinking;
       request.thinking = {
         ...thinkingRest,

--- a/packages/anthropic/src/from-anthropic.ts
+++ b/packages/anthropic/src/from-anthropic.ts
@@ -1,4 +1,5 @@
 import type {
+  Annotation,
   ChatResponse,
   ChatResponseUpdate,
   Content,
@@ -33,6 +34,67 @@ function parseFinishReason(stopReason: unknown): FinishReason | undefined {
 
 function asNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+/** Maps the citation metadata attached to a complete Anthropic text block. */
+function parseCitations(block: AnthropicBlock): Annotation[] | undefined {
+  if (!Array.isArray(block.citations) || block.citations.length === 0) {
+    return undefined;
+  }
+  const annotations: Annotation[] = [];
+  for (const candidate of block.citations) {
+    if (typeof candidate !== 'object' || candidate === null) continue;
+    const citation = candidate as AnthropicBlock;
+    const annotation: Annotation = {
+      type: 'citation',
+      rawRepresentation: candidate,
+    };
+    const snippet = typeof citation.cited_text === 'string' ? citation.cited_text : undefined;
+    if (snippet !== undefined) annotation.snippet = snippet;
+    if (typeof citation.file_id === 'string' && citation.file_id !== '') annotation.fileId = citation.file_id;
+
+    let start: number | undefined;
+    let end: number | undefined;
+    switch (citation.type) {
+      case 'char_location':
+        if (typeof citation.title === 'string') annotation.title = citation.title;
+        start = asNumber(citation.start_char_index);
+        end = asNumber(citation.end_char_index);
+        break;
+      case 'page_location':
+        if (typeof citation.document_title === 'string') annotation.title = citation.document_title;
+        start = asNumber(citation.start_page_number);
+        end = asNumber(citation.end_page_number);
+        break;
+      case 'content_block_location':
+        if (typeof citation.document_title === 'string') annotation.title = citation.document_title;
+        start = asNumber(citation.start_block_index);
+        end = asNumber(citation.end_block_index);
+        break;
+      case 'web_search_result_location':
+      case 'web_fetch_result_location':
+        if (typeof citation.title === 'string') annotation.title = citation.title;
+        if (typeof citation.url === 'string') annotation.url = citation.url;
+        break;
+      case 'search_result_location':
+        if (typeof citation.title === 'string') annotation.title = citation.title;
+        if (typeof citation.source === 'string') annotation.url = citation.source;
+        start = asNumber(citation.start_block_index);
+        end = asNumber(citation.end_block_index);
+        break;
+    }
+    if (start !== undefined || end !== undefined) {
+      annotation.annotatedRegions = [
+        {
+          type: 'text_span',
+          ...(start === undefined ? {} : { startIndex: start }),
+          ...(end === undefined ? {} : { endIndex: end }),
+        },
+      ];
+    }
+    annotations.push(annotation);
+  }
+  return annotations.length === 0 ? undefined : annotations;
 }
 
 /**
@@ -166,9 +228,11 @@ export function parseContentBlocks(blocks: readonly unknown[], state?: StreamPar
     switch (block.type) {
       case 'text':
       case 'text_delta': {
+        const annotations = block.type === 'text' ? parseCitations(block) : undefined;
         contents.push({
           type: 'text',
           text: String(block.text ?? ''),
+          ...(annotations === undefined ? {} : { annotations }),
           rawRepresentation: block,
         });
         break;
@@ -334,6 +398,20 @@ export function parseStreamEvent(event: unknown, state: StreamParseState): ChatR
     case 'content_block_start':
     case 'content_block_delta': {
       const block = raw.type === 'content_block_start' ? raw.content_block : raw.delta;
+      if (raw.type === 'content_block_delta') {
+        const deltaType = (block as AnthropicBlock | null | undefined)?.type;
+        if (
+          deltaType !== 'text_delta' &&
+          deltaType !== 'thinking_delta' &&
+          deltaType !== 'signature_delta' &&
+          deltaType !== 'input_json_delta'
+        ) {
+          // A delta is a fragment, not a replayable Messages API content block. Preserving an
+          // unknown fragment as UnknownContent would send that fragment as a whole block on the
+          // next turn and permanently poison the transcript.
+          return undefined;
+        }
+      }
       const contents = parseContentBlocks([block], state);
       return contents.length === 0
         ? undefined

--- a/packages/anthropic/src/from-anthropic.wire-fallbacks.test.ts
+++ b/packages/anthropic/src/from-anthropic.wire-fallbacks.test.ts
@@ -165,6 +165,20 @@ describe('stream event fallbacks', () => {
     expect(parseStreamEvent({ type: 'content_block_delta' }, state)).toBeUndefined();
   });
 
+  it('does not persist an unknown delta fragment as a replayable content block', () => {
+    const event = {
+      type: 'content_block_delta',
+      delta: { type: 'citations_delta', citation: { url: 'https://example.test/source' } },
+    };
+
+    expect(parseStreamEvent(event, createStreamParseState())).toBeUndefined();
+    // Whole unknown blocks remain forward-compatible and round-trip as before.
+    expect(parseContentBlocks([{ type: 'future_block', value: 1 }])[0]).toMatchObject({
+      type: 'unknown',
+      unknownType: 'future_block',
+    });
+  });
+
   it('parses a message_start without a message as an empty update', () => {
     const update = parseStreamEvent({ type: 'message_start' }, createStreamParseState());
     expect(update?.contents).toEqual([]);

--- a/packages/anthropic/src/hosted-tools.test.ts
+++ b/packages/anthropic/src/hosted-tools.test.ts
@@ -1,7 +1,7 @@
 import { supportsMcp, supportsWebSearch, textContent } from '@polymind-inc/agent-framework-core';
 import { describe, expect, it } from 'vitest';
 import { AnthropicChatClient } from './chat-client.js';
-import { webSearchTool } from './hosted-tools.js';
+import { mcpTool, webSearchTool } from './hosted-tools.js';
 
 function client(): AnthropicChatClient {
   const fake = { beta: { messages: { create: () => Promise.resolve({}) } } };
@@ -56,6 +56,18 @@ describe('hosted tool capability protocol', () => {
   it('delegates getWebSearchTool to the factory', () => {
     const declared = client().getWebSearchTool({ userLocation: { country: 'JP' } });
     expect(declared).toEqual(webSearchTool({ userLocation: { country: 'JP' } }));
+  });
+});
+
+describe('MCP tool declaration', () => {
+  it('reads Authorization case-insensitively', () => {
+    expect(
+      mcpTool({
+        serverLabel: 'docs',
+        serverUrl: 'https://mcp.example',
+        headers: { Authorization: 'Bearer secret' },
+      }).spec,
+    ).toMatchObject({ authorization_token: 'Bearer secret' });
   });
 });
 

--- a/packages/anthropic/src/hosted-tools.ts
+++ b/packages/anthropic/src/hosted-tools.ts
@@ -55,7 +55,10 @@ export function mcpTool(options: McpToolOptions): HostedTool {
   // openai package. Only spaces are replaced — matching the reference implementation exactly rather
   // than sanitising every character the API might dislike.
   const serverLabel = options.serverLabel.replaceAll(' ', '_');
-  const authorization = options.headers?.authorization;
+  const authorizationEntry = Object.entries(options.headers ?? {}).find(
+    ([name]) => name.toLowerCase() === 'authorization',
+  );
+  const authorization = authorizationEntry?.[1];
   return hostedTool(
     serverLabel,
     withoutUndefined({

--- a/packages/anthropic/src/integration.test.ts
+++ b/packages/anthropic/src/integration.test.ts
@@ -1,7 +1,8 @@
 /**
  * Integration tests against the real Anthropic Messages API.
  *
- * Skipped unless `ANTHROPIC_API_KEY` is set, so `pnpm -r test` stays offline by default.
+ * Skipped unless `RUN_INTEGRATION_TESTS=1` and `ANTHROPIC_API_KEY` are set, so ordinary test runs
+ * stay offline.
  *
  * - `ANTHROPIC_API_KEY` — the API key
  * - `ANTHROPIC_MODEL` — model to use (default `claude-haiku-4-5-20251001`, the cheapest current one)
@@ -44,189 +45,192 @@ const client = (override?: string): AnthropicChatClient =>
 const contentsOf = (response: { messages: Array<{ contents: Content[] }> }): Content[] =>
   response.messages.flatMap((message) => message.contents);
 
-describe.runIf(apiKey !== undefined && apiKey !== '')('Anthropic (integration)', () => {
-  it('answers a basic prompt and reports usage', { timeout: TIMEOUT }, async () => {
-    const response = await new Agent({ client: client() }).run('Reply with the single word: pong');
+describe.runIf(process.env.RUN_INTEGRATION_TESTS === '1' && apiKey !== undefined && apiKey !== '')(
+  'Anthropic (integration)',
+  () => {
+    it('answers a basic prompt and reports usage', { timeout: TIMEOUT }, async () => {
+      const response = await new Agent({ client: client() }).run('Reply with the single word: pong');
 
-    expect(response.text.toLowerCase()).toContain('pong');
-    expect(response.usageDetails?.inputTokenCount).toBeGreaterThan(0);
-    expect(response.usageDetails?.outputTokenCount).toBeGreaterThan(0);
-  });
-
-  it('runs the tool loop, replaying the call and result as the API demands', {
-    timeout: TIMEOUT,
-  }, async () => {
-    let executed = 0;
-    const getWeather = tool({
-      name: 'get_weather',
-      description: 'Get the current weather for a location',
-      parameters: {
-        type: 'object',
-        properties: { location: { type: 'string' } },
-        required: ['location'],
-        additionalProperties: false,
-      },
-      execute: async () => {
-        executed++;
-        return 'Sunny, 25C';
-      },
+      expect(response.text.toLowerCase()).toContain('pong');
+      expect(response.usageDetails?.inputTokenCount).toBeGreaterThan(0);
+      expect(response.usageDetails?.outputTokenCount).toBeGreaterThan(0);
     });
 
-    const agent = new Agent({ client: client(), tools: [getWeather] });
-    const response = await agent.run("What's the weather in Tokyo? Use the tool.");
-
-    // The second request carries the tool_use on an assistant turn and the tool_result on a user
-    // turn; the service rejects the request outright if that regrouping is wrong.
-    expect(executed).toBe(1);
-    expect(response.text).not.toBe('');
-  });
-
-  it('produces the same transcript streamed as awaited', { timeout: TIMEOUT }, async () => {
-    const prompt = 'List exactly three Japanese cities, comma separated, nothing else.';
-    const messages = [{ role: 'user' as const, contents: [textContent(prompt)] }];
-
-    const awaited = await client().getResponse(messages, { temperature: 0 });
-
-    const stream = client().getResponse(messages, { temperature: 0 });
-    const updates = [];
-    for await (const update of stream) {
-      updates.push(update);
-    }
-    const folded = await stream.finalResponse();
-    const refolded = mergeChatUpdates(updates);
-
-    // Invariant: how the caller consumed the response cannot change what it contains.
-    expect(folded.messages.flatMap((m) => m.contents.map((c) => c.type))).toEqual(
-      awaited.messages.flatMap((m) => m.contents.map((c) => c.type)),
-    );
-    expect(refolded.text).toBe(folded.text);
-    expect(folded.finishReason).toBe(awaited.finishReason);
-    expect(folded.model).toBe(awaited.model);
-  });
-
-  it('turns cumulative streamed usage into a correct total', { timeout: TIMEOUT }, async () => {
-    const stream = client().getResponse([
-      { role: 'user', contents: [textContent('Count from 1 to 20, numbers only.')] },
-    ]);
-    const perUpdate: number[] = [];
-    for await (const update of stream) {
-      for (const content of update.contents) {
-        if (content.type === 'usage') {
-          perUpdate.push(content.usageDetails.outputTokenCount ?? 0);
-        }
-      }
-    }
-    const folded = await stream.finalResponse();
-
-    // Anthropic streams a running total; the client emits increments so the fold sums back to the
-    // real figure instead of double-counting the seed.
-    expect(perUpdate.length).toBeGreaterThan(1);
-    const summed = perUpdate.reduce((total, value) => total + value, 0);
-    expect(folded.usageDetails?.outputTokenCount).toBe(summed);
-    expect(summed).toBeGreaterThan(10);
-    console.log(`[usage] increments=${JSON.stringify(perUpdate)} total=${summed}`);
-  });
-
-  it('round-trips extended thinking, signature included', { timeout: TIMEOUT }, async () => {
-    const agent = new Agent({ client: client(thinkingModel) });
-    const session = agent.createSession();
-
-    const first = await agent.run('What is 17 * 23? Think it through, then give the number.', {
-      session,
-      options: { maxTokens: 3000, thinking: { type: 'enabled', budgetTokens: 2000 } },
-    });
-
-    const reasoning = contentsOf(first).filter(
-      (content): content is TextReasoningContent => content.type === 'text_reasoning',
-    );
-    expect(reasoning.length).toBeGreaterThan(0);
-    // The opaque signature is what makes a replayed thinking block acceptable to the service.
-    expect(reasoning.some((content) => typeof content.protectedData === 'string')).toBe(true);
-    expect(first.text).toContain('391');
-
-    // The follow-up replays the thinking, signature and all. A broken thinking-block mapping
-    // fails here with a 400 rather than silently degrading.
-    const second = await agent.run('Now multiply that result by 2.', {
-      session,
-      options: { maxTokens: 3000, thinking: { type: 'enabled', budgetTokens: 2000 } },
-    });
-    expect(second.text).toContain('782');
-  });
-
-  it('parses structured output through output_config.format', { timeout: TIMEOUT }, async () => {
-    const response = await new Agent({ client: client() }).run('Where is Mount Fuji?', {
-      responseFormat: {
-        name: 'location',
-        schema: {
+    it('runs the tool loop, replaying the call and result as the API demands', {
+      timeout: TIMEOUT,
+    }, async () => {
+      let executed = 0;
+      const getWeather = tool({
+        name: 'get_weather',
+        description: 'Get the current weather for a location',
+        parameters: {
           type: 'object',
-          properties: { country: { type: 'string' }, prefecture: { type: 'string' } },
-          required: ['country', 'prefecture'],
+          properties: { location: { type: 'string' } },
+          required: ['location'],
           additionalProperties: false,
         },
-      },
+        execute: async () => {
+          executed++;
+          return 'Sunny, 25C';
+        },
+      });
+
+      const agent = new Agent({ client: client(), tools: [getWeather] });
+      const response = await agent.run("What's the weather in Tokyo? Use the tool.");
+
+      // The second request carries the tool_use on an assistant turn and the tool_result on a user
+      // turn; the service rejects the request outright if that regrouping is wrong.
+      expect(executed).toBe(1);
+      expect(response.text).not.toBe('');
     });
 
-    expect(response.value).toBeDefined();
-    expect(String((response.value as { country: string }).country)).not.toBe('');
-    console.log('[structured]', JSON.stringify(response.value));
-  });
+    it('produces the same transcript streamed as awaited', { timeout: TIMEOUT }, async () => {
+      const prompt = 'List exactly three Japanese cities, comma separated, nothing else.';
+      const messages = [{ role: 'user' as const, contents: [textContent(prompt)] }];
 
-  it('sends an image and gets a description of it', { timeout: TIMEOUT }, async () => {
-    // A 64×64 solid-red PNG, so the answer is checkable. Big enough for the service to accept it:
-    // a 2×2 image is rejected with "Could not process image".
-    const red =
-      'iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAeUlEQVR4nO3PQQkAMAzAwIqof2UTMxF7HINABFzm7H7dcEEDWtCAFjSgBQ1oQQNa0IAWNKAFDWhBA1rQgBY0oAUNaEEDWtCAFjSgBQ1oQQNa0IAWNKAFDWhBA1rQgBY0oAUNaEEDWtCAFjSgBQ1oQQNa0IAWNKAFj12qxUDxeFqrFAAAAABJRU5ErkJggg==';
-    const response = await new Agent({ client: client() }).run([
-      {
-        role: 'user',
-        contents: [
-          textContent('What single colour is this image? Answer with one word.'),
-          { type: 'data', uri: `data:image/png;base64,${red}`, mediaType: 'image/png' },
-        ],
-      },
-    ]);
+      const awaited = await client().getResponse(messages, { temperature: 0 });
 
-    console.log('[image]', response.text);
-    expect(response.text.toLowerCase()).toContain('red');
-  });
+      const stream = client().getResponse(messages, { temperature: 0 });
+      const updates = [];
+      for await (const update of stream) {
+        updates.push(update);
+      }
+      const folded = await stream.finalResponse();
+      const refolded = mergeChatUpdates(updates);
 
-  it('surfaces a tool that needs approval, then runs it once approved', { timeout: TIMEOUT }, async () => {
-    let executed = 0;
-    const transfer = tool({
-      name: 'transfer_funds',
-      description: 'Transfer money between accounts',
-      parameters: {
-        type: 'object',
-        properties: { amount: { type: 'number' } },
-        required: ['amount'],
-        additionalProperties: false,
-      },
-      approvalMode: 'always_require',
-      execute: async () => {
-        executed++;
-        return 'transfer complete';
-      },
+      // Invariant: how the caller consumed the response cannot change what it contains.
+      expect(folded.messages.flatMap((m) => m.contents.map((c) => c.type))).toEqual(
+        awaited.messages.flatMap((m) => m.contents.map((c) => c.type)),
+      );
+      expect(refolded.text).toBe(folded.text);
+      expect(folded.finishReason).toBe(awaited.finishReason);
+      expect(folded.model).toBe(awaited.model);
     });
 
-    const agent = new Agent({ client: client(), tools: [transfer] });
-    const session = agent.createSession();
+    it('turns cumulative streamed usage into a correct total', { timeout: TIMEOUT }, async () => {
+      const stream = client().getResponse([
+        { role: 'user', contents: [textContent('Count from 1 to 20, numbers only.')] },
+      ]);
+      const perUpdate: number[] = [];
+      for await (const update of stream) {
+        for (const content of update.contents) {
+          if (content.type === 'usage') {
+            perUpdate.push(content.usageDetails.outputTokenCount ?? 0);
+          }
+        }
+      }
+      const folded = await stream.finalResponse();
 
-    // The tool choice is forced so the test measures the framework rather than whether this
-    // particular model felt like calling a tool; it also exercises the `{required:[name]}` →
-    // `{type:'tool', name}` mapping against the live API.
-    const pending = await agent.run('Transfer 500.', {
-      session,
-      options: { toolChoice: { required: ['transfer_funds'] } },
+      // Anthropic streams a running total; the client emits increments so the fold sums back to the
+      // real figure instead of double-counting the seed.
+      expect(perUpdate.length).toBeGreaterThan(1);
+      const summed = perUpdate.reduce((total, value) => total + value, 0);
+      expect(folded.usageDetails?.outputTokenCount).toBe(summed);
+      expect(summed).toBeGreaterThan(10);
+      console.log(`[usage] increments=${JSON.stringify(perUpdate)} total=${summed}`);
     });
-    expect(pending.userInputRequests).toHaveLength(1);
-    expect(executed).toBe(0);
 
-    const resumed = await agent.run(
-      approvalResponse(pending.userInputRequests[0] as FunctionApprovalRequestContent, true),
-      { session },
-    );
+    it('round-trips extended thinking, signature included', { timeout: TIMEOUT }, async () => {
+      const agent = new Agent({ client: client(thinkingModel) });
+      const session = agent.createSession();
 
-    expect(executed).toBe(1);
-    expect(resumed.text).not.toBe('');
-  });
-});
+      const first = await agent.run('What is 17 * 23? Think it through, then give the number.', {
+        session,
+        options: { maxTokens: 3000, thinking: { type: 'enabled', budgetTokens: 2000 } },
+      });
+
+      const reasoning = contentsOf(first).filter(
+        (content): content is TextReasoningContent => content.type === 'text_reasoning',
+      );
+      expect(reasoning.length).toBeGreaterThan(0);
+      // The opaque signature is what makes a replayed thinking block acceptable to the service.
+      expect(reasoning.some((content) => typeof content.protectedData === 'string')).toBe(true);
+      expect(first.text).toContain('391');
+
+      // The follow-up replays the thinking, signature and all. A broken thinking-block mapping
+      // fails here with a 400 rather than silently degrading.
+      const second = await agent.run('Now multiply that result by 2.', {
+        session,
+        options: { maxTokens: 3000, thinking: { type: 'enabled', budgetTokens: 2000 } },
+      });
+      expect(second.text).toContain('782');
+    });
+
+    it('parses structured output through output_config.format', { timeout: TIMEOUT }, async () => {
+      const response = await new Agent({ client: client() }).run('Where is Mount Fuji?', {
+        responseFormat: {
+          name: 'location',
+          schema: {
+            type: 'object',
+            properties: { country: { type: 'string' }, prefecture: { type: 'string' } },
+            required: ['country', 'prefecture'],
+            additionalProperties: false,
+          },
+        },
+      });
+
+      expect(response.value).toBeDefined();
+      expect(String((response.value as { country: string }).country)).not.toBe('');
+      console.log('[structured]', JSON.stringify(response.value));
+    });
+
+    it('sends an image and gets a description of it', { timeout: TIMEOUT }, async () => {
+      // A 64×64 solid-red PNG, so the answer is checkable. Big enough for the service to accept it:
+      // a 2×2 image is rejected with "Could not process image".
+      const red =
+        'iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAeUlEQVR4nO3PQQkAMAzAwIqof2UTMxF7HINABFzm7H7dcEEDWtCAFjSgBQ1oQQNa0IAWNKAFDWhBA1rQgBY0oAUNaEEDWtCAFjSgBQ1oQQNa0IAWNKAFDWhBA1rQgBY0oAUNaEEDWtCAFjSgBQ1oQQNa0IAWNKAFj12qxUDxeFqrFAAAAABJRU5ErkJggg==';
+      const response = await new Agent({ client: client() }).run([
+        {
+          role: 'user',
+          contents: [
+            textContent('What single colour is this image? Answer with one word.'),
+            { type: 'data', uri: `data:image/png;base64,${red}`, mediaType: 'image/png' },
+          ],
+        },
+      ]);
+
+      console.log('[image]', response.text);
+      expect(response.text.toLowerCase()).toContain('red');
+    });
+
+    it('surfaces a tool that needs approval, then runs it once approved', { timeout: TIMEOUT }, async () => {
+      let executed = 0;
+      const transfer = tool({
+        name: 'transfer_funds',
+        description: 'Transfer money between accounts',
+        parameters: {
+          type: 'object',
+          properties: { amount: { type: 'number' } },
+          required: ['amount'],
+          additionalProperties: false,
+        },
+        approvalMode: 'always_require',
+        execute: async () => {
+          executed++;
+          return 'transfer complete';
+        },
+      });
+
+      const agent = new Agent({ client: client(), tools: [transfer] });
+      const session = agent.createSession();
+
+      // The tool choice is forced so the test measures the framework rather than whether this
+      // particular model felt like calling a tool; it also exercises the `{required:[name]}` →
+      // `{type:'tool', name}` mapping against the live API.
+      const pending = await agent.run('Transfer 500.', {
+        session,
+        options: { toolChoice: { required: ['transfer_funds'] } },
+      });
+      expect(pending.userInputRequests).toHaveLength(1);
+      expect(executed).toBe(0);
+
+      const resumed = await agent.run(
+        approvalResponse(pending.userInputRequests[0] as FunctionApprovalRequestContent, true),
+        { session },
+      );
+
+      expect(executed).toBe(1);
+      expect(resumed.text).not.toBe('');
+    });
+  },
+);

--- a/packages/anthropic/src/options.ts
+++ b/packages/anthropic/src/options.ts
@@ -1,14 +1,17 @@
 import type { ChatOptions } from '@polymind-inc/agent-framework-core';
 
 /** Extended thinking configuration (maps to Anthropic `thinking`). */
-export interface AnthropicThinkingOptions {
-  type: 'enabled' | 'disabled' | (string & {});
-  /**
-   * Maps to `budget_tokens`. Minimum 1024, and counted against `maxTokens`. Required when
-   * `type` is `'enabled'`.
-   */
-  budgetTokens?: number;
-}
+export type AnthropicThinkingOptions =
+  | {
+      type: 'enabled';
+      /** Maps to `budget_tokens`. Minimum 1024, and counted against `maxTokens`. */
+      budgetTokens: number;
+    }
+  | {
+      type: 'disabled';
+      /** Disabled thinking cannot carry a token budget. */
+      budgetTokens?: never;
+    };
 
 /**
  * {@link ChatOptions} plus the Anthropic-specific knobs.

--- a/packages/anthropic/src/to-anthropic.ts
+++ b/packages/anthropic/src/to-anthropic.ts
@@ -108,7 +108,22 @@ function toolResultContent(result: unknown): AnthropicBlock[] | string {
     }
     return blocks.length > 0 ? blocks : '';
   }
-  return JSON.stringify(result);
+  // Caller-built or replayed transcripts can carry results JSON cannot encode (circular
+  // references, bigints, symbols); degrade to the value's string form rather than failing the
+  // whole request, as Python does with json.dumps falling back to str(). Same contract as
+  // stringifyResult in the OpenAI package, which this package cannot depend on.
+  const fallback = (): string => {
+    try {
+      return String(result);
+    } catch {
+      return '[unserializable]';
+    }
+  };
+  try {
+    return JSON.stringify(result) ?? fallback();
+  } catch {
+    return fallback();
+  }
 }
 
 /**

--- a/packages/anthropic/src/to-anthropic.wire-fallbacks.test.ts
+++ b/packages/anthropic/src/to-anthropic.wire-fallbacks.test.ts
@@ -57,6 +57,20 @@ describe('tool_result content rendering', () => {
     expect(resultContentOf(null)).toBe('');
   });
 
+  it('degrades a result JSON cannot encode to its string form instead of throwing', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(resultContentOf(circular)).toBe('[object Object]');
+    expect(resultContentOf(Symbol('opaque'))).toBe('Symbol(opaque)');
+  });
+
+  it('uses a stable placeholder when neither JSON nor string conversion is possible', () => {
+    const unrenderable = Object.create(null) as Record<string, unknown>;
+    unrenderable.self = unrenderable;
+
+    expect(resultContentOf(unrenderable)).toBe('[unserializable]');
+  });
+
   it('renders a content list as text and image blocks, dropping the unrepresentable', () => {
     expect(
       resultContentOf([

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -36,8 +36,9 @@ Known limitations:
   API key — run agents server-side.
 - Agent Skills come from code (`inlineSkill`), from a `SKILL.md` document you supply
   (`markdownSkill`, with `parseSkillMarkdown` for the header alone), or from a `SkillsSource` you
-  implement. **Walking a directory of `SKILL.md` files is not part of this package** — the core has
-  no filesystem, by design; the extensibility examples show the dozen lines of `node:fs` it takes.
+  implement. Node applications can load a directory safely with `directorySkillsSource` from
+  `@polymind-inc/agent-framework-core/node`; it refuses symlink/reparse-point escapes. The root
+  entry remains filesystem-free for browser and edge runtimes.
 - `agent.run()` returns a hybrid thenable/async-iterable stream. Type-aware lint rules such as
   `@typescript-eslint/no-floating-promises` will flag a deliberately unconsumed `run()` call;
   consume the stream or `void` it explicitly.

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -4,6 +4,7 @@ import { MockChatClient } from '../client/test-support.js';
 import type { ContextProvider, HistoryProvider } from '../context/context-provider.js';
 import { InMemoryHistoryProvider } from '../context/in-memory-history-provider.js';
 import { ConfigurationError, StreamConsumedError, UserInputRequiredError } from '../errors.js';
+import { agentMiddleware } from '../middleware/middleware.js';
 import { createResponseStream } from '../streaming/response-stream.js';
 import { approvalResponse } from '../tools/approval.js';
 import { invocationCountOf, tool } from '../tools/tool.js';
@@ -636,6 +637,23 @@ describe('Agent construction', () => {
     expect(() => new Agent({ client: client('x') }).run('hi', { middleware: [(() => {}) as never] })).toThrow(
       ConfigurationError,
     );
+  });
+});
+
+describe('Agent middleware stream lifecycle', () => {
+  it('can be closed before the first pull and still produces a final response', async () => {
+    const agent = new Agent({
+      client: client('unused'),
+      middleware: [agentMiddleware(async (_ctx, next) => next())],
+    });
+    const stream = agent.run('hi');
+    const iterator = stream[Symbol.asyncIterator]();
+
+    await iterator.return?.();
+
+    const response = await stream.finalResponse();
+    expect(response.messages).toEqual([]);
+    expect(response.agentId).toBe(agent.id);
   });
 });
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -47,7 +47,7 @@ import type {
   ChatResponseUpdate,
   ContinuationToken,
 } from '../types/response.js';
-import { chatResponseToUpdates, chatToAgentUpdate, mergeUpdates } from '../types/response.js';
+import { agentResponse, chatResponseToUpdates, chatToAgentUpdate, mergeUpdates } from '../types/response.js';
 import type { AgentAsToolOptions } from './as-tool.js';
 import { agentAsTool } from './as-tool.js';
 import { parseContinuationToken, wrapContinuationToken } from './continuation.js';
@@ -437,7 +437,14 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
       },
       // The pipeline owns the result: an awaited run folded inside the inner stream, and a
       // middleware may have replaced it outright. Re-folding the updates here would lose both.
-      finalize: (): Promise<Final> => (pipeline as { final: () => Promise<Final> }).final(),
+      finalize: (): Promise<Final> =>
+        pipeline?.final() ??
+        Promise.resolve(
+          agentResponse<StructuredValue<TFormat>>({
+            messages: [],
+            agentId: this.id,
+          }),
+        ),
       ...(signal === undefined ? {} : { signal }),
     });
   }

--- a/packages/core/src/agent/as-tool.test.ts
+++ b/packages/core/src/agent/as-tool.test.ts
@@ -126,11 +126,12 @@ describe('agentAsTool invocation', () => {
     expect(spy.mock.calls[0]?.[0]).toBe('what is the answer?');
   });
 
-  it('sends an empty task when the model omitted the argument', async () => {
+  it('rejects a missing required task before invoking the sub-agent', async () => {
     const sub = subAgent({ name: 'helper' });
     const spy = vi.spyOn(sub as unknown as { run: Agent['run'] }, 'run');
-    await delegate([sub.asTool()], '{}');
-    expect(spy.mock.calls[0]?.[0]).toBe('');
+    const results = await delegate([sub.asTool()], '{}');
+    expect(spy).not.toHaveBeenCalled();
+    expect(results[0]?.exception).toContain('Invalid arguments');
   });
 
   it('does not pass a session by default', async () => {

--- a/packages/core/src/agent/as-tool.ts
+++ b/packages/core/src/agent/as-tool.ts
@@ -127,7 +127,7 @@ export function agentAsTool(
     name: toolName,
     description,
     parameters: {
-      type: 'object',
+      type: 'object' as const,
       properties: {
         [argName]: { type: 'string', description: `Task for ${toolName}` },
       },

--- a/packages/core/src/client/function-execution.ts
+++ b/packages/core/src/client/function-execution.ts
@@ -10,6 +10,7 @@ import { runMiddlewareChain, terminateMiddleware } from '../middleware/middlewar
 import { GEN_AI, GEN_AI_OPERATION } from '../observability/attributes.js';
 import { capturesContent, recordSpanError, setAttr, spanName, withSpan } from '../observability/tracing.js';
 import { isApprovalRequest } from '../tools/approval.js';
+import { validateJsonSchema } from '../tools/json-schema.js';
 import { formatSchemaIssues, isStandardSchema } from '../tools/standard-schema.js';
 import type { AnyFunctionTool, ToolContext } from '../tools/tool.js';
 import { claimInvocation, normalizeToolResult } from '../tools/tool.js';
@@ -366,6 +367,13 @@ async function resolveArguments(
       };
     }
     return { ok: true, value: validation.value };
+  }
+  const issues = validateJsonSchema(parsed.value, target.jsonSchema);
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      error: new ToolInvocationError(call.name, `Invalid arguments: ${issues.join('; ')}`),
+    };
   }
   return { ok: true, value: parsed.value };
 }

--- a/packages/core/src/client/function-invocation.test.ts
+++ b/packages/core/src/client/function-invocation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { ConfigurationError, SchemaResolutionError, UserInputRequiredError } from '../errors.js';
 import { functionMiddleware } from '../middleware/middleware.js';
 import { createResponseStream } from '../streaming/response-stream.js';
@@ -37,9 +37,8 @@ function must<T>(value: T | null | undefined): T {
 const echoSchema = {
   type: 'object',
   properties: { value: { type: 'string' } },
-  required: ['value'],
   additionalProperties: false,
-};
+} as const;
 
 describe('withFunctionInvocation', () => {
   it('executes a tool and feeds the result back to the model', async () => {
@@ -192,6 +191,36 @@ describe('withFunctionInvocation', () => {
     expect(results[0]?.exception).toContain('value must be a string');
     expect(results[0]?.result).toContain('Exception: ');
     expect(response.text).toBe('done');
+  });
+
+  it('validates raw JSON Schema arguments before invoking the tool', async () => {
+    const execute = vi.fn(async () => 'ok');
+    const validating = tool({
+      name: 'strict_raw',
+      description: 'd',
+      parameters: {
+        type: 'object',
+        properties: { resource: { type: 'string' } },
+        required: ['resource'],
+        additionalProperties: false,
+      },
+      execute,
+    });
+    const inner = new MockChatClient([
+      { contents: [call('c1', 'strict_raw', 'null')], finishReason: 'tool_calls' },
+      { contents: [call('c2', 'strict_raw', '{"resource":"safe"}')], finishReason: 'tool_calls' },
+      { contents: [textContent('done')], finishReason: 'stop' },
+    ]);
+
+    const response = await withFunctionInvocation(inner, { includeDetailedErrors: true }).getResponse([], {
+      tools: [validating],
+    } as ChatOptions);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledWith({ resource: 'safe' }, expect.anything());
+    expect(resultsOf(response.messages.flatMap((m) => m.contents))[0]?.exception).toContain(
+      'expected object',
+    );
   });
 
   it('aborts the run after maxConsecutiveErrors failing rounds', async () => {
@@ -488,6 +517,18 @@ describe('tool()', () => {
     expect(t.jsonSchema).toEqual({ type: 'object', properties: { a: { type: 'number' } } });
   });
 
+  it('does not claim a non-object raw JSON Schema produces a Record input', () => {
+    tool({
+      name: 'string_input',
+      description: 'd',
+      parameters: { type: 'string' },
+      execute: (input) => {
+        expectTypeOf(input).toEqualTypeOf<unknown>();
+        return String(input);
+      },
+    });
+  });
+
   it('defaults approvalMode to never_require', () => {
     expect(tool({ name: 'x', description: 'd', parameters: echoSchema }).approvalMode).toBe('never_require');
   });
@@ -502,6 +543,15 @@ describe('tool()', () => {
       ConfigurationError,
     );
   });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, 1.5])(
+    'rejects a non-finite or fractional maxInvocations value (%s)',
+    (maxInvocations) => {
+      expect(() => tool({ name: 'x', description: 'd', parameters: echoSchema, maxInvocations })).toThrow(
+        ConfigurationError,
+      );
+    },
+  );
 });
 
 describe('maxInvocations', () => {
@@ -792,6 +842,53 @@ describe('generated function_result metadata (Python parity)', () => {
     expect(result?.result).toContain('rejected by user');
     expect(result?.additionalProperties).toEqual({ serverLabel: 'github' });
   });
+
+  it('correlates an approval to a new logical occurrence when a provider reuses callId', async () => {
+    const execute = vi.fn(() => 'new result');
+    const gated = tool({
+      name: 'gated',
+      description: 'Needs a human',
+      parameters: { type: 'object', properties: {} },
+      approvalMode: 'always_require',
+      execute: execute as never,
+    });
+    const reused = call('reused', 'gated');
+    const client = withFunctionInvocation(
+      new MockChatClient([{ contents: [textContent('done')], finishReason: 'stop' }]),
+    );
+
+    await client.getResponse(
+      [
+        { role: 'assistant', contents: [call('reused', 'gated')] },
+        { role: 'tool', contents: [{ type: 'function_result', callId: 'reused', result: 'old result' }] },
+        {
+          role: 'assistant',
+          contents: [
+            {
+              type: 'function_approval_request',
+              id: 'ficc_reused',
+              functionCall: reused,
+              userInputRequest: true,
+            },
+          ],
+        },
+        {
+          role: 'user',
+          contents: [
+            {
+              type: 'function_approval_response',
+              id: 'ficc_reused',
+              approved: true,
+              functionCall: reused,
+            },
+          ],
+        },
+      ],
+      { tools: [gated] },
+    );
+
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('toolChoice across the approval boundary (Go parity)', () => {
@@ -896,6 +993,141 @@ describe('replayed unanswered approval requests', () => {
       .filter((c): c is FunctionApprovalRequestContent => c.type === 'function_approval_request');
     expect(requests.map((request) => request.id)).toEqual(['a1']);
     expect(requests.map((request) => request.functionCall.callId)).toEqual(['c1']);
+  });
+});
+
+describe('replayed and standalone approval decisions', () => {
+  function pendingRequest(): FunctionApprovalRequestContent {
+    return {
+      type: 'function_approval_request',
+      id: 'ficc_c1',
+      userInputRequest: true,
+      functionCall: call('c1', 'gated'),
+    };
+  }
+
+  it('executes a decision replayed twice for the same call only once', async () => {
+    // A caller replaying a session transcript can carry the same approval response twice, as two
+    // distinct (deserialized) objects. One decision answers one call: the call must run once and
+    // reach the wire once.
+    const execute = vi.fn(() => 'ran');
+    const gated = tool({
+      name: 'gated',
+      description: 'Needs a human',
+      parameters: { type: 'object', properties: {} },
+      approvalMode: 'always_require',
+      execute: execute as never,
+    });
+    const decision: Content = {
+      type: 'function_approval_response',
+      id: 'ficc_c1',
+      approved: true,
+      functionCall: call('c1', 'gated'),
+    };
+    const mock = new MockChatClient([{ contents: [textContent('done')], finishReason: 'stop' }]);
+
+    const response = await withFunctionInvocation(mock).getResponse(
+      [
+        { role: 'assistant', contents: [pendingRequest()] },
+        { role: 'user', contents: [decision, { ...decision }] },
+      ],
+      { tools: [gated] } as ChatOptions,
+    );
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    const emitted = response.messages.flatMap((msg) => msg.contents);
+    expect(emitted.filter((content) => content.type === 'function_call')).toHaveLength(1);
+    expect(resultsOf(emitted)).toHaveLength(1);
+    expect(response.text).toBe('done');
+  });
+
+  it('retires a pending request answered by a decision matching only its callId', async () => {
+    // A wire-compatible caller can hand-build the response with a fresh id; it is accepted and
+    // executed through the callId match, so the same match must retire the request it answers —
+    // re-surfacing the request would ask the human to approve a call that already ran, and a
+    // second yes would run it again.
+    const execute = vi.fn(() => 'ran');
+    const gated = tool({
+      name: 'gated',
+      description: 'Needs a human',
+      parameters: { type: 'object', properties: {} },
+      approvalMode: 'always_require',
+      execute: execute as never,
+    });
+    const decision: Content = {
+      type: 'function_approval_response',
+      id: 'fresh_id_from_caller',
+      approved: true,
+      functionCall: call('c1', 'gated'),
+    };
+    const mock = new MockChatClient([{ contents: [textContent('done')], finishReason: 'stop' }]);
+
+    const response = await withFunctionInvocation(mock).getResponse(
+      [
+        { role: 'assistant', contents: [pendingRequest()] },
+        { role: 'user', contents: [decision] },
+      ],
+      { tools: [gated] } as ChatOptions,
+    );
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    const emitted = response.messages.flatMap((msg) => msg.contents);
+    expect(emitted.filter((content) => content.type === 'function_approval_request')).toEqual([]);
+    expect(response.text).toBe('done');
+  });
+
+  it('accepts a callId-only decision for a new occurrence after an older result', async () => {
+    // Providers may reuse a call id after its previous occurrence has already produced a result.
+    // A fresh-id decision is still a documented wire-compatible answer to the later request, so
+    // the old result must not make that decision disappear merely because the ids differ.
+    const execute = vi.fn(() => 'ran again');
+    const gated = tool({
+      name: 'gated',
+      description: 'Needs a human',
+      parameters: { type: 'object', properties: {} },
+      approvalMode: 'always_require',
+      execute: execute as never,
+    });
+    const laterRequest: FunctionApprovalRequestContent = {
+      ...pendingRequest(),
+      id: 'ficc_c1_second',
+    };
+    const laterDecision: Content = {
+      type: 'function_approval_response',
+      id: 'fresh_id_from_caller',
+      approved: true,
+      functionCall: call('c1', 'gated'),
+    };
+    const mock = new MockChatClient([{ contents: [textContent('done')], finishReason: 'stop' }]);
+
+    const response = await withFunctionInvocation(mock).getResponse(
+      [
+        { role: 'assistant', contents: [pendingRequest()] },
+        {
+          role: 'user',
+          contents: [
+            {
+              type: 'function_approval_response',
+              id: 'ficc_c1',
+              approved: true,
+              functionCall: call('c1', 'gated'),
+            },
+          ],
+        },
+        { role: 'tool', contents: [{ type: 'function_result', callId: 'c1', result: 'old result' }] },
+        { role: 'assistant', contents: [laterRequest] },
+        { role: 'user', contents: [laterDecision] },
+      ],
+      { tools: [gated] } as ChatOptions,
+    );
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(
+      response.messages
+        .flatMap((msg) => msg.contents)
+        .some((content) => content.type === 'function_approval_request'),
+    ).toBe(false);
+    expect(response.text).toBe('done');
   });
 });
 

--- a/packages/core/src/client/function-invocation.ts
+++ b/packages/core/src/client/function-invocation.ts
@@ -1,4 +1,4 @@
-import { ConfigurationError, throwIfAborted } from '../errors.js';
+import { throwIfAborted, validateSafeInteger } from '../errors.js';
 import type { FunctionMiddleware } from '../middleware/middleware.js';
 import { readRunScope, stripRunScope } from '../middleware/run-scope.js';
 import { createResponseStream } from '../streaming/response-stream.js';
@@ -11,7 +11,12 @@ import {
 } from '../tools/approval.js';
 import type { AnyFunctionTool, Tool, ToolContext } from '../tools/tool.js';
 import { isFunctionTool } from '../tools/tool.js';
-import type { Content, FunctionApprovalRequestContent, FunctionCallContent } from '../types/content.js';
+import type {
+  Content,
+  FunctionApprovalRequestContent,
+  FunctionApprovalResponseContent,
+  FunctionCallContent,
+} from '../types/content.js';
 import type { Message } from '../types/message.js';
 import type { ChatResponseUpdate } from '../types/response.js';
 import { chatResponseToUpdates, chatResponseUpdate, mergeChatUpdates } from '../types/response.js';
@@ -59,14 +64,6 @@ export interface FunctionInvocationConfig {
 
 const DEFAULT_MAX_ITERATIONS = 40;
 const DEFAULT_MAX_CONSECUTIVE_ERRORS = 3;
-
-/** Validates a numeric loop limit at the configuration boundary. */
-function loopLimit(name: 'maxIterations' | 'maxConsecutiveErrors', value: number, minimum: number): number {
-  if (!Number.isSafeInteger(value) || value < minimum) {
-    throw new ConfigurationError(`${name} must be a safe integer greater than or equal to ${minimum}.`);
-  }
-  return value;
-}
 
 /** A `function_call` this layer is expected to act on, rather than one the provider already ran. */
 function isPendingCall(content: Content): content is FunctionCallContent {
@@ -247,8 +244,12 @@ export function withFunctionInvocation<TOptions extends ChatOptions>(
   config: FunctionInvocationConfig = {},
 ): ChatClient<TOptions> {
   const enabled = config.enabled ?? true;
-  const maxIterations = loopLimit('maxIterations', config.maxIterations ?? DEFAULT_MAX_ITERATIONS, 1);
-  const maxConsecutiveErrors = loopLimit(
+  const maxIterations = validateSafeInteger(
+    'maxIterations',
+    config.maxIterations ?? DEFAULT_MAX_ITERATIONS,
+    1,
+  );
+  const maxConsecutiveErrors = validateSafeInteger(
     'maxConsecutiveErrors',
     config.maxConsecutiveErrors ?? DEFAULT_MAX_CONSECUTIVE_ERRORS,
     0,
@@ -321,40 +322,99 @@ export function withFunctionInvocation<TOptions extends ChatOptions>(
       }
     | undefined
   > {
-    const answered = new Set<string>();
-    const respondedCallIds = new Set<string>();
-    const requested = new Map<string, FunctionApprovalRequestContent>();
-    let hasApprovalContent = false;
+    // One pass collects everything the acceptance and retirement rules below need: the position
+    // of every content object (per occurrence, keyed by identity), the latest position of each
+    // result / request / response, and the approval contents themselves.
+    const positions = new WeakMap<object, number>();
+    const lastResultPosition = new Map<string, number>();
+    const lastRequestPosition = new Map<string, number>();
+    const lastRequestPositionByCallId = new Map<string, number>();
+    const lastResponsePosition = new Map<string, number>();
+    const requested: FunctionApprovalRequestContent[] = [];
+    const responses: FunctionApprovalResponseContent[] = [];
+    let position = 0;
     for (const msg of messages) {
       for (const content of msg.contents) {
+        const contentPosition = position++;
+        positions.set(content, contentPosition);
         if (content.type === 'function_result') {
-          answered.add(content.callId);
+          lastResultPosition.set(content.callId, contentPosition);
         } else if (
           (isApprovalRequest(content) || isApprovalResponse(content)) &&
           !isHostedApproval(content)
         ) {
-          hasApprovalContent = true;
           if (isApprovalRequest(content)) {
-            requested.set(content.functionCall.callId, content);
+            requested.push(content);
+            lastRequestPosition.set(content.id, contentPosition);
+            lastRequestPositionByCallId.set(content.functionCall.callId, contentPosition);
           } else {
-            respondedCallIds.add(content.functionCall.callId);
+            responses.push(content);
+            lastResponsePosition.set(content.id, contentPosition);
           }
         }
       }
     }
-    if (!hasApprovalContent) {
+    if (requested.length === 0 && responses.length === 0) {
       return undefined;
     }
 
-    const pending = [...requested.entries()]
-      .filter(([callId]) => !answered.has(callId) && !respondedCallIds.has(callId))
-      .map(([, request]) => request);
+    const isActionableResponse = (response: FunctionApprovalResponseContent): boolean => {
+      const responsePosition = positions.get(response) ?? -1;
+      const callId = response.functionCall.callId;
+      const resultPosition = lastResultPosition.get(callId) ?? -1;
+      // Prefer the exact request id: if it names an older closed occurrence, falling back to a
+      // newer request with the same call id would let that stale decision approve the new call.
+      // A response whose id names no request is the documented callId-only path, so correlate it
+      // with the latest request for that call instead.
+      const requestPosition = lastRequestPosition.get(response.id) ?? lastRequestPositionByCallId.get(callId);
+      // A result after the response closes that logical occurrence. When a provider reuses a
+      // call id, a later request opens a new occurrence even though an older result has the same
+      // id. A matched decision must come after that request as well; a response with no request
+      // remains accepted only when no prior result makes it ambiguous, preserving the
+      // wire-compatible standalone-decision path.
+      return requestPosition === undefined
+        ? resultPosition < 0
+        : requestPosition > resultPosition && responsePosition > requestPosition;
+    };
+    const respondedCallIds = new Set(
+      responses.filter(isActionableResponse).map((response) => response.functionCall.callId),
+    );
+    const pendingById = new Map<string, FunctionApprovalRequestContent>();
+    for (const request of requested.filter((request) => {
+      const requestPosition = positions.get(request) ?? -1;
+      const resultPosition = lastResultPosition.get(request.functionCall.callId) ?? -1;
+      const responsePosition = lastResponsePosition.get(request.id) ?? -1;
+      // A request is retired by the response that answers it — matched by id, or, like the
+      // standalone-decision path above, by its call's callId alone. The retirement criteria must
+      // mirror the acceptance criteria: a decision this turn executes cannot leave its own
+      // request pending, or the re-surfaced request would ask the human to approve a call that
+      // already ran.
+      return (
+        requestPosition > resultPosition &&
+        requestPosition > responsePosition &&
+        !respondedCallIds.has(request.functionCall.callId)
+      );
+    })) {
+      // Session replay may contain the same still-pending control item more than once. Keep its
+      // latest copy without asking the human twice; a genuinely reused id after a closed
+      // occurrence is the only surviving copy because the earlier request was filtered above.
+      pendingById.delete(request.id);
+      pendingById.set(request.id, request);
+    }
+    const pending = [...pendingById.values()];
 
     // Strip every local approval control item from provider-visible history. Answered calls are
     // re-materialized below as assistant tool calls; unanswered requests are returned to the
     // caller again and keep the loop paused.
     const history: Message[] = [];
-    const decided = new Map<string, { approved: boolean; call: FunctionCallContent; reason?: string }>();
+    // Keyed by callId: a replayed transcript can carry the same decision more than once, but one
+    // call is answered by exactly one result, so only one decision per call may survive — the
+    // latest occurrence, like Python, which collects responses into a dict and lets a later
+    // entry overwrite an earlier one.
+    const decidedByCallId = new Map<
+      string,
+      { approved: boolean; call: FunctionCallContent; reason?: string }
+    >();
     for (const msg of messages) {
       const kept: Content[] = [];
       for (const content of msg.contents) {
@@ -367,9 +427,9 @@ export function withFunctionInvocation<TOptions extends ChatOptions>(
         }
         if (isApprovalResponse(content)) {
           const call = content.functionCall;
-          if (!answered.has(call.callId) && call.informationalOnly !== true) {
+          if (isActionableResponse(content) && call.informationalOnly !== true) {
             const reason = approvalReason(content);
-            decided.set(call.callId, {
+            decidedByCallId.set(call.callId, {
               approved: content.approved,
               call,
               ...(reason === undefined ? {} : { reason }),
@@ -381,7 +441,7 @@ export function withFunctionInvocation<TOptions extends ChatOptions>(
           content.type === 'function_call' &&
           content.informationalOnly !== true &&
           respondedCallIds.has(content.callId) &&
-          !answered.has(content.callId)
+          (positions.get(content) ?? -1) > (lastResultPosition.get(content.callId) ?? -1)
         ) {
           // A middleware-deferred round leaves the *raw* call in the transcript (it was flushed to
           // the caller before the middleware asked for a human), unlike the `approvalMode` path
@@ -397,7 +457,7 @@ export function withFunctionInvocation<TOptions extends ChatOptions>(
       }
     }
 
-    if (decided.size === 0) {
+    if (decidedByCallId.size === 0) {
       if (pending.length === 0) {
         return { history, emitted: [], terminated: false, errorCount: 0, invoked: false };
       }
@@ -413,7 +473,7 @@ export function withFunctionInvocation<TOptions extends ChatOptions>(
       };
     }
 
-    const decisions = [...decided.values()];
+    const decisions = [...decidedByCallId.values()];
     const callMessage: Message = {
       role: 'assistant',
       contents: decisions.map((decision) => decision.call),

--- a/packages/core/src/client/structured-output.ts
+++ b/packages/core/src/client/structured-output.ts
@@ -4,6 +4,7 @@ import type { JsonSchema } from '../tools/json-schema.js';
 import { resolveJsonSchema } from '../tools/json-schema.js';
 import type { StandardSchemaV1 } from '../tools/standard-schema.js';
 import { formatSchemaIssues, isStandardSchema } from '../tools/standard-schema.js';
+import { isUserInputRequest } from '../types/content.js';
 import type { ResponseBase } from '../types/response.js';
 import type {
   ChatClient,
@@ -85,8 +86,7 @@ function isSuspended(response: ResponseBase<unknown>): boolean {
   return response.messages.some((msg) =>
     msg.contents.some(
       (content) =>
-        content.type === 'function_approval_request' ||
-        content.type === 'oauth_consent_request' ||
+        isUserInputRequest(content) ||
         (content.type === 'function_call' &&
           content.informationalOnly !== true &&
           !resultCallIds.has(content.callId)),

--- a/packages/core/src/client/tool-approval.test.ts
+++ b/packages/core/src/client/tool-approval.test.ts
@@ -232,6 +232,138 @@ describe('tool approval', () => {
     expect(executed).toEqual([{}]);
   });
 
+  it('binds an approval to a deep snapshot of object arguments', async () => {
+    const mock = new MockChatClient([
+      {
+        contents: [
+          {
+            type: 'function_call',
+            callId: 'c1',
+            name: 'delete_all',
+            arguments: { scope: { target: 'safe' } },
+          },
+        ],
+        finishReason: 'tool_calls',
+      },
+      { contents: [textContent('done')], finishReason: 'stop' },
+    ]);
+    const executed: unknown[] = [];
+    const guarded = tool({
+      name: 'delete_all',
+      description: 'Delete records',
+      parameters: { type: 'object', properties: { scope: { type: 'object' } } },
+      approvalMode: 'always_require',
+      execute: async (input) => {
+        executed.push(input);
+        return 'deleted';
+      },
+    });
+    const agent = new Agent({ client: mock, tools: [guarded] });
+    const session = agent.createSession();
+
+    const first = await agent.run('delete', { session });
+    const request = must(approvals(first)[0]);
+    const decision = approvalResponse(structuredClone(request), true);
+    const args = request.functionCall.arguments as { scope: { target: string } };
+    args.scope.target = 'everything';
+
+    await agent.run(decision, { session });
+    expect(executed).toEqual([{ scope: { target: 'safe' } }]);
+  });
+
+  it('records a streaming approval before exposing its mutable request object', async () => {
+    const mock = new MockChatClient([
+      {
+        contents: [
+          {
+            type: 'function_call',
+            callId: 'c1',
+            name: 'delete_all',
+            arguments: '{"scope":"safe"}',
+          },
+        ],
+        finishReason: 'tool_calls',
+      },
+      { contents: [textContent('done')], finishReason: 'stop' },
+    ]);
+    const executed: unknown[] = [];
+    const guarded = tool({
+      name: 'delete_all',
+      description: 'Delete records',
+      parameters: { type: 'object', properties: { scope: { type: 'string' } } },
+      approvalMode: 'always_require',
+      execute: async (input) => {
+        executed.push(input);
+        return 'deleted';
+      },
+    });
+    const agent = new Agent({ client: mock, tools: [guarded] });
+    const session = agent.createSession();
+    const stream = agent.run('delete', { session });
+    const iterator = stream[Symbol.asyncIterator]();
+    let request: FunctionApprovalRequestContent | undefined;
+
+    while (request === undefined) {
+      const next = await iterator.next();
+      if (next.done === true) throw new Error('approval request was not surfaced');
+      request = next.value.contents.find(isApprovalRequest);
+    }
+    const decision = approvalResponse(structuredClone(request), true);
+    request.functionCall.arguments = '{"scope":"everything"}';
+    await iterator.return?.();
+
+    await agent.run(decision, { session });
+    expect(executed).toEqual([{ scope: 'safe' }]);
+  });
+
+  it('executes the recorded arguments when a streamed request is deep-mutated before approval', async () => {
+    // Pins the snapshot invariant end-to-end: the object handed to the caller mid-stream is not
+    // the record the decision is bound against. Deep-mutating the caller's copy — while the
+    // stream is still open, so before the record is persisted — and approving from that mutated
+    // copy must still execute the arguments the model originally produced.
+    const mock = new MockChatClient([
+      {
+        contents: [
+          {
+            type: 'function_call',
+            callId: 'c1',
+            name: 'delete_all',
+            arguments: { scope: { target: 'safe' } },
+          },
+        ],
+        finishReason: 'tool_calls',
+      },
+      { contents: [textContent('done')], finishReason: 'stop' },
+    ]);
+    const executed: unknown[] = [];
+    const guarded = tool({
+      name: 'delete_all',
+      description: 'Delete records',
+      parameters: { type: 'object', properties: { scope: { type: 'object' } } },
+      approvalMode: 'always_require',
+      execute: async (input) => {
+        executed.push(input);
+        return 'deleted';
+      },
+    });
+    const agent = new Agent({ client: mock, tools: [guarded] });
+    const session = agent.createSession();
+    const stream = agent.run('delete', { session });
+    const iterator = stream[Symbol.asyncIterator]();
+    let request: FunctionApprovalRequestContent | undefined;
+
+    while (request === undefined) {
+      const next = await iterator.next();
+      if (next.done === true) throw new Error('approval request was not surfaced');
+      request = next.value.contents.find(isApprovalRequest);
+    }
+    (request.functionCall.arguments as { scope: { target: string } }).scope.target = 'everything';
+    await iterator.return?.();
+
+    await agent.run(approvalResponse(request, true), { session });
+    expect(executed).toEqual([{ scope: { target: 'safe' } }]);
+  });
+
   it('prefers the stored request over a replayed one carrying the same id', async () => {
     const mock = new MockChatClient([
       { contents: [call('c1', 'delete_all')], finishReason: 'tool_calls' },
@@ -397,6 +529,32 @@ describe('tool approval', () => {
     const response = await agent.run('read', { session: agent.createSession() });
     expect(response.userInputRequests).toEqual([]);
     expect(results(response.messages)).toEqual([['c1', 'read']]);
+  });
+
+  it('keeps declaration-only calls visible beside an approval request', async () => {
+    const guarded = tool({
+      name: 'guarded',
+      description: 'd',
+      parameters: { type: 'object', properties: {} },
+      approvalMode: 'always_require',
+      execute: async () => 'done',
+    });
+    const manual = tool({ name: 'manual', description: 'd', parameters: { type: 'object', properties: {} } });
+    const mock = new MockChatClient([
+      {
+        contents: [call('c1', 'guarded'), call('c2', 'manual')],
+        finishReason: 'tool_calls',
+      },
+    ]);
+    const agent = new Agent({ client: mock, tools: [guarded, manual] });
+
+    const response = await agent.run('go', { session: agent.createSession() });
+    expect(response.userInputRequests).toHaveLength(2);
+    expect(
+      response.userInputRequests.some(
+        (content) => content.type === 'function_approval_request' && content.functionCall.name === 'manual',
+      ),
+    ).toBe(true);
   });
 
   it('behaves the same when streamed', async () => {

--- a/packages/core/src/client/tool-approval.ts
+++ b/packages/core/src/client/tool-approval.ts
@@ -46,20 +46,21 @@ function snapshot(request: FunctionApprovalRequestContent): FunctionApprovalRequ
     type: 'function_approval_request',
     id: request.id,
     userInputRequest: true,
+    ...(request.callId === undefined ? {} : { callId: request.callId }),
     // Kept because it carries why the request exists — `requiredByMiddleware` above all, which the
     // bypass layer reads on the turn that replays it.
     ...(request.additionalProperties === undefined
       ? {}
-      : { additionalProperties: { ...request.additionalProperties } }),
+      : { additionalProperties: structuredClone(request.additionalProperties) }),
     functionCall: {
       type: 'function_call',
       callId: call.callId,
       name: call.name,
-      arguments: typeof call.arguments === 'string' ? call.arguments : { ...call.arguments },
+      arguments: typeof call.arguments === 'string' ? call.arguments : structuredClone(call.arguments),
       ...(call.informationalOnly === undefined ? {} : { informationalOnly: call.informationalOnly }),
       ...(call.additionalProperties === undefined
         ? {}
-        : { additionalProperties: { ...call.additionalProperties } }),
+        : { additionalProperties: structuredClone(call.additionalProperties) }),
     },
   };
 }
@@ -252,7 +253,11 @@ function autoApprovableNames(
 ): Set<string> {
   const names = new Set<string>();
   for (const candidate of [...(tools ?? []), ...additionalTools]) {
-    if (isFunctionTool(candidate) && candidate.approvalMode !== 'always_require') {
+    if (
+      isFunctionTool(candidate) &&
+      candidate.execute !== undefined &&
+      candidate.approvalMode !== 'always_require'
+    ) {
       names.add(candidate.name);
     }
   }
@@ -321,10 +326,13 @@ export function withToolApproval<TOptions extends ChatOptions>(
             } else if (autoApprovable.has(content.functionCall.name) && !isMiddlewareApproval(content)) {
               // A middleware asked for this specific call, not for every call of this tool, so the
               // tool's `never_require` declaration does not answer it.
-              suppressed.push(content);
+              suppressed.push(snapshot(content));
             } else {
+              // The caller gets its own deep snapshot, so nothing the caller mutates can reach the
+              // original request — which is what the store records when the run winds down. One
+              // clone keeps the binding record independent from the object yielded to the caller.
               surfaced.push(content);
-              kept.push(content);
+              kept.push(snapshot(content));
             }
           }
           // An update that carried nothing but suppressed approvals has nothing left to report.

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -125,6 +125,20 @@ export class StreamConsumedError extends AgentFrameworkError {
 }
 
 /**
+ * Validates an integer configuration value at the boundary where it is declared.
+ *
+ * Returns `value` when it is a safe integer of at least `minimum`, and throws a
+ * {@link ConfigurationError} naming the offending option otherwise — eagerly, so a bad limit
+ * fails where it is written rather than on the first call that reaches it.
+ */
+export function validateSafeInteger(name: string, value: number, minimum: number): number {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new ConfigurationError(`${name} must be a safe integer greater than or equal to ${minimum}.`);
+  }
+  return value;
+}
+
+/**
  * Throws the abort reason when `signal` is already aborted.
  *
  * The thrown value is whatever the caller's {@link AbortController} carries — by default a

--- a/packages/core/src/middleware/agent-pipeline.ts
+++ b/packages/core/src/middleware/agent-pipeline.ts
@@ -149,14 +149,54 @@ async function* transform(
   source: AsyncIterable<AgentResponseUpdate> | Iterable<AgentResponseUpdate>,
   hooks: readonly UpdateHook[],
 ): AsyncGenerator<AgentResponseUpdate> {
-  for await (const update of source) {
-    let current = update;
-    for (const hook of hooks) {
-      const hooked = await hook(current);
-      if (hooked !== undefined && hooked !== null) {
-        current = hooked;
+  const iterator: AsyncIterator<AgentResponseUpdate> | Iterator<AgentResponseUpdate> =
+    Symbol.asyncIterator in source
+      ? source[Symbol.asyncIterator]()
+      : (source[Symbol.iterator]() as Iterator<AgentResponseUpdate>);
+  let cleanupHandled = false;
+  try {
+    for (;;) {
+      let result: IteratorResult<AgentResponseUpdate>;
+      try {
+        result = await iterator.next();
+      } catch (error) {
+        // A failing source has already performed its own cleanup on the way out.
+        cleanupHandled = true;
+        throw error;
       }
+      if (result.done === true) {
+        // Normal completion: the source finished by itself, so there is nothing left to close.
+        cleanupHandled = true;
+        return;
+      }
+
+      let current = result.value;
+      try {
+        for (const hook of hooks) {
+          const hooked = await hook(current);
+          if (hooked !== undefined && hooked !== null) {
+            current = hooked;
+          }
+        }
+      } catch (error) {
+        // A hook failure is a failure of the run, not an early consumer `break`. Forward it into
+        // the ResponseStream so its cleanup observes the error and history does not persist a
+        // partial response as a successful turn — deliberately `throw()` instead of `return()`.
+        cleanupHandled = true;
+        if (iterator.throw !== undefined) {
+          await iterator.throw(error);
+        } else {
+          await iterator.return?.();
+        }
+        throw error;
+      }
+      yield current;
     }
-    yield current;
+  } finally {
+    // Preserve normal early-break semantics: only a consumer that stopped iterating mid-stream
+    // leaves an iterator that still needs to be closed here.
+    if (!cleanupHandled) {
+      await iterator.return?.();
+    }
   }
 }

--- a/packages/core/src/middleware/middleware.test.ts
+++ b/packages/core/src/middleware/middleware.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { Agent } from '../agent/agent.js';
 import type { ChatOptions } from '../client/chat-client.js';
 import { MockChatClient } from '../client/test-support.js';
 import type { ContextProvider } from '../context/context-provider.js';
+import { InMemoryHistoryProvider } from '../context/in-memory-history-provider.js';
 import { ConfigurationError } from '../errors.js';
 import { approvalResponse } from '../tools/approval.js';
 import { supportsMcp, supportsWebSearch } from '../tools/hosted.js';
@@ -243,6 +244,36 @@ describe('agent middleware', () => {
 
     expect(seen).toEqual(['QUIET']);
     expect((await stream.finalResponse()).text).toBe('quiet');
+  });
+
+  it('classifies an onUpdate failure as a failed run and does not persist a partial turn', async () => {
+    const boom = new Error('update hook failed');
+    const afterRun = vi.fn();
+    const history = new InMemoryHistoryProvider();
+    const fail = agentMiddleware(async (ctx, next) => {
+      ctx.onUpdate(() => {
+        throw boom;
+      });
+      await next();
+    });
+    const agent = new Agent({
+      client: client('partial'),
+      middleware: [fail],
+      contextProviders: [{ sourceId: 'observer', afterRun }],
+      historyProvider: history,
+    });
+    const session = agent.createSession();
+
+    await expect(async () => {
+      for await (const _update of agent.run('x', { session })) {
+        // The hook fails before an update reaches the caller.
+      }
+    }).rejects.toBe(boom);
+
+    expect(afterRun).toHaveBeenCalledTimes(1);
+    expect(afterRun.mock.calls[0]?.[0]).toMatchObject({ error: boom });
+    expect(afterRun.mock.calls[0]?.[0].response).toBeUndefined();
+    expect(await history.getMessages(session, session.partition(history.sourceId))).toEqual([]);
   });
 
   it('transforms the folded result of a streamed run', async () => {

--- a/packages/core/src/skills/provider.test.ts
+++ b/packages/core/src/skills/provider.test.ts
@@ -26,7 +26,7 @@ const unitConverter = inlineSkill({
         type: 'object',
         properties: { value: { type: 'number' }, factor: { type: 'number' } },
       },
-      run: (args) => Number(args.value) * Number(args.factor),
+      run: (args: Record<string, unknown>) => Number(args.value) * Number(args.factor),
     }),
   ],
 });

--- a/packages/core/src/skills/provider.ts
+++ b/packages/core/src/skills/provider.ts
@@ -200,7 +200,7 @@ function skillTools(skills: readonly Skill[], approvals: SkillApprovalModes): To
     description: 'Loads the full instructions for a specific skill.',
     approvalMode: approvals.loadSkill ?? 'always_require',
     parameters: {
-      type: 'object',
+      type: 'object' as const,
       properties: {
         skill_name: { type: 'string', description: 'The name of the skill to load.' },
       },
@@ -224,7 +224,7 @@ function skillTools(skills: readonly Skill[], approvals: SkillApprovalModes): To
     description: 'Reads a resource associated with a skill, such as references, assets, or dynamic data.',
     approvalMode: approvals.readSkillResource ?? 'always_require',
     parameters: {
-      type: 'object',
+      type: 'object' as const,
       properties: {
         skill_name: { type: 'string', description: 'The name of the skill.' },
         resource_name: { type: 'string', description: 'The name of the resource.' },
@@ -260,7 +260,7 @@ function skillTools(skills: readonly Skill[], approvals: SkillApprovalModes): To
     description: 'Runs a script associated with a skill.',
     approvalMode: approvals.runSkillScript ?? 'always_require',
     parameters: {
-      type: 'object',
+      type: 'object' as const,
       properties: {
         skill_name: { type: 'string', description: 'The name of the skill.' },
         script_name: {

--- a/packages/core/src/skills/skill.test.ts
+++ b/packages/core/src/skills/skill.test.ts
@@ -49,7 +49,7 @@ describe('skillScript', () => {
       properties: { value: { type: 'number' }, factor: { type: 'number' } },
       required: ['value', 'factor'],
     },
-    run: (args) => Number(args.value) * Number(args.factor),
+    run: (args: Record<string, unknown>) => Number(args.value) * Number(args.factor),
   });
 
   it('advertises the resolved JSON Schema', () => {
@@ -83,6 +83,26 @@ describe('skillScript', () => {
 
     expect(await typed.run({ name: 'ada' }, invocation(skill))).toBe('hello ada');
     await expect(typed.run({ name: 7 }, invocation(skill))).rejects.toThrow(ToolInvocationError);
+  });
+
+  it('validates raw JSON Schema arguments before running a skill script', async () => {
+    let executed = false;
+    const raw = skillScript({
+      name: 'raw',
+      parameters: {
+        type: 'object',
+        properties: { value: { type: 'number' } },
+        required: ['value'],
+        additionalProperties: false,
+      },
+      run: () => {
+        executed = true;
+      },
+    });
+    const skill = inlineSkill({ name: 'a', description: 'x', instructions: 'y', scripts: [raw] });
+
+    await expect(raw.run({ value: 'not a number' }, invocation(skill))).rejects.toThrow(ToolInvocationError);
+    expect(executed).toBe(false);
   });
 });
 

--- a/packages/core/src/skills/skill.ts
+++ b/packages/core/src/skills/skill.ts
@@ -1,7 +1,7 @@
 import type { AgentSession } from '../agent/session.js';
 import { ConfigurationError, ToolInvocationError } from '../errors.js';
 import type { JsonSchema, SchemaInput } from '../tools/json-schema.js';
-import { resolveJsonSchema } from '../tools/json-schema.js';
+import { resolveJsonSchema, validateJsonSchema } from '../tools/json-schema.js';
 import { formatSchemaIssues, isStandardSchema } from '../tools/standard-schema.js';
 import type { ToolInputOf } from '../tools/tool.js';
 import type { SkillFrontmatter } from './frontmatter.js';
@@ -154,6 +154,12 @@ export interface SkillScriptConfig<TParams extends SchemaInput, TOutput> {
  *
  * @throws {SchemaResolutionError} When `parameters` cannot be converted to a JSON Schema.
  */
+export function skillScript<TOutput = unknown>(
+  config: SkillScriptConfig<JsonSchema & { type: 'object' }, TOutput>,
+): SkillScript;
+export function skillScript<TParams extends SchemaInput, TOutput = unknown>(
+  config: SkillScriptConfig<TParams, TOutput>,
+): SkillScript;
 export function skillScript<TParams extends SchemaInput, TOutput = unknown>(
   config: SkillScriptConfig<TParams, TOutput>,
 ): SkillScript {
@@ -182,7 +188,12 @@ async function validateScriptArguments<TParams extends SchemaInput>(
   args: SkillScriptArguments,
 ): Promise<ToolInputOf<TParams>> {
   if (!isStandardSchema(parameters)) {
-    return (args ?? {}) as ToolInputOf<TParams>;
+    const value = args ?? {};
+    const issues = validateJsonSchema(value, resolveJsonSchema(parameters));
+    if (issues.length > 0) {
+      throw new ToolInvocationError(name, `Invalid arguments: ${issues.join('; ')}`);
+    }
+    return value as ToolInputOf<TParams>;
   }
   const result = await parameters['~standard'].validate(args ?? {});
   if (result.issues !== undefined) {

--- a/packages/core/src/streaming/response-stream.test.ts
+++ b/packages/core/src/streaming/response-stream.test.ts
@@ -57,6 +57,35 @@ describe('createResponseStream', () => {
     expect(await stream.finalResponse()).toBe(6);
   });
 
+  it('shares one source and drain across concurrent finalResponse() calls', async () => {
+    const gate = Promise.withResolvers<void>();
+    const starts: number[] = [];
+    const closed: number[] = [];
+    const stream = createResponseStream({
+      start: async () => {
+        const id = starts.push(starts.length + 1);
+        await gate.promise;
+        return (async function* () {
+          try {
+            yield id;
+          } finally {
+            closed.push(id);
+          }
+        })();
+      },
+      finalize: sum,
+    });
+
+    const first = stream.finalResponse();
+    const second = stream.finalResponse();
+    await Promise.resolve();
+    gate.resolve();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([1, 1]);
+    expect(starts).toEqual([1]);
+    expect(closed).toEqual([1]);
+  });
+
   it('rejects a second consumption synchronously', async () => {
     const awaited = createResponseStream({ start: () => numbers(2), finalize: sum });
     await awaited;

--- a/packages/core/src/streaming/response-stream.ts
+++ b/packages/core/src/streaming/response-stream.ts
@@ -127,6 +127,8 @@ class HybridResponseStream<TUpdate, TFinal> implements ResponseStream<TUpdate, T
 
   #claimed = false;
   #iterator: AsyncIterator<TUpdate> | undefined;
+  #sourcePromise: Promise<AsyncIterator<TUpdate>> | undefined;
+  #drainPromise: Promise<TFinal> | undefined;
   #sourceDone = false;
   /** The consumer stopped early (`break`), so the folded result describes an unfinished run. */
   #abandoned = false;
@@ -188,15 +190,21 @@ class HybridResponseStream<TUpdate, TFinal> implements ResponseStream<TUpdate, T
   }
 
   async #source(stream: boolean): Promise<AsyncIterator<TUpdate>> {
-    if (this.#iterator === undefined) {
+    if (this.#iterator !== undefined) {
+      return this.#iterator;
+    }
+    // Assign before `start` can suspend so concurrent result readers share one provider call.
+    this.#sourcePromise ??= (async (): Promise<AsyncIterator<TUpdate>> => {
       const ctx: StreamStartContext = { stream };
       if (this.#init.signal !== undefined) {
         ctx.signal = this.#init.signal;
       }
       const iterable = await this.#init.start(ctx);
-      this.#iterator = iterable[Symbol.asyncIterator]();
-    }
-    return this.#iterator;
+      const iterator = iterable[Symbol.asyncIterator]();
+      this.#iterator = iterator;
+      return iterator;
+    })();
+    return this.#sourcePromise;
   }
 
   async #next(stream: boolean): Promise<IteratorResult<TUpdate, void>> {
@@ -395,14 +403,19 @@ class HybridResponseStream<TUpdate, TFinal> implements ResponseStream<TUpdate, T
     return this.#finalizing;
   }
 
-  async #drain(stream: boolean): Promise<TFinal> {
-    for (;;) {
-      const result = await this.#next(stream);
-      if (result.done === true) {
-        break;
+  #drain(stream: boolean): Promise<TFinal> {
+    // Sharing source initialization is not enough: two drains would still pull one iterator in
+    // parallel and race update recording and cleanup.
+    this.#drainPromise ??= (async (): Promise<TFinal> => {
+      for (;;) {
+        const result = await this.#next(stream);
+        if (result.done === true) {
+          break;
+        }
       }
-    }
-    return this.#finalize();
+      return this.#finalize();
+    })();
+    return this.#drainPromise;
   }
 
   [Symbol.asyncIterator](): AsyncIterator<TUpdate, void, void> {

--- a/packages/core/src/tools/json-schema.test.ts
+++ b/packages/core/src/tools/json-schema.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import { type JsonSchema, validateJsonSchema } from './json-schema.js';
+
+describe('validateJsonSchema', () => {
+  it('supports local references, combinators, and conditional schemas', () => {
+    const schema: JsonSchema = {
+      $defs: {
+        'payload/type': {
+          type: 'object',
+          properties: {
+            kind: { const: 'ok' },
+            mode: { enum: ['read', 'write'] },
+          },
+          required: ['kind', 'mode'],
+        },
+      },
+      $ref: '#/$defs/payload~1type',
+      allOf: [{ type: 'object' }],
+      anyOf: [{ required: ['kind'] }, false],
+      oneOf: [{ properties: { kind: { const: 'ok' } } }, { properties: { kind: { const: 'other' } } }],
+      not: { required: ['forbidden'] },
+      if: { required: ['flag'] },
+      else: { required: ['fallback'] },
+    };
+    // biome-ignore lint/suspicious/noThenProperty: `then` is a JSON Schema conditional keyword.
+    schema.then = { required: ['dependent'] };
+
+    expect(validateJsonSchema({ kind: 'ok', mode: 'read', fallback: true }, schema)).toEqual([]);
+    expect(validateJsonSchema({ kind: 'ok', mode: 'write', flag: true, dependent: true }, schema)).toEqual(
+      [],
+    );
+  });
+
+  it('reports reference, schema, type, const, enum, and combinator failures', () => {
+    expect(validateJsonSchema('value', false as unknown as JsonSchema)).toEqual([
+      '$: schema rejects every value',
+    ]);
+    expect(validateJsonSchema('value', [] as unknown as JsonSchema)).toEqual(['$: invalid JSON Schema']);
+    expect(validateJsonSchema('value', { $ref: 'https://example.test/schema' })).toEqual([
+      "$: unsupported or unresolved $ref 'https://example.test/schema'",
+    ]);
+    expect(validateJsonSchema('value', { $ref: '#/missing' })).toEqual([
+      "$: unsupported or unresolved $ref '#/missing'",
+    ]);
+    expect(validateJsonSchema(1.5, { type: ['integer', null, 'string'] as unknown as string[] })).toEqual([
+      '$: expected integer or string',
+    ]);
+    expect(validateJsonSchema({ a: 1 }, { const: { a: 2 }, enum: [{ a: 3 }] })).toEqual([
+      '$: value does not match const',
+      '$: value is not in enum',
+    ]);
+    expect(
+      validateJsonSchema('x', { allOf: [{ type: 'number' }], anyOf: [false], oneOf: [true, true] }),
+    ).toEqual([
+      '$: expected number',
+      '$: value does not match anyOf',
+      '$: value must match exactly one oneOf schema',
+    ]);
+    expect(validateJsonSchema('x', { not: { type: 'string' } })).toEqual([
+      '$: value matches forbidden schema',
+    ]);
+  });
+
+  it('resolves a $ref whose pointer ends on an array index', () => {
+    // JSON Pointer numeric segments index into arrays; `#/$defs/choice/anyOf/0` is a legal local
+    // reference, and leaving it unresolved would fail validation closed on every call.
+    const schema: JsonSchema = {
+      $defs: { choice: { anyOf: [{ type: 'string' }, { type: 'number' }] } },
+      $ref: '#/$defs/choice/anyOf/0',
+    };
+
+    expect(validateJsonSchema('ok', schema)).toEqual([]);
+    expect(validateJsonSchema(1, schema)).toEqual(['$: expected string']);
+  });
+
+  it('resolves a $ref crossing an array index and then object keys', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      prefixItems: [{ properties: { x: { type: 'integer' } } }],
+      properties: { y: { $ref: '#/prefixItems/0/properties/x' } },
+    };
+
+    expect(validateJsonSchema({ y: 3 }, schema)).toEqual([]);
+    expect(validateJsonSchema({ y: 'no' }, schema)).toEqual(['$.y: expected integer']);
+  });
+
+  it('fails closed on array segments that are not valid JSON Pointer indices', () => {
+    // Only an unsigned base-10 integer without leading zeros indexes an array; anything else —
+    // including an out-of-range index and the append token `-` — stays unresolved.
+    const defs = { $defs: { choice: { anyOf: [{ type: 'string' }] } } };
+    for (const pointer of [
+      '#/$defs/choice/anyOf/01',
+      '#/$defs/choice/anyOf/1',
+      '#/$defs/choice/anyOf/-',
+      '#/$defs/choice/anyOf/0x0',
+    ]) {
+      expect(validateJsonSchema('ok', { ...defs, $ref: pointer })).toEqual([
+        `$: unsupported or unresolved $ref '${pointer}'`,
+      ]);
+    }
+  });
+
+  it('validates object properties, patterns, dependencies, and size', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { fixed: { type: 'string' } },
+      required: ['fixed', 1] as unknown as string[],
+      patternProperties: { '^n': { type: 'number' }, '[': { type: 'boolean' } },
+      additionalProperties: false,
+      minProperties: 6,
+      maxProperties: 2,
+      dependentRequired: { fixed: ['companion', 1], ignored: 'not-an-array' },
+    };
+
+    expect(validateJsonSchema({ fixed: 1, n1: 'bad', extra: true }, schema)).toEqual(
+      expect.arrayContaining([
+        '$.fixed: expected string',
+        '$.n1: expected number',
+        '$.extra: additional property is not allowed',
+        '$: expected at least 6 properties',
+        '$: expected at most 2 properties',
+        "$.companion: property is required by 'fixed'",
+      ]),
+    );
+    expect(validateJsonSchema({ arbitrary: 'bad' }, { additionalProperties: { type: 'number' } })).toEqual([
+      '$.arbitrary: expected number',
+    ]);
+  });
+
+  it('applies properties and every matching patternProperties schema to the same key', () => {
+    const schema: JsonSchema = {
+      properties: { named: { type: 'string' } },
+      patternProperties: {
+        '^name': { minLength: 5 },
+        ed$: { pattern: '^other' },
+      },
+    };
+
+    expect(validateJsonSchema({ named: 'x' }, schema)).toEqual([
+      '$.named: string is shorter than 5',
+      '$.named: string does not match pattern',
+    ]);
+  });
+
+  it('fails closed on an invalid patternProperties pattern', () => {
+    // Same contract as an invalid `pattern`: a pattern that cannot be compiled must report an
+    // issue rather than silently letting the keys it would have constrained pass unchecked.
+    expect(validateJsonSchema({ anything: 1 }, { patternProperties: { '[': { type: 'boolean' } } })).toEqual([
+      '$: schema contains an invalid pattern',
+    ]);
+    // A valid pattern alongside the invalid one still applies.
+    expect(
+      validateJsonSchema(
+        { n1: 'text' },
+        { patternProperties: { '[': { type: 'boolean' }, '^n': { type: 'number' } } },
+      ),
+    ).toEqual(['$: schema contains an invalid pattern', '$.n1: expected number']);
+  });
+
+  it('validates tuple and homogeneous array constraints', () => {
+    const issues = validateJsonSchema([1, 'bad', 1], {
+      type: 'array',
+      prefixItems: [{ type: 'string' }],
+      items: { type: 'number' },
+      minItems: 4,
+      maxItems: 2,
+      uniqueItems: true,
+    });
+
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        '$[0]: expected string',
+        '$[1]: expected number',
+        '$: expected at least 4 items',
+        '$: expected at most 2 items',
+        '$: items must be unique',
+      ]),
+    );
+  });
+
+  it('validates string and numeric constraints and terminates cyclic references', () => {
+    expect(validateJsonSchema('a', { minLength: 2, maxLength: 0, pattern: '^z' })).toEqual([
+      '$: string is shorter than 2',
+      '$: string is longer than 0',
+      '$: string does not match pattern',
+    ]);
+    expect(validateJsonSchema('a', { pattern: '[' })).toEqual(['$: schema contains an invalid pattern']);
+    expect(
+      validateJsonSchema(4, {
+        minimum: 5,
+        maximum: 3,
+        exclusiveMinimum: 4,
+        exclusiveMaximum: 4,
+        multipleOf: 3,
+      }),
+    ).toEqual([
+      '$: number is below minimum',
+      '$: number is above maximum',
+      '$: number is not above exclusiveMinimum',
+      '$: number is not below exclusiveMaximum',
+      '$: number is not a multipleOf 3',
+    ]);
+    expect(validateJsonSchema('ok', { $ref: '#', type: 'string' })).toEqual([]);
+    expect(validateJsonSchema('ok', { allOf: [{ $ref: '#' }], type: 'string' })).toEqual([]);
+    expect(validateJsonSchema(null, { type: ['null', 'boolean'] })).toEqual([]);
+    // JSON numbers compare by mathematical value: negative zero is the same JSON value as zero.
+    expect(validateJsonSchema(JSON.parse('-0'), { const: 0, enum: [0] })).toEqual([]);
+  });
+});

--- a/packages/core/src/tools/json-schema.ts
+++ b/packages/core/src/tools/json-schema.ts
@@ -98,3 +98,341 @@ function stripRootSchemaKeyword(schema: JsonSchema): JsonSchema {
   const { $schema: _dropped, ...rest } = schema;
   return rest;
 }
+
+/**
+ * Validates a JSON value against the assertion keywords used by tool parameter schemas.
+ *
+ * Kept dependency-free so core stays runtime-agnostic. Unknown annotation and extension keywords
+ * are ignored; unresolved or external references fail closed because executing a tool without
+ * checking the referenced constraints would be unsafe.
+ *
+ * @internal
+ */
+export function validateJsonSchema(value: unknown, schema: JsonSchema): string[] {
+  const issues: string[] = [];
+  validateValue(value, schema, schema, '$', issues, new Set());
+  return issues;
+}
+
+/**
+ * Compiled `pattern` / `patternProperties` regexes, keyed by pattern source. `null` records a
+ * pattern that failed to compile, so an invalid pattern is also detected once instead of throwing
+ * on every value. Validation runs on every tool invocation while the schemas it sees are static
+ * per tool, so the cache stays small and needs no eviction; the cap only guards against a
+ * pathological caller generating schemas dynamically.
+ */
+const patternCache = new Map<string, RegExp | null>();
+const PATTERN_CACHE_LIMIT = 5000;
+
+function compilePattern(source: string): RegExp | null {
+  const cached = patternCache.get(source);
+  if (cached !== undefined) return cached;
+  let regex: RegExp | null;
+  try {
+    regex = new RegExp(source, 'u');
+  } catch {
+    regex = null;
+  }
+  if (patternCache.size >= PATTERN_CACHE_LIMIT) patternCache.clear();
+  patternCache.set(source, regex);
+  return regex;
+}
+
+function schemaRecord(schema: unknown): Record<string, unknown> | undefined {
+  return typeof schema === 'object' && schema !== null && !Array.isArray(schema)
+    ? (schema as Record<string, unknown>)
+    : undefined;
+}
+
+function jsonEqual(left: unknown, right: unknown): boolean {
+  // JSON Schema compares numbers by mathematical value, so -0 and 0 are equal. `Object.is`
+  // deliberately distinguishes them and would reject a valid `const: 0` / `enum: [0]` call.
+  if (left === right) return true;
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return left.length === right.length && left.every((item, index) => jsonEqual(item, right[index]));
+  }
+  const a = schemaRecord(left);
+  const b = schemaRecord(right);
+  if (a === undefined || b === undefined) return false;
+  const keys = Object.keys(a);
+  return keys.length === Object.keys(b).length && keys.every((key) => key in b && jsonEqual(a[key], b[key]));
+}
+
+function typeMatches(value: unknown, type: string): boolean {
+  switch (type) {
+    case 'null':
+      return value === null;
+    case 'array':
+      return Array.isArray(value);
+    case 'object':
+      return typeof value === 'object' && value !== null && !Array.isArray(value);
+    case 'integer':
+      return typeof value === 'number' && Number.isInteger(value);
+    case 'number':
+      return typeof value === 'number' && Number.isFinite(value);
+    case 'string':
+    case 'boolean':
+      return typeof value === type;
+    default:
+      return false;
+  }
+}
+
+/** A JSON Pointer array index: an unsigned base-10 integer with no leading zeros ("0" excepted). */
+const ARRAY_INDEX_SEGMENT = /^(?:0|[1-9]\d*)$/;
+
+function resolveLocalReference(root: JsonSchema, reference: string): unknown {
+  if (reference === '#') return root;
+  if (!reference.startsWith('#/')) return undefined;
+  let current: unknown = root;
+  for (const encoded of reference.slice(2).split('/')) {
+    const key = encoded.replaceAll('~1', '/').replaceAll('~0', '~');
+    if (Array.isArray(current)) {
+      // A pointer can legally cross an array (`#/anyOf/0`); any segment that is not a valid
+      // index — including the append token `-` — leaves the reference unresolved.
+      if (!ARRAY_INDEX_SEGMENT.test(key)) return undefined;
+      const index = Number(key);
+      if (index >= current.length) return undefined;
+      current = current[index];
+      continue;
+    }
+    const record = schemaRecord(current);
+    if (record === undefined || !Object.hasOwn(record, key)) return undefined;
+    current = record[key];
+  }
+  return current;
+}
+
+function subIssues(
+  value: unknown,
+  schema: unknown,
+  root: JsonSchema,
+  path: string,
+  activeReferences: Set<string>,
+): string[] {
+  const issues: string[] = [];
+  validateValue(value, schema, root, path, issues, new Set(activeReferences));
+  return issues;
+}
+
+function validateValue(
+  value: unknown,
+  schema: unknown,
+  root: JsonSchema,
+  path: string,
+  issues: string[],
+  activeReferences: Set<string>,
+): void {
+  if (schema === true) return;
+  if (schema === false) {
+    issues.push(`${path}: schema rejects every value`);
+    return;
+  }
+  const rule = schemaRecord(schema);
+  if (rule === undefined) {
+    issues.push(`${path}: invalid JSON Schema`);
+    return;
+  }
+
+  if (typeof rule.$ref === 'string') {
+    const referenced = resolveLocalReference(root, rule.$ref);
+    if (referenced === undefined) {
+      issues.push(`${path}: unsupported or unresolved $ref '${rule.$ref}'`);
+      return;
+    }
+    const referenceKey = `${path}:${rule.$ref}`;
+    if (!activeReferences.has(referenceKey)) {
+      activeReferences.add(referenceKey);
+      validateValue(value, referenced, root, path, issues, activeReferences);
+      activeReferences.delete(referenceKey);
+    }
+  }
+
+  const declaredTypes =
+    typeof rule.type === 'string'
+      ? [rule.type]
+      : Array.isArray(rule.type)
+        ? rule.type.filter((item): item is string => typeof item === 'string')
+        : [];
+  if (declaredTypes.length > 0 && !declaredTypes.some((type) => typeMatches(value, type))) {
+    issues.push(`${path}: expected ${declaredTypes.join(' or ')}`);
+    return;
+  }
+
+  if ('const' in rule && !jsonEqual(value, rule.const)) issues.push(`${path}: value does not match const`);
+  if (Array.isArray(rule.enum) && !rule.enum.some((candidate) => jsonEqual(value, candidate))) {
+    issues.push(`${path}: value is not in enum`);
+  }
+
+  const checkCombinator = (key: 'allOf' | 'anyOf' | 'oneOf'): void => {
+    const choices = rule[key];
+    if (!Array.isArray(choices)) return;
+    const results = choices.map((choice) => subIssues(value, choice, root, path, activeReferences));
+    const matches = results.filter((result) => result.length === 0).length;
+    if (key === 'allOf') {
+      for (const result of results) issues.push(...result);
+    } else if (key === 'anyOf' && matches === 0) {
+      issues.push(`${path}: value does not match anyOf`);
+    } else if (key === 'oneOf' && matches !== 1) {
+      issues.push(`${path}: value must match exactly one oneOf schema`);
+    }
+  };
+  checkCombinator('allOf');
+  checkCombinator('anyOf');
+  checkCombinator('oneOf');
+  if ('not' in rule && subIssues(value, rule.not, root, path, activeReferences).length === 0) {
+    issues.push(`${path}: value matches forbidden schema`);
+  }
+  if ('if' in rule) {
+    const branch =
+      subIssues(value, rule.if, root, path, activeReferences).length === 0 ? rule.then : rule.else;
+    if (branch !== undefined) validateValue(value, branch, root, path, issues, activeReferences);
+  }
+
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    validateObject(value as Record<string, unknown>, rule, root, path, issues, activeReferences);
+  }
+  if (Array.isArray(value)) validateArray(value, rule, root, path, issues, activeReferences);
+  if (typeof value === 'string') validateString(value, rule, path, issues);
+  if (typeof value === 'number') validateNumber(value, rule, path, issues);
+}
+
+function validateObject(
+  value: Record<string, unknown>,
+  rule: Record<string, unknown>,
+  root: JsonSchema,
+  path: string,
+  issues: string[],
+  activeReferences: Set<string>,
+): void {
+  const properties = schemaRecord(rule.properties) ?? {};
+  const required = Array.isArray(rule.required)
+    ? rule.required.filter((item): item is string => typeof item === 'string')
+    : [];
+  for (const key of required) {
+    if (!Object.hasOwn(value, key)) issues.push(`${path}.${key}: required property is missing`);
+  }
+  for (const [key, childSchema] of Object.entries(properties)) {
+    if (Object.hasOwn(value, key)) {
+      validateValue(value[key], childSchema, root, `${path}.${key}`, issues, activeReferences);
+    }
+  }
+  const patterns = schemaRecord(rule.patternProperties) ?? {};
+  // Compile each pattern once for the whole object. A pattern that does not compile fails closed
+  // with the same issue an invalid `pattern` keyword reports: skipping it would silently leave the
+  // keys it was meant to constrain unchecked.
+  const compiledPatterns: [RegExp, unknown][] = [];
+  for (const [pattern, childSchema] of Object.entries(patterns)) {
+    const regex = compilePattern(pattern);
+    if (regex === null) {
+      issues.push(`${path}: schema contains an invalid pattern`);
+    } else {
+      compiledPatterns.push([regex, childSchema]);
+    }
+  }
+  for (const [key, child] of Object.entries(value)) {
+    const declaredProperty = Object.hasOwn(properties, key);
+    const matchingPatterns = compiledPatterns.filter(([regex]) => regex.test(key));
+    if (matchingPatterns.length > 0) {
+      // `properties` and every matching `patternProperties` schema are cumulative in JSON Schema;
+      // declaring a key explicitly must not let it bypass its matching patterns.
+      for (const [, childSchema] of matchingPatterns) {
+        validateValue(child, childSchema, root, `${path}.${key}`, issues, activeReferences);
+      }
+    } else if (!declaredProperty && rule.additionalProperties === false) {
+      issues.push(`${path}.${key}: additional property is not allowed`);
+    } else if (
+      !declaredProperty &&
+      (schemaRecord(rule.additionalProperties) !== undefined ||
+        typeof rule.additionalProperties === 'boolean')
+    ) {
+      validateValue(child, rule.additionalProperties, root, `${path}.${key}`, issues, activeReferences);
+    }
+  }
+  const count = Object.keys(value).length;
+  if (typeof rule.minProperties === 'number' && count < rule.minProperties) {
+    issues.push(`${path}: expected at least ${rule.minProperties} properties`);
+  }
+  if (typeof rule.maxProperties === 'number' && count > rule.maxProperties) {
+    issues.push(`${path}: expected at most ${rule.maxProperties} properties`);
+  }
+  const dependentRequired = schemaRecord(rule.dependentRequired);
+  if (dependentRequired !== undefined) {
+    for (const [key, dependencies] of Object.entries(dependentRequired)) {
+      if (!Object.hasOwn(value, key) || !Array.isArray(dependencies)) continue;
+      for (const dependency of dependencies) {
+        if (typeof dependency === 'string' && !Object.hasOwn(value, dependency)) {
+          issues.push(`${path}.${dependency}: property is required by '${key}'`);
+        }
+      }
+    }
+  }
+}
+
+function validateArray(
+  value: unknown[],
+  rule: Record<string, unknown>,
+  root: JsonSchema,
+  path: string,
+  issues: string[],
+  activeReferences: Set<string>,
+): void {
+  const prefixItems = Array.isArray(rule.prefixItems) ? rule.prefixItems : [];
+  for (let index = 0; index < Math.min(value.length, prefixItems.length); index += 1) {
+    validateValue(value[index], prefixItems[index], root, `${path}[${index}]`, issues, activeReferences);
+  }
+  if (rule.items !== undefined) {
+    for (let index = prefixItems.length; index < value.length; index += 1) {
+      validateValue(value[index], rule.items, root, `${path}[${index}]`, issues, activeReferences);
+    }
+  }
+  if (typeof rule.minItems === 'number' && value.length < rule.minItems) {
+    issues.push(`${path}: expected at least ${rule.minItems} items`);
+  }
+  if (typeof rule.maxItems === 'number' && value.length > rule.maxItems) {
+    issues.push(`${path}: expected at most ${rule.maxItems} items`);
+  }
+  if (
+    rule.uniqueItems === true &&
+    value.some((item, index) => value.slice(0, index).some((other) => jsonEqual(item, other)))
+  ) {
+    issues.push(`${path}: items must be unique`);
+  }
+}
+
+function validateString(value: string, rule: Record<string, unknown>, path: string, issues: string[]): void {
+  const length = [...value].length;
+  if (typeof rule.minLength === 'number' && length < rule.minLength) {
+    issues.push(`${path}: string is shorter than ${rule.minLength}`);
+  }
+  if (typeof rule.maxLength === 'number' && length > rule.maxLength) {
+    issues.push(`${path}: string is longer than ${rule.maxLength}`);
+  }
+  if (typeof rule.pattern === 'string') {
+    const regex = compilePattern(rule.pattern);
+    if (regex === null) {
+      issues.push(`${path}: schema contains an invalid pattern`);
+    } else if (!regex.test(value)) {
+      issues.push(`${path}: string does not match pattern`);
+    }
+  }
+}
+
+function validateNumber(value: number, rule: Record<string, unknown>, path: string, issues: string[]): void {
+  if (typeof rule.minimum === 'number' && value < rule.minimum)
+    issues.push(`${path}: number is below minimum`);
+  if (typeof rule.maximum === 'number' && value > rule.maximum)
+    issues.push(`${path}: number is above maximum`);
+  if (typeof rule.exclusiveMinimum === 'number' && value <= rule.exclusiveMinimum) {
+    issues.push(`${path}: number is not above exclusiveMinimum`);
+  }
+  if (typeof rule.exclusiveMaximum === 'number' && value >= rule.exclusiveMaximum) {
+    issues.push(`${path}: number is not below exclusiveMaximum`);
+  }
+  if (typeof rule.multipleOf === 'number' && rule.multipleOf > 0) {
+    const quotient = value / rule.multipleOf;
+    if (Math.abs(quotient - Math.round(quotient)) > Number.EPSILON * 10) {
+      issues.push(`${path}: number is not a multipleOf ${rule.multipleOf}`);
+    }
+  }
+}

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -1,5 +1,5 @@
 import type { AgentSession } from '../agent/session.js';
-import { AgentFrameworkError, ConfigurationError, errorMessageOf, ToolInvocationError } from '../errors.js';
+import { AgentFrameworkError, errorMessageOf, ToolInvocationError, validateSafeInteger } from '../errors.js';
 import type { Content } from '../types/content.js';
 import type { Message } from '../types/message.js';
 import type { JsonSchema, SchemaInput } from './json-schema.js';
@@ -115,7 +115,11 @@ export type AnyFunctionTool = FunctionTool<never, unknown>;
 
 /** Resolves the argument type a tool's `execute` receives. */
 export type ToolInputOf<TParams> =
-  TParams extends StandardSchemaV1<unknown, infer Output> ? Output : Record<string, unknown>;
+  TParams extends StandardSchemaV1<unknown, infer Output>
+    ? Output
+    : TParams extends { readonly type: 'object' }
+      ? Record<string, unknown>
+      : unknown;
 
 /** Configuration accepted by {@link tool}. */
 export interface FunctionToolConfig<TParams extends SchemaInput, TOutput> {
@@ -152,13 +156,19 @@ export interface FunctionToolConfig<TParams extends SchemaInput, TOutput> {
  *
  * @throws {SchemaResolutionError} When `parameters` cannot be converted to a JSON Schema.
  */
+export function tool<TOutput = unknown>(
+  config: FunctionToolConfig<JsonSchema & { type: 'object' }, TOutput>,
+): FunctionTool<Record<string, unknown>, TOutput>;
+export function tool<TParams extends SchemaInput, TOutput = unknown>(
+  config: FunctionToolConfig<TParams, TOutput>,
+): FunctionTool<ToolInputOf<TParams>, TOutput>;
 export function tool<TParams extends SchemaInput, TOutput = unknown>(
   config: FunctionToolConfig<TParams, TOutput>,
 ): FunctionTool<ToolInputOf<TParams>, TOutput> {
-  if (config.maxInvocations !== undefined && config.maxInvocations < 1) {
+  if (config.maxInvocations !== undefined) {
     // Python raises the same way. A cap below 1 declares a tool the model can see and can never
     // use, which is a configuration mistake rather than a runtime state worth reporting.
-    throw new ConfigurationError('maxInvocations must be at least 1.');
+    validateSafeInteger('maxInvocations', config.maxInvocations, 1);
   }
   const declared: FunctionTool<ToolInputOf<TParams>, TOutput> = {
     kind: 'function',

--- a/packages/core/src/types/base64.test.ts
+++ b/packages/core/src/types/base64.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { decodeBase64, encodeBase64 } from './base64.js';
+
+describe('base64', () => {
+  it.each([
+    [[], ''],
+    [[0], 'AA=='],
+    [[0, 1], 'AAE='],
+    [[0, 1, 2], 'AAEC'],
+    [[255, 254, 253, 252], '//79/A=='],
+  ] as const)('round-trips %j', (input, encoded) => {
+    const bytes = Uint8Array.from(input);
+    expect(encodeBase64(bytes)).toBe(encoded);
+    expect(decodeBase64(encoded)).toEqual(bytes);
+  });
+
+  it('ignores characters outside the standard alphabet', () => {
+    expect(decodeBase64(' YW\nJj==!')).toEqual(Uint8Array.from([97, 98, 99]));
+  });
+
+  it('round-trips a large byte array without per-byte boxed storage', () => {
+    const bytes = Uint8Array.from({ length: 256 * 1024 }, (_, index) => index & 0xff);
+    expect(decodeBase64(encodeBase64(bytes))).toEqual(bytes);
+  });
+});

--- a/packages/core/src/types/base64.ts
+++ b/packages/core/src/types/base64.ts
@@ -16,23 +16,29 @@ const BASE64_LOOKUP: Record<string, number> = (() => {
 
 /** Encodes bytes as standard base64. */
 export function encodeBase64(bytes: Uint8Array): string {
-  let out = '';
+  const output = new Uint8Array(Math.ceil(bytes.length / 3) * 4);
+  let outputIndex = 0;
   for (let i = 0; i < bytes.length; i += 3) {
     const b0 = bytes[i] ?? 0;
     const b1 = bytes[i + 1];
     const b2 = bytes[i + 2];
     const triplet = (b0 << 16) | ((b1 ?? 0) << 8) | (b2 ?? 0);
-    out += BASE64_ALPHABET[(triplet >> 18) & 63];
-    out += BASE64_ALPHABET[(triplet >> 12) & 63];
-    out += b1 === undefined ? '=' : BASE64_ALPHABET[(triplet >> 6) & 63];
-    out += b2 === undefined ? '=' : BASE64_ALPHABET[triplet & 63];
+    output[outputIndex++] = BASE64_ALPHABET.charCodeAt((triplet >> 18) & 63);
+    output[outputIndex++] = BASE64_ALPHABET.charCodeAt((triplet >> 12) & 63);
+    output[outputIndex++] = b1 === undefined ? 61 : BASE64_ALPHABET.charCodeAt((triplet >> 6) & 63);
+    output[outputIndex++] = b2 === undefined ? 61 : BASE64_ALPHABET.charCodeAt(triplet & 63);
   }
-  return out;
+  return new TextDecoder().decode(output);
 }
 
 /** Decodes standard base64 into bytes. Characters outside the alphabet (including padding) are ignored. */
 export function decodeBase64(value: string): Uint8Array {
-  const out: number[] = [];
+  let sextetCount = 0;
+  for (const char of value) {
+    if (BASE64_LOOKUP[char] !== undefined) sextetCount++;
+  }
+  const output = new Uint8Array(Math.floor((sextetCount * 6) / 8));
+  let outputIndex = 0;
   let buffer = 0;
   let bits = 0;
   for (const char of value) {
@@ -44,8 +50,8 @@ export function decodeBase64(value: string): Uint8Array {
     bits += 6;
     if (bits >= 8) {
       bits -= 8;
-      out.push((buffer >> bits) & 0xff);
+      output[outputIndex++] = (buffer >> bits) & 0xff;
     }
   }
-  return Uint8Array.from(out);
+  return output;
 }

--- a/packages/core/src/types/content.test.ts
+++ b/packages/core/src/types/content.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { Content } from './content.js';
+import { isUserInputRequest } from './content.js';
+
+describe('isUserInputRequest', () => {
+  it('matches the userInputRequest marker and both request discriminators', () => {
+    // The serialized marker alone is enough: a request variant this framework version does not
+    // model still surfaces after a round trip through a transcript.
+    expect(
+      isUserInputRequest({ type: 'unknown', unknownType: 'future_request', userInputRequest: true }),
+    ).toBe(true);
+    expect(
+      isUserInputRequest({
+        type: 'function_approval_request',
+        id: 'req-1',
+        functionCall: { type: 'function_call', callId: 'call-1', name: 'tool', arguments: {} },
+      }),
+    ).toBe(true);
+    expect(
+      isUserInputRequest({ type: 'oauth_consent_request', consentLink: 'https://example.test/consent' }),
+    ).toBe(true);
+  });
+
+  it('rejects content that does not ask for user input', () => {
+    const negatives: Content[] = [
+      { type: 'text', text: 'plain' },
+      { type: 'unknown', unknownType: 'future_request' },
+      {
+        type: 'function_approval_response',
+        id: 'req-1',
+        approved: true,
+        functionCall: { type: 'function_call', callId: 'call-1', name: 'tool', arguments: {} },
+      },
+    ];
+    for (const content of negatives) {
+      expect(isUserInputRequest(content)).toBe(false);
+    }
+  });
+});

--- a/packages/core/src/types/content.ts
+++ b/packages/core/src/types/content.ts
@@ -270,7 +270,27 @@ export interface OAuthConsentRequestContent extends ContentBase {
  * Content that suspends the run until a human responds — what
  * `AgentResponse.userInputRequests` surfaces (.NET `UserInputRequestContent`).
  */
-export type UserInputRequestContent = FunctionApprovalRequestContent | OAuthConsentRequestContent;
+export type UserInputRequestContent =
+  | FunctionApprovalRequestContent
+  | OAuthConsentRequestContent
+  | (UnknownContent & { userInputRequest: true });
+
+/**
+ * `true` when `content` suspends the run until a human responds — the filter behind
+ * `AgentResponse.userInputRequests`, expressed as a type guard like .NET's
+ * `content is UserInputRequestContent` check.
+ *
+ * Matches the serialized `userInputRequest` marker as well as the two request discriminators, so
+ * a request variant this framework version does not model (deserialized as unknown content with
+ * the marker set) is still surfaced.
+ */
+export function isUserInputRequest(content: Content): content is UserInputRequestContent {
+  return (
+    content.userInputRequest === true ||
+    content.type === 'function_approval_request' ||
+    content.type === 'oauth_consent_request'
+  );
+}
 
 /**
  * A content item whose wire `type` this version of the framework does not know.

--- a/packages/core/src/types/response.test.ts
+++ b/packages/core/src/types/response.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { decodeBase64 } from './base64.js';
 import { coalesceContents } from './coalesce.js';
-import { dataContent, textContent } from './content.js';
+import { dataContent, textContent, unknownContent } from './content.js';
 import type { AgentResponseUpdate, ChatResponseUpdate } from './response.js';
 import {
   agentResponse,
@@ -441,5 +441,18 @@ describe('agentResponse.userInputRequests', () => {
       'function_approval_request',
       'oauth_consent_request',
     ]);
+  });
+
+  it('surfaces a forward-compatible unknown content item marked as a user-input request', () => {
+    const futureRequest = unknownContent({
+      type: 'future_approval',
+      id: 'request-1',
+      userInputRequest: true,
+    });
+    const response = agentResponse({
+      messages: [{ role: 'assistant', contents: [futureRequest] }],
+    });
+
+    expect(response.userInputRequests).toEqual([futureRequest]);
   });
 });

--- a/packages/core/src/types/response.ts
+++ b/packages/core/src/types/response.ts
@@ -1,6 +1,6 @@
 import { coalesceContents } from './coalesce.js';
 import type { Content, UserInputRequestContent } from './content.js';
-import { textOfContents } from './content.js';
+import { isUserInputRequest, textOfContents } from './content.js';
 import type { Message, Role } from './message.js';
 import { textOfMessages } from './message.js';
 import type { UsageDetails } from './usage.js';
@@ -62,8 +62,9 @@ export interface ResponseBase<T> {
   readonly text: string;
   /**
    * The parsed structured output when the run specified a `responseFormat`, otherwise `undefined`.
+   * A suspended run also has no value until it is resumed and completes.
    */
-  value: T;
+  value: T | undefined;
   responseId?: string;
   /** ISO 8601 timestamp. */
   createdAt?: string;
@@ -132,21 +133,16 @@ export function agentResponseUpdate(init: AgentResponseUpdateInit): AgentRespons
 
 /** Creates a {@link ChatResponse} with a live `text` getter. */
 export function chatResponse<T = undefined>(init: ChatResponseInit<T>): ChatResponse<T> {
-  const response = { value: undefined as T, ...init } as ChatResponse<T>;
+  const response = { value: undefined, ...init } as ChatResponse<T>;
   return defineDerived(response, 'text', () => textOfMessages(response.messages));
 }
 
 /** Creates an {@link AgentResponse} with live `text` and `userInputRequests` getters. */
 export function agentResponse<T = undefined>(init: AgentResponseInit<T>): AgentResponse<T> {
-  const response = { value: undefined as T, ...init } as AgentResponse<T>;
+  const response = { value: undefined, ...init } as AgentResponse<T>;
   defineDerived(response, 'text', () => textOfMessages(response.messages));
   return defineDerived(response, 'userInputRequests', () =>
-    response.messages.flatMap((msg) =>
-      msg.contents.filter(
-        (content): content is UserInputRequestContent =>
-          content.type === 'function_approval_request' || content.type === 'oauth_consent_request',
-      ),
-    ),
+    response.messages.flatMap((msg) => msg.contents.filter(isUserInputRequest)),
   );
 }
 

--- a/packages/core/src/types/serialization.test.ts
+++ b/packages/core/src/types/serialization.test.ts
@@ -70,6 +70,41 @@ describe('message serialization', () => {
     expect(serializeMessage(deserializeMessage(wire))).toEqual(wire);
   });
 
+  it('round-trips a plain-JSON tool result carrying type keys untouched', () => {
+    // A tool result is arbitrary JSON. `[{type: 'row', id: 1}]` merely happens to carry a `type`
+    // key; rewriting it to `{type: 'unknown', unknownType: 'row', ...}` on deserialization would
+    // hand the model corrupted data when the session is re-sent.
+    const msg: Message = {
+      role: 'tool',
+      contents: [{ type: 'function_result', callId: 'c1', result: [{ type: 'row', id: 1 }] }],
+    };
+
+    expect(deserializeMessage(serializeMessage(msg))).toEqual(msg);
+  });
+
+  it('round-trips a single plain-JSON object result carrying a type key untouched', () => {
+    const msg: Message = {
+      role: 'tool',
+      contents: [{ type: 'function_result', callId: 'c1', result: { type: 'row', id: 1 } }],
+    };
+
+    expect(deserializeMessage(serializeMessage(msg))).toEqual(msg);
+  });
+
+  it('strips rawRepresentation from Content values inside a function result result', () => {
+    const circular: Record<string, unknown> = { type: 'sdk_block' };
+    circular.self = circular;
+    const wire = serializeContent({
+      type: 'function_result',
+      callId: 'c1',
+      result: [{ type: 'text', text: 'from a tool', rawRepresentation: circular }],
+    });
+
+    const result = wire.result as Array<Record<string, unknown>>;
+    expect(result[0]).not.toHaveProperty('rawRepresentation');
+    expect(() => JSON.stringify(wire)).not.toThrow();
+  });
+
   it('drops rawRepresentation inside an mcp_server_tool_result output', () => {
     // `output` carries a Content list (Python `fields_to_capture` includes it and recurses
     // structurally), so the "dropped at every level" contract has to hold inside it too.

--- a/packages/core/src/types/serialization.ts
+++ b/packages/core/src/types/serialization.ts
@@ -53,9 +53,10 @@ const KNOWN_CONTENT_TYPES: ReadonlySet<string> = new Set(Object.keys(WIRE_CONTEN
 /**
  * Content keys whose values are themselves content items or lists of content items.
  *
- * Both {@link serializeContent} and {@link deserializeContent} recurse through exactly these keys,
- * so the list is what makes `rawRepresentation` stripping and {@link UnknownContent} restoration
- * hold at every level. Python recurses structurally instead (`_serialize_value` tests
+ * {@link deserializeContent} recurses through exactly these keys; {@link serializeContent}
+ * recurses through them plus `result` ({@link SERIALIZED_NESTED_CONTENT_KEYS}, which explains the
+ * asymmetry). The lists are what make `rawRepresentation` stripping and {@link UnknownContent}
+ * restoration hold at every level. Python recurses structurally instead (`_serialize_value` tests
  * `isinstance(value, Content)`); TypeScript has no runtime equivalent, so the key list is a
  * deliberate stand-in.
  *
@@ -65,6 +66,22 @@ const KNOWN_CONTENT_TYPES: ReadonlySet<string> = new Set(Object.keys(WIRE_CONTEN
  * entries of Python's `Content.to_dict` `fields_to_capture`.
  */
 const NESTED_CONTENT_KEYS = ['functionCall', 'inputs', 'output', 'outputs', 'items'] as const;
+
+/**
+ * The keys {@link serializeContent} recurses through — the shared list plus `result`.
+ *
+ * The two directions are deliberately asymmetric about `result`, mirroring Python. `result` holds
+ * whatever a tool returned. When that is Content (a rich tool result), serialization must still
+ * strip `rawRepresentation` at every level — an SDK object stored there can be circular, and
+ * persisting the session would throw (Python's `_serialize_value` recurses into it via its
+ * `isinstance(Content)` test, so plain values pass through untouched). Deserialization must NOT
+ * recurse into `result`: a plain-JSON tool result such as `[{type: 'row', id: 1}]` merely happens
+ * to carry a `type` key, and rewriting it to `{type: 'unknown', unknownType: 'row', ...}` would
+ * corrupt data the model reads when the restored session is re-sent. Python's `Content.from_dict`
+ * draws the same line — it restores nested content only under `function_call`, `inputs`,
+ * `outputs` and `items`, never under `result`.
+ */
+const SERIALIZED_NESTED_CONTENT_KEYS = [...NESTED_CONTENT_KEYS, 'result'] as const;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -111,7 +128,7 @@ export function serializeContent(content: Content): SerializedContent {
   if (Array.isArray(out.annotations)) {
     out.annotations = (out.annotations as Annotation[]).map(stripAnnotation);
   }
-  for (const key of NESTED_CONTENT_KEYS) {
+  for (const key of SERIALIZED_NESTED_CONTENT_KEYS) {
     const value = out[key];
     if (Array.isArray(value)) {
       out[key] = value.map((item) => (isContentShaped(item) ? serializeContent(item as Content) : item));

--- a/packages/foundry/src/chat-client.test.ts
+++ b/packages/foundry/src/chat-client.test.ts
@@ -50,6 +50,12 @@ describe('Foundry endpoint construction', () => {
     expect(() => resolveEndpoint(PROJECT, { modelDeployment: ' ' })).toThrow(ConfigurationError);
     expect(() => resolveEndpoint(PROJECT, { serverAgent: '' })).toThrow(ConfigurationError);
   });
+
+  it('rejects a target with both selectors at runtime', () => {
+    expect(() =>
+      resolveEndpoint(PROJECT, { modelDeployment: 'gpt-4o', serverAgent: 'support-bot' } as never),
+    ).toThrow(ConfigurationError);
+  });
 });
 
 describe('Foundry token provider', () => {
@@ -95,6 +101,21 @@ describe('Foundry token provider', () => {
 });
 
 describe('FoundryChatClient', () => {
+  it('uses a preconfigured SDK endpoint without requiring or resolving projectEndpoint', () => {
+    const sdk = {
+      responses: { create: vi.fn() },
+      baseURL: 'https://custom.example/v1',
+    } as unknown as OpenAI;
+
+    const client = new FoundryChatClient({
+      target: { modelDeployment: 'gpt-4o' },
+      client: sdk,
+    });
+
+    expect(client.baseURL).toBe('https://custom.example/v1');
+    expect(client.client).toBe(sdk);
+  });
+
   it('points at the right endpoint and reports the Foundry provider', () => {
     const deployment = new FoundryChatClient({
       projectEndpoint: PROJECT,

--- a/packages/foundry/src/chat-client.ts
+++ b/packages/foundry/src/chat-client.ts
@@ -22,10 +22,8 @@ import { tokenProvider } from './credential.js';
 import type { FoundryTarget } from './target.js';
 import { FOUNDRY_SCOPE, isModelDeployment, resolveEndpoint } from './target.js';
 
-/** Construction options for {@link FoundryChatClient}. */
-export interface FoundryChatClientConfig {
-  /** The Foundry project endpoint, for example `https://my-project.services.ai.azure.com/api/projects/p`. */
-  projectEndpoint: string;
+/** Options shared by both construction paths for {@link FoundryChatClient}. */
+interface FoundryChatClientConfigBase {
   /** Which agent to talk to: a model deployment in the project, or an existing server agent. */
   target: FoundryTarget;
   /** Defaults to {@link DefaultAzureCredential}. */
@@ -39,6 +37,22 @@ export interface FoundryChatClientConfig {
   /** Replaces the SDK's `fetch`, for proxies, custom agents, or tests. */
   fetch?: OpenAI['fetch'];
 }
+
+/** Construction options for {@link FoundryChatClient}. */
+export type FoundryChatClientConfig = FoundryChatClientConfigBase &
+  (
+    | {
+        /** A preconfigured SDK client. Its endpoint is used directly. */
+        client: OpenAI;
+        /** Ignored when `client` is supplied; retained for source compatibility. */
+        projectEndpoint?: string;
+      }
+    | {
+        client?: undefined;
+        /** The Foundry project endpoint, for example `https://my-project.services.ai.azure.com/api/projects/p`. */
+        projectEndpoint: string;
+      }
+  );
 
 /**
  * A {@link ChatClient} for Microsoft Foundry.
@@ -83,23 +97,24 @@ export class FoundryChatClient
   readonly #baseURL: string;
 
   constructor(config: FoundryChatClientConfig) {
-    const endpoint = resolveEndpoint(config.projectEndpoint, config.target);
     // A server agent is addressed by its endpoint, and the agent definition picks the model, so
     // there is nothing to name here: .NET removes `$.model` from the request and Go leaves it
     // unset. Sending a placeholder would reach the wire, `metadata.modelId` and telemetry alike.
     const model = isModelDeployment(config.target) ? config.target.modelDeployment : undefined;
+    const endpoint =
+      config.client === undefined ? resolveEndpoint(config.projectEndpoint, config.target) : undefined;
 
-    this.#baseURL = endpoint.baseURL;
+    this.#baseURL = config.client?.baseURL ?? (endpoint as { baseURL: string }).baseURL;
     const client =
       config.client ??
       new OpenAI({
-        baseURL: endpoint.baseURL,
+        baseURL: (endpoint as { baseURL: string }).baseURL,
         // The SDK calls this before every request, so rotation is handled for us.
         apiKey: tokenProvider(
           config.credential ?? new DefaultAzureCredential(),
           config.scope ?? FOUNDRY_SCOPE,
         ),
-        ...(endpoint.defaultQuery === undefined ? {} : { defaultQuery: endpoint.defaultQuery }),
+        ...(endpoint?.defaultQuery === undefined ? {} : { defaultQuery: endpoint.defaultQuery }),
         ...(config.defaultHeaders === undefined ? {} : { defaultHeaders: config.defaultHeaders }),
         ...(config.fetch === undefined ? {} : { fetch: config.fetch }),
       });

--- a/packages/foundry/src/hosting/converters.ts
+++ b/packages/foundry/src/hosting/converters.ts
@@ -12,6 +12,7 @@ import {
   codeInterpreterCallContents,
   mcpCallContents,
   searchCallContents,
+  stringifyResult,
 } from '@polymind-inc/agent-framework-openai/internal';
 
 /**
@@ -34,18 +35,13 @@ export const AGENT_FRAMEWORK_SERVER_LABEL = 'agent_framework';
  * - a result that merely *looks* like JSON (`"42"`, `'{"k":1}'`) sent unquoted silently changes
  *   type on the wire, arriving as a number or an object.
  *
- * Mirrors .NET `OutputConverter.EncodeFunctionResultAsJsonStringPayload`.
+ * Mirrors .NET `OutputConverter.EncodeFunctionResultAsJsonStringPayload`. The inner text comes
+ * from {@link stringifyResult}, the shared rendering the live provider path uses, so a persisted
+ * result and a re-sent one read identically — including its degraded `String(...)` form for a
+ * value `JSON.stringify` cannot encode.
  */
 export function encodeFunctionOutput(result: unknown): string {
-  let inner: string;
-  if (result === undefined || result === null) {
-    inner = '';
-  } else if (typeof result === 'string') {
-    inner = result;
-  } else {
-    inner = JSON.stringify(result) ?? '';
-  }
-  return JSON.stringify(inner);
+  return JSON.stringify(stringifyResult(result));
 }
 
 /**
@@ -360,8 +356,7 @@ export function itemToMessage(item: OutputItem): Message | undefined {
       // a call id carrying the `mcp_` prefix routes back to a hosted-MCP result content, anything
       // else replays as an ordinary function result (Python `_item_to_message`, issue #5546).
       const callId = typeof item.call_id === 'string' ? item.call_id : '';
-      const raw = item.output;
-      const output = typeof raw === 'string' ? raw : raw === undefined || raw === null ? '' : String(raw);
+      const output = stringifyResult(item.output);
       if (callId.startsWith('mcp_')) {
         return {
           role: 'tool',
@@ -508,9 +503,11 @@ export function itemToMessage(item: OutputItem): Message | undefined {
       };
 
     case 'structured_outputs': {
-      // Replayed as its JSON text, which is exactly what the model produced.
+      // Replayed as its JSON text, which is exactly what the model produced. A JSON `null`
+      // output is a value under a nullable schema, so it renders as its JSON text rather than
+      // as an absent output.
       const output = item.output;
-      const text = typeof output === 'string' ? output : (JSON.stringify(output) ?? '');
+      const text = output === null ? 'null' : stringifyResult(output);
       return { role: 'assistant', contents: [{ type: 'text', text, rawRepresentation: item }] };
     }
 

--- a/packages/foundry/src/hosting/converters.wire-fallbacks.test.ts
+++ b/packages/foundry/src/hosting/converters.wire-fallbacks.test.ts
@@ -1,5 +1,6 @@
 import type { OutputItem } from '@polymind-inc/agent-framework-agentserver';
 import type { Message } from '@polymind-inc/agent-framework-core';
+import { stringifyResult } from '@polymind-inc/agent-framework-openai/internal';
 import { describe, expect, it } from 'vitest';
 import {
   approvalResponseTarget,
@@ -23,8 +24,17 @@ function messageOf(item: OutputItem): Message {
 }
 
 describe('function output codec fallbacks', () => {
-  it('encodes a value JSON.stringify cannot represent as an empty string', () => {
-    expect(encodeFunctionOutput(Symbol('opaque'))).toBe('""');
+  it('encodes a value JSON.stringify cannot represent as its string form', () => {
+    // `JSON.stringify` answers `undefined` for a symbol; the inner text degrades to `String(...)`
+    // (Python's `Content.from_function_result` renders unencodable results via `str` the same
+    // way), so the persisted payload still says what the tool answered instead of "".
+    expect(encodeFunctionOutput(Symbol('opaque'))).toBe('"Symbol(opaque)"');
+  });
+
+  it('encodes a cyclic result as its string form instead of failing the persist', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(encodeFunctionOutput(circular)).toBe('"[object Object]"');
   });
 
   it('decodes an absent payload to an empty string', () => {
@@ -241,6 +251,37 @@ describe('call and result item fallbacks', () => {
   it('stringifies a non-string custom tool output', () => {
     expect(messageOf({ type: 'custom_tool_call_output', output: 7 }).contents[0]).toMatchObject({
       result: '7',
+    });
+    expect(
+      messageOf({ type: 'custom_tool_call_output', output: { status: 'ok', count: 2 } }).contents[0],
+    ).toMatchObject({ result: '{"status":"ok","count":2}' });
+  });
+
+  it('renders an unencodable custom tool output identically to the live provider path', () => {
+    // Replay and the live provider path share one stringify implementation (`stringifyResult`),
+    // so a value `JSON.stringify` throws on renders the same both ways.
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const replayed = messageOf({ type: 'custom_tool_call_output', call_id: 'call_1', output: circular });
+    expect(replayed.contents[0]).toMatchObject({ type: 'function_result', result: '[object Object]' });
+    expect(replayed.contents[0]).toMatchObject({ result: stringifyResult(circular) });
+  });
+
+  it('replays an unencodable structured output as its string form instead of failing the replay', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(messageOf({ type: 'structured_outputs', output: circular }).contents[0]).toMatchObject({
+      type: 'text',
+      text: '[object Object]',
+    });
+  });
+
+  it('replays a JSON null structured output as its JSON text', () => {
+    // `null` is a value the model can produce under a nullable schema; it renders as the JSON
+    // text `null`, not as an absent output.
+    expect(messageOf({ type: 'structured_outputs', output: null }).contents[0]).toMatchObject({
+      type: 'text',
+      text: 'null',
     });
   });
 });

--- a/packages/foundry/src/hosting/foundry-storage-client.ts
+++ b/packages/foundry/src/hosting/foundry-storage-client.ts
@@ -86,8 +86,18 @@ export class FoundryStorageClient {
       const last = attempt === RETRY_ATTEMPTS - 1;
       // Rebuilt per attempt: the token may have refreshed, and the platform headers belong to the
       // request in flight, never to construction time — one container serves many users.
+      let token: string;
+      try {
+        token = await this.#getToken();
+      } catch (error) {
+        // Credential refresh is transient too, but no request reached the service, so it cannot
+        // make a later conflict ambiguous.
+        if (last) throw error;
+        await delay(this.#retryBaseDelayMs * 2 ** attempt);
+        continue;
+      }
       const headers: Record<string, string> = {
-        authorization: `Bearer ${await this.#getToken()}`,
+        authorization: `Bearer ${token}`,
         accept: 'application/json',
         ...(this.#forwardCallId ? platformHeaders() : {}),
       };

--- a/packages/foundry/src/hosting/invocations.test.ts
+++ b/packages/foundry/src/hosting/invocations.test.ts
@@ -1,10 +1,20 @@
 import { HEADERS, INVOCATION_ID_HEADER } from '@polymind-inc/agent-framework-agentserver';
 import type { AgentLike } from '@polymind-inc/agent-framework-core';
-import { Agent, textContent } from '@polymind-inc/agent-framework-core';
+import {
+  Agent,
+  agentResponseUpdate,
+  createResponseStream,
+  mergeUpdates,
+  textContent,
+} from '@polymind-inc/agent-framework-core';
 import type { MockTurn } from '@polymind-inc/agent-framework-core/testing';
 import { MockChatClient } from '@polymind-inc/agent-framework-core/testing';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { InvocationsHostServer } from './invocations.js';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 function say(text: string): MockTurn {
   return { contents: [textContent(text)], finishReason: 'stop' };
@@ -41,6 +51,148 @@ describe('InvocationsHostServer', () => {
     expect(await response.text()).toBe('Hello there');
     expect(response.headers.get(INVOCATION_ID_HEADER)).toBeTruthy();
     expect(response.headers.get(HEADERS.sessionId)).toBeTruthy();
+  });
+
+  it('answers 413 before parsing a request body over the configured bound', async () => {
+    const app = new InvocationsHostServer({
+      agent: new Agent({ client: new MockChatClient([say('unused')]) }),
+      hosted: false,
+      maxBodyBytes: 32,
+    });
+    const response = await app.handle(invoke({ message: 'x'.repeat(100) }));
+
+    expect(response.status).toBe(413);
+    expect(errorCodeOf(await response.json())).toBe('request_too_large');
+  });
+
+  it('honours a raised AGENTSERVER_MAX_BODY_BYTES like the Responses endpoint does', async () => {
+    // One container, one bound: the operator raising the environment override must raise it for
+    // every endpoint the container serves, not only for POST /responses.
+    vi.stubEnv('AGENTSERVER_MAX_BODY_BYTES', String(12 * 1024 * 1024));
+    const app = server(new MockChatClient([say('big body ok')]));
+    const response = await app.handle(invoke({ message: 'x'.repeat(11 * 1024 * 1024) }));
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('big body ok');
+  });
+
+  it('lets an explicit maxBodyBytes win over the environment override', async () => {
+    vi.stubEnv('AGENTSERVER_MAX_BODY_BYTES', String(1024));
+    const app = new InvocationsHostServer({
+      agent: new Agent({ client: new MockChatClient([say('unused')]) }),
+      hosted: false,
+      maxBodyBytes: 32,
+    });
+    const response = await app.handle(invoke({ message: 'x'.repeat(100) }));
+
+    expect(response.status).toBe(413);
+  });
+
+  it('serializes concurrent turns for the same session', async () => {
+    let releaseFirst!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let markFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    let active = 0;
+    let maxActive = 0;
+    const base = new Agent({ client: new MockChatClient([say('one'), say('two')]) });
+    const wrapped: AgentLike = {
+      id: base.id,
+      createSession: base.createSession.bind(base),
+      deserializeSession: base.deserializeSession.bind(base),
+      asTool: base.asTool.bind(base),
+      run: (async (...args: Parameters<AgentLike['run']>) => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        if (active === 1) {
+          markFirstStarted();
+          await gate;
+        }
+        try {
+          return await base.run(...args);
+        } finally {
+          active--;
+        }
+      }) as never,
+    };
+    const app = new InvocationsHostServer({ agent: wrapped, hosted: false });
+    const first = app.handle(invoke({ message: 'first' }, {}, '?agent_session_id=same'));
+    await firstStarted;
+    const second = app.handle(invoke({ message: 'second' }, {}, '?agent_session_id=same'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(maxActive).toBe(1);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(maxActive).toBe(1);
+  });
+
+  it('releases a streamed session when its abandoned request is aborted', async () => {
+    const base = new Agent({ client: new MockChatClient([say('second reply')]) });
+    const hanging: AgentLike = {
+      id: base.id,
+      createSession: base.createSession.bind(base),
+      deserializeSession: base.deserializeSession.bind(base),
+      asTool: base.asTool.bind(base),
+      run: ((input, options) => {
+        if (input !== 'first') return base.run(input, options);
+        return createResponseStream({
+          start: async function* () {
+            yield agentResponseUpdate({ role: 'assistant', contents: [textContent('first chunk')] });
+            await new Promise<void>(() => undefined);
+          },
+          finalize: mergeUpdates,
+          ...(options?.signal === undefined ? {} : { signal: options.signal }),
+        });
+      }) as AgentLike['run'],
+    };
+    const app = new InvocationsHostServer({ agent: hanging, hosted: false });
+    const controller = new AbortController();
+    const first = await app.handle(
+      new Request('http://localhost:8088/invocations?agent_session_id=same', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ message: 'first', stream: true }),
+        signal: controller.signal,
+      }),
+    );
+    expect(first.status).toBe(200);
+
+    let secondSettled = false;
+    const second = app
+      .handle(invoke({ message: 'second' }, {}, '?agent_session_id=same'))
+      .then((response) => {
+        secondSettled = true;
+        return response;
+      });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(secondSettled).toBe(false);
+
+    controller.abort();
+    await vi.waitFor(() => expect(secondSettled).toBe(true), { timeout: 1000, interval: 10 });
+    expect(await (await second).text()).toBe('second reply');
+  });
+
+  it('evicts an idle least-recently-used session at the configured capacity', async () => {
+    const created: Array<string | undefined> = [];
+    const agent = new Agent({ client: new MockChatClient([say('one'), say('two'), say('three')]) });
+    const app = new InvocationsHostServer({
+      agent: recording(agent, created),
+      hosted: false,
+      maxSessions: 1,
+    });
+
+    await app.handle(invoke({ message: 'a' }, {}, '?agent_session_id=a'));
+    await app.handle(invoke({ message: 'b' }, {}, '?agent_session_id=b'));
+    await app.handle(invoke({ message: 'a again' }, {}, '?agent_session_id=a'));
+
+    expect(created).toEqual(['a', 'b', 'a']);
   });
 
   it('streams the update text under text/event-stream when asked to', async () => {

--- a/packages/foundry/src/hosting/invocations.ts
+++ b/packages/foundry/src/hosting/invocations.ts
@@ -7,10 +7,16 @@ import {
   badRequest,
   InvocationsServer,
   isHosted,
+  maxBodyBytes,
   notImplemented,
   ProtocolError,
+  readJsonBody,
+  unavailable,
 } from '@polymind-inc/agent-framework-agentserver';
 import type { AgentLike, AgentSession } from '@polymind-inc/agent-framework-core';
+import { ConfigurationError } from '@polymind-inc/agent-framework-core';
+
+const DEFAULT_MAX_SESSIONS = 1024;
 
 /** Construction options for {@link InvocationsHostServer}. */
 export interface InvocationsHostServerConfig extends Pick<InvocationsServerConfig, 'prefix'> {
@@ -18,6 +24,21 @@ export interface InvocationsHostServerConfig extends Pick<InvocationsServerConfi
   agent: AgentLike;
   /** Overrides `FOUNDRY_HOSTING_ENVIRONMENT` detection. */
   hosted?: boolean;
+  /**
+   * Largest request body read, in bytes. Defaults to `AGENTSERVER_MAX_BODY_BYTES`, or 10 MiB —
+   * the same default the Responses endpoint reads, so one container answers every endpoint under
+   * one bound.
+   */
+  maxBodyBytes?: number;
+  /** Maximum number of idle/in-use conversations retained in memory. Defaults to 1024. */
+  maxSessions?: number;
+}
+
+function positiveLimit(name: string, value: number): number {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new ConfigurationError(`${name} must be a positive safe integer.`);
+  }
+  return value;
 }
 
 /**
@@ -81,76 +102,143 @@ function parseInvocation(payload: unknown): { message: string; stream: boolean }
   return { message, stream: stream === true };
 }
 
-function invocationHandler(agent: AgentLike, hosted: boolean): InvocationHandler {
+function invocationHandler(
+  agent: AgentLike,
+  hosted: boolean,
+  maxBodyBytes: number,
+  maxSessions: number,
+): InvocationHandler {
   // In memory on purpose: the platform stores no conversation history for the Invocations
   // protocol — the `agent_session_id` the caller pins routes it back to the same sandbox, and
   // the sandbox's own memory is where the conversation lives (the Python adapter keeps the same
   // dict). A recycled sandbox starts the conversation over.
   const sessions = new Map<string, AgentSession>();
+  // Each promise is the tail of one session's queue. Holding the lock through streamed response
+  // consumption prevents two turns from reading and then overwriting the same transcript.
+  const sessionLocks = new Map<string, Promise<void>>();
+
+  async function acquireSession(key: string): Promise<() => void> {
+    const previous = sessionLocks.get(key) ?? Promise.resolve();
+    let unlock!: () => void;
+    const current = new Promise<void>((resolve) => {
+      unlock = resolve;
+    });
+    sessionLocks.set(key, current);
+    await previous;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      unlock();
+      if (sessionLocks.get(key) === current) sessionLocks.delete(key);
+    };
+  }
+
+  function sessionFor(key: string): AgentSession {
+    const existing = sessions.get(key);
+    if (existing !== undefined) {
+      // Touch the entry so Map insertion order is an LRU order.
+      sessions.delete(key);
+      sessions.set(key, existing);
+      return existing;
+    }
+
+    if (sessions.size >= maxSessions) {
+      let evictable: string | undefined;
+      for (const candidate of sessions.keys()) {
+        if (!sessionLocks.has(candidate)) {
+          evictable = candidate;
+          break;
+        }
+      }
+      if (evictable === undefined) {
+        throw unavailable('The in-memory invocation session capacity is currently exhausted.');
+      }
+      sessions.delete(evictable);
+    }
+    const created = agent.createSession({ sessionId: key });
+    sessions.set(key, created);
+    return created;
+  }
 
   return async (request: Request, context: InvocationContext): Promise<Response> => {
     const key = partitionKey(context, hosted);
 
     let payload: unknown;
     try {
-      payload = await request.json();
+      payload = await readJsonBody(request, maxBodyBytes);
     } catch (error) {
+      if (error instanceof ProtocolError) throw error;
       throw badRequest('The request body must be a JSON object.', { cause: error });
     }
     const { message, stream } = parseInvocation(payload);
 
-    let session = sessions.get(key);
-    if (session === undefined) {
+    const releaseSession = await acquireSession(key);
+    let handedToStream = false;
+    try {
       // Under the partition key on purpose (the reference constructs
       // `AgentSession(session_id=partition_key)`): tools, middleware and custom agents observe
       // the conversation's real identity through the session, not a throwaway UUID.
-      session = agent.createSession({ sessionId: key });
-      sessions.set(key, session);
-    }
+      const session = sessionFor(key);
 
-    if (!stream) {
-      const response = await agent.run(message, { session, signal: context.signal });
-      return new Response(response.text, {
-        headers: { 'content-type': 'text/plain; charset=utf-8' },
-      });
-    }
+      if (!stream) {
+        const response = await agent.run(message, { session, signal: context.signal });
+        return new Response(response.text, {
+          headers: { 'content-type': 'text/plain; charset=utf-8' },
+        });
+      }
 
-    // The chunks are the updates' text, verbatim — the shape the Python adapter streams. The
-    // content type asks the protocol layer for SSE keep-alives; the framing of the payload
-    // itself is this adapter's wire contract, not the SSE spec's.
-    const updates = agent.run(message, { session, signal: context.signal });
-    const iterator = updates[Symbol.asyncIterator]();
-    const encoder = new TextEncoder();
-    return new Response(
-      new ReadableStream<Uint8Array>({
-        async pull(controller): Promise<void> {
-          // Until something is enqueued or the run ends: a tool round surfaces as updates with
-          // no text, and returning empty-handed would just make the stream machinery re-enter
-          // immediately — the loop is the same consumption, without the churn.
-          for (;;) {
-            const { done, value } = await iterator.next();
-            if (done === true) {
-              controller.close();
-              return;
+      // The chunks are the updates' text, verbatim — the shape the Python adapter streams. The
+      // content type asks the protocol layer for SSE keep-alives; the framing of the payload
+      // itself is this adapter's wire contract, not the SSE spec's.
+      const updates = agent.run(message, { session, signal: context.signal });
+      const iterator = updates[Symbol.asyncIterator]();
+      const encoder = new TextEncoder();
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          async pull(controller): Promise<void> {
+            try {
+              // Until something is enqueued or the run ends: a tool round surfaces as updates with
+              // no text, and returning empty-handed would just make the stream machinery re-enter
+              // immediately — the loop is the same consumption, without the churn.
+              for (;;) {
+                const { done, value } = await iterator.next();
+                if (done === true) {
+                  releaseSession();
+                  controller.close();
+                  return;
+                }
+                if (value.text !== '') {
+                  controller.enqueue(encoder.encode(value.text));
+                  return;
+                }
+              }
+            } catch (error) {
+              releaseSession();
+              controller.error(error);
             }
-            if (value.text !== '') {
-              controller.enqueue(encoder.encode(value.text));
-              return;
+          },
+          async cancel(): Promise<void> {
+            try {
+              await iterator.return?.();
+            } finally {
+              releaseSession();
             }
-          }
+          },
+        }),
+        {
+          headers: {
+            'content-type': 'text/event-stream',
+            'cache-control': 'no-cache',
+            connection: 'keep-alive',
+          },
         },
-        async cancel(): Promise<void> {
-          await iterator.return?.();
-        },
-      }),
-      {
-        headers: {
-          'content-type': 'text/event-stream',
-          'cache-control': 'no-cache',
-          connection: 'keep-alive',
-        },
-      },
-    );
+      );
+      handedToStream = true;
+      return response;
+    } finally {
+      if (!handedToStream) releaseSession();
+    }
   };
 }
 
@@ -180,7 +268,17 @@ function invocationHandler(agent: AgentLike, hosted: boolean): InvocationHandler
 export class InvocationsHostServer extends InvocationsServer {
   constructor(options: InvocationsHostServerConfig) {
     super({
-      handler: invocationHandler(options.agent, options.hosted ?? isHosted()),
+      handler: invocationHandler(
+        options.agent,
+        options.hosted ?? isHosted(),
+        // The environment default flows through unvalidated on purpose: it is the very value the
+        // Responses endpoint serves under, and refusing here what that endpoint accepts would
+        // split the container's behaviour over one variable. Only an explicit option is checked.
+        options.maxBodyBytes === undefined
+          ? maxBodyBytes()
+          : positiveLimit('maxBodyBytes', options.maxBodyBytes),
+        positiveLimit('maxSessions', options.maxSessions ?? DEFAULT_MAX_SESSIONS),
+      ),
       ...(options.prefix === undefined ? {} : { prefix: options.prefix }),
     });
   }

--- a/packages/foundry/src/hosting/response-store.test.ts
+++ b/packages/foundry/src/hosting/response-store.test.ts
@@ -37,7 +37,7 @@ let replayDirCount = 0;
 /** A store whose every request is recorded, with scripted replies. */
 function store(
   replies: Array<{ status?: number; body?: unknown; networkError?: boolean }>,
-  options: { forwardCallId?: boolean; replayRoot?: string } = {},
+  options: { credential?: TokenCredential; forwardCallId?: boolean; replayRoot?: string } = {},
 ): {
   store: FoundryResponseStore;
   calls: Call[];
@@ -71,7 +71,7 @@ function store(
   return {
     store: new FoundryResponseStore({
       projectEndpoint: PROJECT,
-      credential,
+      credential: options.credential ?? credential,
       fetch: fetchStub,
       replayRoot: options.replayRoot ?? join(replayScratch, `store-${replayDirCount++}`),
       retry: { baseDelayMs: 0 },
@@ -698,6 +698,24 @@ describe('replay mirror integrity', () => {
 });
 
 describe('bounded retry', () => {
+  it('retries a transient credential failure before sending the request', async () => {
+    let tokenAttempts = 0;
+    const transientCredential: TokenCredential = {
+      async getToken(): Promise<AccessToken> {
+        tokenAttempts++;
+        if (tokenAttempts === 1) throw new Error('credential temporarily unavailable');
+        return { token: 'refreshed-token', expiresOnTimestamp: Date.now() + 3_600_000 };
+      },
+    };
+    const { store: subject, calls } = store([{ status: 201 }], { credential: transientCredential });
+
+    await subject.put({ response: response() });
+
+    expect(tokenAttempts).toBe(2);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.headers.authorization).toBe('Bearer refreshed-token');
+  });
+
   it('retries a transient failure and succeeds', async () => {
     const { store: subject, calls } = store([{ status: 503 }, { status: 201 }]);
 

--- a/packages/foundry/src/integration.test.ts
+++ b/packages/foundry/src/integration.test.ts
@@ -1,8 +1,9 @@
 /**
  * Integration tests against a real Microsoft Foundry project.
  *
- * Skipped unless `FOUNDRY_PROJECT_ENDPOINT` is set, so `pnpm -r test` stays offline by default.
- * Authentication uses `DefaultAzureCredential`, so `az login` (or a managed identity) is enough.
+ * Skipped unless `RUN_INTEGRATION_TESTS=1` and `FOUNDRY_PROJECT_ENDPOINT` are set, so ordinary
+ * test runs stay offline. Authentication uses `DefaultAzureCredential`, so `az login` (or a
+ * managed identity) is enough.
  *
  * - `FOUNDRY_PROJECT_ENDPOINT` — e.g. `https://<resource>.services.ai.azure.com/api/projects/<p>`
  * - `AZURE_AI_MODEL_DEPLOYMENT_NAME` — model deployment name (default `gpt-4o-mini`). This is the
@@ -25,6 +26,7 @@ const modelDeployment =
   process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? process.env.FOUNDRY_MODEL_DEPLOYMENT ?? 'gpt-4o-mini';
 const serverAgent = process.env.FOUNDRY_SERVER_AGENT;
 const toolboxName = process.env.FOUNDRY_TOOLBOX_NAME;
+const runIntegration = process.env.RUN_INTEGRATION_TESTS === '1';
 const TIMEOUT = 60_000;
 
 /** Narrows away undefined; a missing value fails the test with a clear error. */
@@ -36,52 +38,57 @@ function must<T>(value: T | null | undefined): T {
 const deploymentClient = (): FoundryChatClient =>
   new FoundryChatClient({ projectEndpoint: must(projectEndpoint), target: { modelDeployment } });
 
-describe.runIf(projectEndpoint !== undefined && projectEndpoint !== '')('Foundry (integration)', () => {
-  it('answers a basic prompt', { timeout: TIMEOUT }, async () => {
-    const response = await new Agent({ client: deploymentClient() }).run('Reply with the single word: pong');
+describe.runIf(runIntegration && projectEndpoint !== undefined && projectEndpoint !== '')(
+  'Foundry (integration)',
+  () => {
+    it('answers a basic prompt', { timeout: TIMEOUT }, async () => {
+      const response = await new Agent({ client: deploymentClient() }).run(
+        'Reply with the single word: pong',
+      );
 
-    expect(response.text.toLowerCase()).toContain('pong');
-    expect(response.usageDetails?.inputTokenCount).toBeGreaterThan(0);
-  });
-
-  it('runs the tool loop end to end', { timeout: TIMEOUT }, async () => {
-    let executed = 0;
-    const getWeather = tool({
-      name: 'get_weather',
-      description: 'Get the current weather for a location',
-      parameters: {
-        type: 'object',
-        properties: { location: { type: 'string' } },
-        required: ['location'],
-        additionalProperties: false,
-      },
-      execute: async () => {
-        executed++;
-        return 'Sunny, 25C';
-      },
+      expect(response.text.toLowerCase()).toContain('pong');
+      expect(response.usageDetails?.inputTokenCount).toBeGreaterThan(0);
     });
 
-    const agent = new Agent({ client: deploymentClient(), tools: [getWeather] });
-    const response = await agent.run("What's the weather in Tokyo? Use the tool.");
-
-    expect(executed).toBe(1);
-    expect(response.text).not.toBe('');
-  });
-
-  it.runIf(serverAgent !== undefined && serverAgent !== '')(
-    'talks to an existing server agent',
-    { timeout: TIMEOUT },
-    async () => {
-      const client = new FoundryChatClient({
-        projectEndpoint: must(projectEndpoint),
-        target: { serverAgent: must(serverAgent) },
+    it('runs the tool loop end to end', { timeout: TIMEOUT }, async () => {
+      let executed = 0;
+      const getWeather = tool({
+        name: 'get_weather',
+        description: 'Get the current weather for a location',
+        parameters: {
+          type: 'object',
+          properties: { location: { type: 'string' } },
+          required: ['location'],
+          additionalProperties: false,
+        },
+        execute: async () => {
+          executed++;
+          return 'Sunny, 25C';
+        },
       });
 
-      const response = await new Agent({ client }).run('Hello');
+      const agent = new Agent({ client: deploymentClient(), tools: [getWeather] });
+      const response = await agent.run("What's the weather in Tokyo? Use the tool.");
+
+      expect(executed).toBe(1);
       expect(response.text).not.toBe('');
-    },
-  );
-});
+    });
+
+    it.runIf(serverAgent !== undefined && serverAgent !== '')(
+      'talks to an existing server agent',
+      { timeout: TIMEOUT },
+      async () => {
+        const client = new FoundryChatClient({
+          projectEndpoint: must(projectEndpoint),
+          target: { serverAgent: must(serverAgent) },
+        });
+
+        const response = await new Agent({ client }).run('Hello');
+        expect(response.text).not.toBe('');
+      },
+    );
+  },
+);
 
 /**
  * Foundry Toolbox (hosted MCP tools).
@@ -90,7 +97,11 @@ describe.runIf(projectEndpoint !== undefined && projectEndpoint !== '')('Foundry
  * a managed identity) supplies the credential.
  */
 describe.runIf(
-  projectEndpoint !== undefined && projectEndpoint !== '' && toolboxName !== undefined && toolboxName !== '',
+  runIntegration &&
+    projectEndpoint !== undefined &&
+    projectEndpoint !== '' &&
+    toolboxName !== undefined &&
+    toolboxName !== '',
 )('Foundry Toolbox (integration)', () => {
   const toolbox = (): FoundryToolbox =>
     new FoundryToolbox({ name: must(toolboxName), projectEndpoint: must(projectEndpoint) });
@@ -144,7 +155,7 @@ describe.runIf(
  * The storage API is live on the project endpoint with nothing to enable: an Entra token for
  * `https://ai.azure.com/.default` is enough to reach it.
  */
-describe.runIf(projectEndpoint !== undefined && projectEndpoint !== '')(
+describe.runIf(runIntegration && projectEndpoint !== undefined && projectEndpoint !== '')(
   'Foundry storage (integration)',
   () => {
     const store = (): FoundryResponseStore =>
@@ -173,7 +184,12 @@ describe.runIf(projectEndpoint !== undefined && projectEndpoint !== '')(
  * write resolves platform-side caller context that only exists when the request is routed by
  * Foundry, i.e. from inside a deployed container; the error is opaque, so that stays a hypothesis.
  */
-describe.runIf(process.env.FOUNDRY_STORAGE_WRITABLE === '1')('Foundry storage writes (integration)', () => {
+describe.runIf(
+  runIntegration &&
+    projectEndpoint !== undefined &&
+    projectEndpoint !== '' &&
+    process.env.FOUNDRY_STORAGE_WRITABLE === '1',
+)('Foundry storage writes (integration)', () => {
   const store = (): FoundryResponseStore =>
     new FoundryResponseStore({ projectEndpoint: must(projectEndpoint) });
 

--- a/packages/foundry/src/target.ts
+++ b/packages/foundry/src/target.ts
@@ -19,11 +19,20 @@ export const FOUNDRY_API_VERSION = 'v1';
  * version field could only ever be ignored — and a caller who set one would reasonably believe it
  * pinned something.
  */
-export type FoundryTarget = { modelDeployment: string } | { serverAgent: string };
+export type FoundryTarget =
+  | { modelDeployment: string; serverAgent?: never }
+  | { serverAgent: string; modelDeployment?: never };
 
 /** Narrows a {@link FoundryTarget} to the model-deployment case. */
 export function isModelDeployment(target: FoundryTarget): target is { modelDeployment: string } {
-  return 'modelDeployment' in target;
+  const hasModelDeployment = typeof target.modelDeployment === 'string';
+  const hasServerAgent = typeof target.serverAgent === 'string';
+  if (hasModelDeployment === hasServerAgent) {
+    throw new ConfigurationError(
+      'Foundry target must specify exactly one of modelDeployment or serverAgent.',
+    );
+  }
+  return hasModelDeployment;
 }
 
 /**

--- a/packages/mcp/src/client.test.ts
+++ b/packages/mcp/src/client.test.ts
@@ -155,6 +155,9 @@ describe('tool enumeration', () => {
     expect(() => new McpClient({ transport: server(), transportFactory: server })).toThrow(
       ConfigurationError,
     );
+    expect(() => new McpClient({ transportFactory: server, headers: { authorization: 'secret' } })).toThrow(
+      ConfigurationError,
+    );
   });
 });
 

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -146,6 +146,11 @@ export class McpClient {
         'McpClient needs exactly one of `url`, `transport`, or `transportFactory`.',
       );
     }
+    if (config.url === undefined && (config.headers !== undefined || config.fetch !== undefined)) {
+      throw new ConfigurationError(
+        'A custom transport owns its own fetch; configure `headers` and `fetch` on it instead.',
+      );
+    }
     this.#config = config;
     this.#allowedTools = config.allowedTools === undefined ? undefined : new Set(config.allowedTools);
     this.#target = config.url === undefined ? 'mcp' : String(config.url);

--- a/packages/mcp/src/integration.test.ts
+++ b/packages/mcp/src/integration.test.ts
@@ -1,11 +1,11 @@
 /**
  * Integration tests against a real MCP server.
  *
- * Skipped unless `MCP_SERVER_URL` is set, so `pnpm -r test` stays offline by default. The public
- * Microsoft Learn MCP server needs no credentials and is a good default:
+ * Skipped unless `RUN_INTEGRATION_TESTS=1` and `MCP_SERVER_URL` are set, so ordinary test runs
+ * stay offline. The public Microsoft Learn MCP server needs no credentials and is a good default:
  *
  * ```
- * MCP_SERVER_URL=https://learn.microsoft.com/api/mcp pnpm --filter @polymind-inc/agent-framework-mcp test
+ * RUN_INTEGRATION_TESTS=1 MCP_SERVER_URL=https://learn.microsoft.com/api/mcp pnpm --filter @polymind-inc/agent-framework-mcp test
  * ```
  *
  * - `MCP_SERVER_URL` — the server's Streamable HTTP endpoint
@@ -41,93 +41,96 @@ function connect(): McpClient {
   });
 }
 
-describe.runIf(url !== undefined && url !== '')('MCP client (integration)', () => {
-  it('enumerates a real server’s tools as framework tools', { timeout: TIMEOUT }, async () => {
-    const mcp = connect();
-    try {
+describe.runIf(process.env.RUN_INTEGRATION_TESTS === '1' && url !== undefined && url !== '')(
+  'MCP client (integration)',
+  () => {
+    it('enumerates a real server’s tools as framework tools', { timeout: TIMEOUT }, async () => {
+      const mcp = connect();
+      try {
+        expect(mcp.connected).toBe(false);
+        const tools = await mcp.getTools();
+        expect(mcp.connected).toBe(true);
+
+        expect(tools.length).toBeGreaterThan(0);
+        for (const declared of tools) {
+          expect(declared.kind).toBe('function');
+          expect(declared.name).not.toBe('');
+          // The server's own JSON Schema is the contract; the framework does not re-derive it.
+          expect(declared.jsonSchema).toBeDefined();
+          // A server may omit a tool's description, which stays empty (Python parity) — so only
+          // the shape is asserted here.
+          expect(typeof declared.description).toBe('string');
+        }
+        console.log('[mcp] tools:', tools.map((entry) => entry.name).join(', '));
+      } finally {
+        await mcp.close();
+      }
+    });
+
+    it('calls a real tool and converts its content', { timeout: TIMEOUT }, async () => {
+      const mcp = connect();
+      try {
+        const tools = await mcp.getTools();
+        const target = tools.find((entry) => entry.name === toolName) ?? tools[0];
+        expect(target).toBeDefined();
+
+        const result = await target?.execute?.(JSON.parse(toolArgs), { callId: 'call_1' });
+
+        // MCP content becomes framework content, so a tool result drops straight into a transcript.
+        expect(Array.isArray(result)).toBe(true);
+        const contents = result as Array<{ type: string }>;
+        expect(contents.length).toBeGreaterThan(0);
+        for (const content of contents) {
+          expect(typeof content.type).toBe('string');
+        }
+        console.log(`[mcp] ${target?.name} returned ${contents.length} content item(s):`, [
+          ...new Set(contents.map((content) => content.type)),
+        ]);
+      } finally {
+        await mcp.close();
+      }
+    });
+
+    it('fails clearly when the endpoint is not an MCP server', { timeout: TIMEOUT }, async () => {
+      // A reachable host that speaks HTTP but not MCP — a copied-and-pasted URL, a proxy in front of
+      // the wrong route. The connection must fail rather than hang, and it must fail on the first
+      // `getTools()` rather than at construction, since the client is deliberately lazy.
+      const origin = new URL(must(url)).origin;
+      const mcp = new McpClient({ url: origin });
+
       expect(mcp.connected).toBe(false);
-      const tools = await mcp.getTools();
-      expect(mcp.connected).toBe(true);
+      await expect(mcp.getTools()).rejects.toBeInstanceOf(Error);
+      expect(mcp.connected).toBe(false);
 
-      expect(tools.length).toBeGreaterThan(0);
-      for (const declared of tools) {
-        expect(declared.kind).toBe('function');
-        expect(declared.name).not.toBe('');
-        // The server's own JSON Schema is the contract; the framework does not re-derive it.
-        expect(declared.jsonSchema).toBeDefined();
-        // A server may omit a tool's description, which stays empty (Python parity) — so only
-        // the shape is asserted here.
-        expect(typeof declared.description).toBe('string');
+      // A failed attempt is not cached as a rejection: the next call tries again.
+      await expect(mcp.getTools()).rejects.toBeInstanceOf(Error);
+      await mcp.close();
+    });
+
+    it('traces the call as an MCP client span', { timeout: TIMEOUT }, async () => {
+      const exporter = new InMemorySpanExporter();
+      const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
+      trace.setGlobalTracerProvider(provider);
+      const mcp = connect();
+      try {
+        const tools = await mcp.getTools();
+        const target = tools.find((entry) => entry.name === toolName) ?? tools[0];
+        await target?.execute?.(JSON.parse(toolArgs), { callId: 'call_1' });
+
+        const spans = exporter.getFinishedSpans();
+        const names = spans.map((span) => span.name);
+        expect(names).toContain('initialize');
+        expect(names).toContain('tools/list');
+        const call = spans.find((span) => span.name.startsWith('tools/call'));
+        expect(call?.kind).toBe(SpanKind.CLIENT);
+        expect(call?.attributes['mcp.method.name']).toBe('tools/call');
+        expect(call?.attributes['gen_ai.tool.type']).toBe('mcp');
+        expect(call?.attributes['server.address']).toBe(new URL(must(url)).hostname);
+      } finally {
+        await mcp.close();
+        await provider.shutdown();
+        trace.disable();
       }
-      console.log('[mcp] tools:', tools.map((entry) => entry.name).join(', '));
-    } finally {
-      await mcp.close();
-    }
-  });
-
-  it('calls a real tool and converts its content', { timeout: TIMEOUT }, async () => {
-    const mcp = connect();
-    try {
-      const tools = await mcp.getTools();
-      const target = tools.find((entry) => entry.name === toolName) ?? tools[0];
-      expect(target).toBeDefined();
-
-      const result = await target?.execute?.(JSON.parse(toolArgs), { callId: 'call_1' });
-
-      // MCP content becomes framework content, so a tool result drops straight into a transcript.
-      expect(Array.isArray(result)).toBe(true);
-      const contents = result as Array<{ type: string }>;
-      expect(contents.length).toBeGreaterThan(0);
-      for (const content of contents) {
-        expect(typeof content.type).toBe('string');
-      }
-      console.log(`[mcp] ${target?.name} returned ${contents.length} content item(s):`, [
-        ...new Set(contents.map((content) => content.type)),
-      ]);
-    } finally {
-      await mcp.close();
-    }
-  });
-
-  it('fails clearly when the endpoint is not an MCP server', { timeout: TIMEOUT }, async () => {
-    // A reachable host that speaks HTTP but not MCP — a copied-and-pasted URL, a proxy in front of
-    // the wrong route. The connection must fail rather than hang, and it must fail on the first
-    // `getTools()` rather than at construction, since the client is deliberately lazy.
-    const origin = new URL(must(url)).origin;
-    const mcp = new McpClient({ url: origin });
-
-    expect(mcp.connected).toBe(false);
-    await expect(mcp.getTools()).rejects.toBeInstanceOf(Error);
-    expect(mcp.connected).toBe(false);
-
-    // A failed attempt is not cached as a rejection: the next call tries again.
-    await expect(mcp.getTools()).rejects.toBeInstanceOf(Error);
-    await mcp.close();
-  });
-
-  it('traces the call as an MCP client span', { timeout: TIMEOUT }, async () => {
-    const exporter = new InMemorySpanExporter();
-    const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
-    trace.setGlobalTracerProvider(provider);
-    const mcp = connect();
-    try {
-      const tools = await mcp.getTools();
-      const target = tools.find((entry) => entry.name === toolName) ?? tools[0];
-      await target?.execute?.(JSON.parse(toolArgs), { callId: 'call_1' });
-
-      const spans = exporter.getFinishedSpans();
-      const names = spans.map((span) => span.name);
-      expect(names).toContain('initialize');
-      expect(names).toContain('tools/list');
-      const call = spans.find((span) => span.name.startsWith('tools/call'));
-      expect(call?.kind).toBe(SpanKind.CLIENT);
-      expect(call?.attributes['mcp.method.name']).toBe('tools/call');
-      expect(call?.attributes['gen_ai.tool.type']).toBe('mcp');
-      expect(call?.attributes['server.address']).toBe(new URL(must(url)).hostname);
-    } finally {
-      await mcp.close();
-      await provider.shutdown();
-      trace.disable();
-    }
-  });
-});
+    });
+  },
+);

--- a/packages/mcp/src/skills.test.ts
+++ b/packages/mcp/src/skills.test.ts
@@ -192,14 +192,53 @@ describe('loading', () => {
     await connection.close();
   });
 
-  it.each([['/etc/passwd'], ['../../secrets.md'], ['file:///etc/passwd'], ['..\\..\\secrets.md']])(
-    'refuses the resource name %j without asking the server',
-    async (name) => {
-      const { server, connection } = serverWith([indexOf(unitConverterEntry)]);
-      const [skill] = await mcpSkillsSource(connection).getSkills(context());
+  it.each([
+    ['/etc/passwd'],
+    ['../../secrets.md'],
+    ['file:///etc/passwd'],
+    ['..\\..\\secrets.md'],
+    ['%2e%2e/secrets.md'],
+    ['nested/%252e%252e/secrets.md'],
+  ])('refuses the resource name %j without asking the server', async (name) => {
+    const { server, connection } = serverWith([indexOf(unitConverterEntry)]);
+    const [skill] = await mcpSkillsSource(connection).getSkills(context());
 
-      expect(await skill?.getResource?.(name)).toBeUndefined();
-      expect(server.reads).toEqual([INDEX_URI]);
+    expect(await skill?.getResource?.(name)).toBeUndefined();
+    expect(server.reads).toEqual([INDEX_URI]);
+    await connection.close();
+  });
+
+  it('fetches a resource whose listed name contains a literal percent-escape at that exact uri', async () => {
+    // The traversal check decodes the name to inspect it, but the name the server listed is the
+    // name it serves: the request must go out undecoded.
+    const { server, connection } = serverWith([
+      indexOf(unitConverterEntry),
+      { uri: 'skill://unit-converter/references/a%20b.md', text: '| miles | km |' },
+    ]);
+
+    const [skill] = await mcpSkillsSource(connection).getSkills(context());
+    const resource = await skill?.getResource?.('references/a%20b.md');
+
+    expect(server.reads).toContain('skill://unit-converter/references/a%20b.md');
+    expect(await resource?.read({ skill: skill as Skill, callId: 'c1' })).toBe('| miles | km |');
+    await connection.close();
+  });
+
+  it.each([['100%.md'], ['50%_off.md']])(
+    'accepts the name %j, whose bare percent is not a valid escape, and fetches it literally',
+    async (name) => {
+      // A segment that decodeURIComponent refuses cannot be decoded by anything downstream either,
+      // so it is not an encoding attack — the name goes through as-is.
+      const { server, connection } = serverWith([
+        indexOf(unitConverterEntry),
+        { uri: `skill://unit-converter/${name}`, text: 'plain' },
+      ]);
+
+      const [skill] = await mcpSkillsSource(connection).getSkills(context());
+      const resource = await skill?.getResource?.(name);
+
+      expect(server.reads).toContain(`skill://unit-converter/${name}`);
+      expect(await resource?.read({ skill: skill as Skill, callId: 'c1' })).toBe('plain');
       await connection.close();
     },
   );

--- a/packages/mcp/src/skills.ts
+++ b/packages/mcp/src/skills.ts
@@ -267,10 +267,28 @@ function skillRootUri(url: string): string {
  */
 function safeResourceName(name: string): string | undefined {
   const normalized = name.replaceAll('\\', '/');
-  if (normalized.startsWith('/') || normalized.includes('://') || normalized.split('/').includes('..')) {
-    return undefined;
+  // A downstream server or URI library may decode once or more before resolving the path. Run the
+  // same checks over every decoded stage so `%2e%2e` and double-encoded variants cannot become
+  // traversal only after they cross this trust boundary — but the decoding is inspection only:
+  // the name the server listed is the name it serves, so on success the request goes out with the
+  // original name, not a decoded one.
+  let stage = normalized;
+  for (let depth = 0; depth < 4; depth++) {
+    if (stage.startsWith('/') || stage.includes('://') || stage.split('/').includes('..')) {
+      return undefined;
+    }
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(stage).replaceAll('\\', '/');
+    } catch {
+      // Not valid percent-encoding, so no downstream decoder can unwrap it further either: the
+      // stages checked so far are all there are.
+      return normalized;
+    }
+    if (decoded === stage) return normalized;
+    stage = decoded;
   }
-  return normalized;
+  return undefined;
 }
 
 /** The text of every text block in a read result, joined; `''` when there is none. */

--- a/packages/meta/README.md
+++ b/packages/meta/README.md
@@ -14,6 +14,7 @@ The root entry is the core; everything else lives under a subpath:
 | Import | Re-exports |
 | ------ | ---------- |
 | `@polymind-inc/agent-framework` | [`@polymind-inc/agent-framework-core`](https://www.npmjs.com/package/@polymind-inc/agent-framework-core) — `Agent`, `AgentSession`, `tool()`, middleware, Agent Skills, the `ChatClient` seam |
+| `@polymind-inc/agent-framework/node` | `@polymind-inc/agent-framework-core/node` — Node-only skill directory and file-history adapters |
 | `@polymind-inc/agent-framework/testing` | `@polymind-inc/agent-framework-core/testing` — `MockChatClient` |
 | `@polymind-inc/agent-framework/openai` | [`@polymind-inc/agent-framework-openai`](https://www.npmjs.com/package/@polymind-inc/agent-framework-openai) |
 | `@polymind-inc/agent-framework/anthropic` | [`@polymind-inc/agent-framework-anthropic`](https://www.npmjs.com/package/@polymind-inc/agent-framework-anthropic) |

--- a/packages/openai/src/chat-client.test.ts
+++ b/packages/openai/src/chat-client.test.ts
@@ -994,6 +994,28 @@ describe('OpenAIChatClient background responses', () => {
     expect(response.conversationId).toBe('resp_bg');
   });
 
+  it.each([
+    {
+      name: 'additionalProperties',
+      options: { store: true, additionalProperties: { store: false } },
+    },
+    {
+      name: 'rawRequestTransform',
+      options: {
+        store: true,
+        rawRequestTransform: (request: Record<string, unknown>) => ({ ...request, store: false }),
+      },
+    },
+  ])('parses service storage from the final request after $name', async ({ options }) => {
+    const create = vi.fn().mockResolvedValue(completedResponse({ id: 'resp_not_stored' }));
+    const client = new OpenAIChatClient({ client: fakeClient(create), model: 'gpt-4o' });
+
+    const response = await client.getResponse(HI, options);
+
+    expect(create.mock.calls[0]?.[0].store).toBe(false);
+    expect(response.conversationId).toBeUndefined();
+  });
+
   it('offers a continuation token while a background response is still running', async () => {
     const create = vi.fn().mockResolvedValue(completedResponse({ id: 'resp_1', status: 'in_progress' }));
     const client = new OpenAIChatClient({ client: fakeClient(create), model: 'gpt-4o' });

--- a/packages/openai/src/chat-client.ts
+++ b/packages/openai/src/chat-client.ts
@@ -495,6 +495,12 @@ export class OpenAIChatClient
         }
 
         const request = this.buildRequest(messages, options);
+        // Raw pass-through options are allowed to override `store`, so parsing must follow the
+        // final request body rather than the typed option captured before buildRequest.
+        const requestParseContext: ParseContext = {
+          ...(configuredModel === undefined ? {} : { model: configuredModel }),
+          ...(typeof request.store === 'boolean' ? { store: request.store } : {}),
+        };
 
         if (!ctx.stream) {
           const { data, servedModel } = await this.#callWithHeaders(
@@ -507,7 +513,7 @@ export class OpenAIChatClient
               ),
             options?.signal,
           );
-          directResponse = parseResponse(data, withServedModel(parseContext, servedModel));
+          directResponse = parseResponse(data, withServedModel(requestParseContext, servedModel));
           return arrayToStream(chatResponseToUpdates(directResponse));
         }
 
@@ -521,7 +527,7 @@ export class OpenAIChatClient
         );
         return this.#parseStream(
           OpenAIChatClient.#untilTerminalEvent(created.data as unknown as AsyncIterable<unknown>),
-          withServedModel(parseContext, created.servedModel),
+          withServedModel(requestParseContext, created.servedModel),
           options?.signal,
         );
       },

--- a/packages/openai/src/from-openai.test.ts
+++ b/packages/openai/src/from-openai.test.ts
@@ -290,6 +290,35 @@ describe('failed responses surface their error', () => {
     );
   });
 
+  it('surfaces a standalone stream error event even when no response.failed follows', () => {
+    const updates = fold([
+      { type: 'response.output_text.delta', delta: 'partial' },
+      { type: 'error', code: 'rate_limit_exceeded', message: 'Rate limited.' },
+    ]);
+
+    expect(updates.flatMap((update) => update.contents)).toContainEqual(
+      expect.objectContaining({ type: 'error', message: 'Rate limited.', errorCode: 'rate_limit_exceeded' }),
+    );
+  });
+
+  it('surfaces an error field on an incomplete stream response', () => {
+    const updates = fold([
+      {
+        type: 'response.incomplete',
+        response: {
+          id: 'resp_1',
+          status: 'incomplete',
+          error: { code: 'server_error', message: 'Connection ended.' },
+          output: [],
+        },
+      },
+    ]);
+
+    expect(updates.flatMap((update) => update.contents)).toContainEqual(
+      expect.objectContaining({ type: 'error', message: 'Connection ended.', errorCode: 'server_error' }),
+    );
+  });
+
   it('adds nothing to a successful response', () => {
     const awaited = parseResponse({ id: 'resp_1', status: 'completed', output: [] });
     expect(contentsOf(awaited).some((content) => content.type === 'error')).toBe(false);
@@ -416,6 +445,24 @@ describe('unmodelled output items round-trip through serialization', () => {
 
     const merged = mergeChatUpdates(updates);
     expect(serializeMessage(must(merged.messages[0])).contents).toEqual([futureItem]);
+  });
+
+  it('keeps an unmodelled part inside an awaited message item', () => {
+    const part = { type: 'future_output', id: 'part_1', payload: { value: 42 } };
+    const response = parseResponse({
+      id: 'resp_1',
+      status: 'completed',
+      output: [{ type: 'message', role: 'assistant', content: [part] }],
+    });
+
+    expect(serializeMessage(must(response.messages[0])).contents).toEqual([part]);
+  });
+
+  it('keeps an unmodelled streamed content part', () => {
+    const part = { type: 'future_output', id: 'part_1', payload: { value: 42 } };
+    const updates = fold([{ type: 'response.content_part.added', output_index: 0, part }]);
+
+    expect(serializeMessage(must(mergeChatUpdates(updates).messages[0])).contents).toEqual([part]);
   });
 
   it('restores the same content after a full JSON session round trip', () => {

--- a/packages/openai/src/from-openai.ts
+++ b/packages/openai/src/from-openai.ts
@@ -560,6 +560,8 @@ function outputItemToContents(item: unknown): Content[] {
           contents.push(content);
         } else if (part?.type === 'refusal') {
           contents.push({ type: 'text', text: part.refusal ?? '', rawRepresentation: part });
+        } else {
+          contents.push(unknownContent(part));
         }
       }
       return contents;
@@ -745,15 +747,25 @@ export function parseStreamEvent(
     if (usageDetails !== undefined) {
       contents.push({ type: 'usage', usageDetails, rawRepresentation: event });
     }
-    if (eventType === 'response.failed') {
-      const failure = failureContent(response, event);
-      if (failure !== undefined) {
-        contents.push(failure);
-      }
+    const failure = failureContent(response, event);
+    if (failure !== undefined) {
+      contents.push(failure);
     }
   }
 
   switch (raw?.type) {
+    case 'error': {
+      const message = typeof raw.message === 'string' ? raw.message : '';
+      const code = typeof raw.code === 'string' ? raw.code : '';
+      contents.push({
+        type: 'error',
+        message: message.trim() === '' ? DEFAULT_FAILURE_MESSAGE : message,
+        errorCode: code === '' ? DEFAULT_FAILURE_CODE : code,
+        rawRepresentation: event,
+      });
+      break;
+    }
+
     case 'response.content_part.added': {
       // The part's initial text is usually empty, but Python emits whatever it carries so a
       // pre-filled part is not lost; deltas then stream the rest.
@@ -763,7 +775,7 @@ export function parseStreamEvent(
       } else if (part?.type === 'refusal') {
         contents.push({ type: 'text', text: part.refusal ?? '', rawRepresentation: event });
       } else {
-        return undefined;
+        contents.push(unknownContent(part));
       }
       break;
     }

--- a/packages/openai/src/from-openai.wire-fallbacks.test.ts
+++ b/packages/openai/src/from-openai.wire-fallbacks.test.ts
@@ -168,11 +168,11 @@ describe('awaited message parts', () => {
     expect(contents).toEqual([expect.objectContaining({ type: 'text', text: 'cannot help' })]);
   });
 
-  it('skips message parts of an unknown type', () => {
+  it('preserves message parts of an unknown type', () => {
     const contents = contentsOf(
       parseResponse({ output: [{ type: 'message', content: [{ type: 'mystery_part' }] }] }),
     );
-    expect(contents).toEqual([]);
+    expect(contents).toEqual([expect.objectContaining({ type: 'unknown', unknownType: 'mystery_part' })]);
   });
 
   it('maps a message without content to no contents at all', () => {
@@ -448,8 +448,10 @@ describe('stream event fallbacks', () => {
     expect(update?.contents).toEqual([expect.objectContaining({ type: 'text', text: 'nope' })]);
   });
 
-  it('skips a streamed content part of an unknown type', () => {
-    expect(parseOne({ type: 'response.content_part.added', part: { type: 'mystery_part' } })).toBeUndefined();
+  it('preserves a streamed content part of an unknown type', () => {
+    expect(
+      parseOne({ type: 'response.content_part.added', part: { type: 'mystery_part' } })?.contents,
+    ).toEqual([expect.objectContaining({ type: 'unknown', unknownType: 'mystery_part' })]);
   });
 
   it('maps a text delta without a payload to empty text', () => {

--- a/packages/openai/src/integration.test.ts
+++ b/packages/openai/src/integration.test.ts
@@ -1,8 +1,8 @@
 /**
  * Integration tests against the real OpenAI Responses API.
  *
- * Skipped unless `OPENAI_API_KEY` is set, so `pnpm -r test` stays offline by
- * default. The model defaults to `gpt-4o-mini`; override with `OPENAI_MODEL`.
+ * Skipped unless `RUN_INTEGRATION_TESTS=1` and `OPENAI_API_KEY` are set, so ordinary test runs
+ * stay offline. The model defaults to `gpt-4o-mini`; override with `OPENAI_MODEL`.
  */
 import { Agent, tool } from '@polymind-inc/agent-framework-core';
 import { describe, expect, it } from 'vitest';
@@ -12,86 +12,89 @@ const apiKey = process.env.OPENAI_API_KEY;
 const model = process.env.OPENAI_MODEL ?? 'gpt-4o-mini';
 const TIMEOUT = 60_000;
 
-describe.runIf(apiKey !== undefined && apiKey !== '')('OpenAI Responses API (integration)', () => {
-  const client = (): OpenAIChatClient => new OpenAIChatClient({ model });
+describe.runIf(process.env.RUN_INTEGRATION_TESTS === '1' && apiKey !== undefined && apiKey !== '')(
+  'OpenAI Responses API (integration)',
+  () => {
+    const client = (): OpenAIChatClient => new OpenAIChatClient({ model });
 
-  it('answers a basic prompt and reports usage', { timeout: TIMEOUT }, async () => {
-    const response = await new Agent({ client: client() }).run('Reply with the single word: pong');
+    it('answers a basic prompt and reports usage', { timeout: TIMEOUT }, async () => {
+      const response = await new Agent({ client: client() }).run('Reply with the single word: pong');
 
-    expect(response.text.toLowerCase()).toContain('pong');
-    expect(response.responseId).toBeDefined();
-    expect(response.finishReason).toBe('stop');
-    expect(response.usageDetails?.inputTokenCount).toBeGreaterThan(0);
-    expect(response.usageDetails?.outputTokenCount).toBeGreaterThan(0);
-  });
-
-  it('runs the tool loop end to end', { timeout: TIMEOUT }, async () => {
-    let executed = 0;
-    const getWeather = tool({
-      name: 'get_weather',
-      description: 'Get the current weather for a location',
-      parameters: {
-        type: 'object',
-        properties: { location: { type: 'string' } },
-        required: ['location'],
-        additionalProperties: false,
-      },
-      execute: async (input) => {
-        executed++;
-        return `${String((input as { location?: unknown }).location)}: sunny, 25C`;
-      },
+      expect(response.text.toLowerCase()).toContain('pong');
+      expect(response.responseId).toBeDefined();
+      expect(response.finishReason).toBe('stop');
+      expect(response.usageDetails?.inputTokenCount).toBeGreaterThan(0);
+      expect(response.usageDetails?.outputTokenCount).toBeGreaterThan(0);
     });
 
-    const response = await new Agent({
-      client: client(),
-      instructions: 'Use the get_weather tool to answer weather questions.',
-      tools: [getWeather],
-    }).run('What is the weather in Tokyo right now?');
-
-    expect(executed).toBe(1);
-    const types = response.messages.flatMap((m) => m.contents.map((c) => c.type));
-    expect(types).toContain('function_call');
-    expect(types).toContain('function_result');
-    expect(response.text.toLowerCase()).toContain('sunny');
-  });
-
-  it('streams updates and folds them into the same final response', { timeout: TIMEOUT }, async () => {
-    const stream = new Agent({ client: client() }).run('Count from 1 to 5 as digits, nothing else.');
-
-    let streamedText = '';
-    for await (const update of stream) {
-      streamedText += update.text;
-    }
-    const final = await stream.finalResponse();
-
-    expect(streamedText).toBe(final.text);
-    expect(final.text).toContain('5');
-    expect(final.usageDetails?.totalTokenCount).toBeGreaterThan(0);
-  });
-
-  it('parses structured output into value', { timeout: TIMEOUT }, async () => {
-    const response = await new Agent({ client: client() }).run('Taro is 30 years old.', {
-      responseFormat: {
-        name: 'person',
-        schema: {
+    it('runs the tool loop end to end', { timeout: TIMEOUT }, async () => {
+      let executed = 0;
+      const getWeather = tool({
+        name: 'get_weather',
+        description: 'Get the current weather for a location',
+        parameters: {
           type: 'object',
-          properties: { name: { type: 'string' }, age: { type: 'integer' } },
-          required: ['name', 'age'],
+          properties: { location: { type: 'string' } },
+          required: ['location'],
           additionalProperties: false,
         },
-      },
+        execute: async (input) => {
+          executed++;
+          return `${String((input as { location?: unknown }).location)}: sunny, 25C`;
+        },
+      });
+
+      const response = await new Agent({
+        client: client(),
+        instructions: 'Use the get_weather tool to answer weather questions.',
+        tools: [getWeather],
+      }).run('What is the weather in Tokyo right now?');
+
+      expect(executed).toBe(1);
+      const types = response.messages.flatMap((m) => m.contents.map((c) => c.type));
+      expect(types).toContain('function_call');
+      expect(types).toContain('function_result');
+      expect(response.text.toLowerCase()).toContain('sunny');
     });
 
-    expect(response.value).toMatchObject({ age: 30 });
-  });
+    it('streams updates and folds them into the same final response', { timeout: TIMEOUT }, async () => {
+      const stream = new Agent({ client: client() }).run('Count from 1 to 5 as digits, nothing else.');
 
-  it('keeps history across turns in one session', { timeout: TIMEOUT }, async () => {
-    const agent = new Agent({ client: client(), instructions: 'Answer briefly.' });
-    const session = agent.createSession();
+      let streamedText = '';
+      for await (const update of stream) {
+        streamedText += update.text;
+      }
+      const final = await stream.finalResponse();
 
-    await agent.run('My favourite colour is vermilion. Remember it.', { session });
-    const second = await agent.run('What is my favourite colour? One word only.', { session });
+      expect(streamedText).toBe(final.text);
+      expect(final.text).toContain('5');
+      expect(final.usageDetails?.totalTokenCount).toBeGreaterThan(0);
+    });
 
-    expect(second.text.toLowerCase()).toContain('vermilion');
-  });
-});
+    it('parses structured output into value', { timeout: TIMEOUT }, async () => {
+      const response = await new Agent({ client: client() }).run('Taro is 30 years old.', {
+        responseFormat: {
+          name: 'person',
+          schema: {
+            type: 'object',
+            properties: { name: { type: 'string' }, age: { type: 'integer' } },
+            required: ['name', 'age'],
+            additionalProperties: false,
+          },
+        },
+      });
+
+      expect(response.value).toMatchObject({ age: 30 });
+    });
+
+    it('keeps history across turns in one session', { timeout: TIMEOUT }, async () => {
+      const agent = new Agent({ client: client(), instructions: 'Answer briefly.' });
+      const session = agent.createSession();
+
+      await agent.run('My favourite colour is vermilion. Remember it.', { session });
+      const second = await agent.run('What is my favourite colour? One word only.', { session });
+
+      expect(second.text.toLowerCase()).toContain('vermilion');
+    });
+  },
+);

--- a/packages/openai/src/internal.ts
+++ b/packages/openai/src/internal.ts
@@ -14,4 +14,4 @@ export {
   mcpCallContents,
   searchCallContents,
 } from './from-openai.js';
-export { reasoningEncryptedContent, stringifyMcpOutput } from './to-openai.js';
+export { reasoningEncryptedContent, stringifyMcpOutput, stringifyResult } from './to-openai.js';

--- a/packages/openai/src/to-openai.ts
+++ b/packages/openai/src/to-openai.ts
@@ -25,14 +25,40 @@ function stringifyArguments(args: Record<string, unknown> | string): string {
   return typeof args === 'string' ? args : JSON.stringify(args);
 }
 
-function resultToOutput(result: unknown): string {
-  if (typeof result === 'string') {
-    return result;
+/**
+ * Renders a tool or model result value as the string a wire field carries.
+ *
+ * A string passes through, an absent value (`undefined` / `null`) becomes an empty string, and
+ * anything else is JSON-encoded — the same shape Python's `Content.from_function_result` and
+ * .NET's `EncodeFunctionResultAsJsonStringPayload` give a function result. A value
+ * `JSON.stringify` cannot encode — it throws on a cycle or a `BigInt`, and answers `undefined`
+ * for a symbol or a function — degrades to `String(value)` instead, mirroring Python's
+ * `str(result)` fallback: a wire mapper renders a transcript that already exists, so failing the
+ * whole request over one unencodable value is not an option, and the string form still says
+ * *something* about what the tool answered.
+ *
+ * The single implementation of this rendering: the live provider path and the Foundry hosting
+ * replay and persist paths all go through it, so they cannot drift apart.
+ */
+export function stringifyResult(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
   }
-  if (result === undefined || result === null) {
+  if (value === undefined || value === null) {
     return '';
   }
-  return JSON.stringify(result);
+  const fallback = (): string => {
+    try {
+      return String(value);
+    } catch {
+      return '[unserializable]';
+    }
+  };
+  try {
+    return JSON.stringify(value) ?? fallback();
+  } catch {
+    return fallback();
+  }
 }
 
 /**
@@ -250,7 +276,7 @@ function answeredCallIds(messages: readonly Message[]): Set<string> {
 function functionCallOutput(content: FunctionResultContent): string | ResponsesInputItem[] {
   const items = content.items;
   if (items === undefined || !items.some((item) => item.type === 'data' || item.type === 'uri')) {
-    return resultToOutput(content.result);
+    return stringifyResult(content.result);
   }
   const parts: ResponsesInputItem[] = [];
   for (const item of items) {
@@ -259,7 +285,7 @@ function functionCallOutput(content: FunctionResultContent): string | ResponsesI
       parts.push(part);
     }
   }
-  return parts.length === 0 ? resultToOutput(content.result) : parts;
+  return parts.length === 0 ? stringifyResult(content.result) : parts;
 }
 
 /**

--- a/packages/openai/src/to-openai.wire-fallbacks.test.ts
+++ b/packages/openai/src/to-openai.wire-fallbacks.test.ts
@@ -29,7 +29,7 @@ describe('function result rendering', () => {
     expect(outputOf({ ok: true })).toBe('{"ok":true}');
   });
 
-  it('renders a result JSON.stringify throws on as its string form instead of failing the request', () => {
+  it('renders a result as its string form when JSON.stringify throws', () => {
     // A caller-built transcript can carry a result the tool loop never normalized. `JSON.stringify`
     // throws on a cycle and on a BigInt; failing the whole request over one such result is worse
     // than the degraded string rendering (Python's `Content.from_function_result` falls back to
@@ -47,8 +47,8 @@ describe('function result rendering', () => {
     expect(outputOf(unrenderable)).toBe('[unserializable]');
   });
 
-  it('renders a result JSON.stringify answers undefined for as its string form', () => {
-    // `JSON.stringify` answers `undefined` for a symbol or a function; passing that through put a
+  it('renders a result as its string form when JSON.stringify returns undefined', () => {
+    // `JSON.stringify` returns `undefined` for a symbol or a function; passing that through put a
     // non-string into the wire's string field.
     expect(outputOf(Symbol('opaque'))).toBe('Symbol(opaque)');
   });

--- a/packages/openai/src/to-openai.wire-fallbacks.test.ts
+++ b/packages/openai/src/to-openai.wire-fallbacks.test.ts
@@ -29,6 +29,30 @@ describe('function result rendering', () => {
     expect(outputOf({ ok: true })).toBe('{"ok":true}');
   });
 
+  it('renders a result JSON.stringify throws on as its string form instead of failing the request', () => {
+    // A caller-built transcript can carry a result the tool loop never normalized. `JSON.stringify`
+    // throws on a cycle and on a BigInt; failing the whole request over one such result is worse
+    // than the degraded string rendering (Python's `Content.from_function_result` falls back to
+    // `str(result)` the same way).
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(outputOf(circular)).toBe('[object Object]');
+    expect(outputOf(10n)).toBe('10');
+  });
+
+  it('uses a stable placeholder when neither JSON nor string conversion is possible', () => {
+    const unrenderable = Object.create(null) as Record<string, unknown>;
+    unrenderable.self = unrenderable;
+
+    expect(outputOf(unrenderable)).toBe('[unserializable]');
+  });
+
+  it('renders a result JSON.stringify answers undefined for as its string form', () => {
+    // `JSON.stringify` answers `undefined` for a symbol or a function; passing that through put a
+    // non-string into the wire's string field.
+    expect(outputOf(Symbol('opaque'))).toBe('Symbol(opaque)');
+  });
+
   it('falls back to the string result when rich items carry nothing sendable', () => {
     // The rich-output gate needs a data/uri item, but conversion can still drop it (here: an
     // unsupported audio codec); the string result is what remains.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ catalogs:
       specifier: ^4.1.10
       version: 4.1.10
 
+overrides:
+  nanoid@>=3.0.0 <3.3.18: 3.3.18
+
 importers:
 
   .:
@@ -1987,8 +1990,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3800,7 +3803,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   negotiator@1.0.0: {}
 
@@ -3843,7 +3846,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,8 @@ packages:
   - 'examples/*'
   - 'scripts/type-resolution'
 minimumReleaseAge: 1440
+overrides:
+  'nanoid@>=3.0.0 <3.3.18': 3.3.18
 catalog:
   '@types/node': ^24.0.0
   '@vitest/coverage-v8': 4.1.10

--- a/scripts/pack-check.mjs
+++ b/scripts/pack-check.mjs
@@ -11,7 +11,7 @@
 // Usage: node scripts/pack-check.mjs
 
 import { execSync } from 'node:child_process';
-import { readPackageManifests, workspaceRoot } from './workspace.mjs';
+import { assertLockstepVersions, readPackageManifests, workspaceRoot } from './workspace.mjs';
 
 const stdout = execSync('pnpm -r --filter "./packages/*" pack --dry-run --json', {
   cwd: workspaceRoot,
@@ -25,7 +25,9 @@ const packed = JSON.parse(stdout.slice(stdout.indexOf('[')));
 
 // Map package name -> manifest, so a packed result can be checked against what it promised.
 const manifests = new Map();
-for (const { manifest } of readPackageManifests()) {
+const packageManifests = readPackageManifests();
+const releaseVersion = assertLockstepVersions(packageManifests);
+for (const { manifest } of packageManifests) {
   manifests.set(manifest.name, manifest);
 }
 
@@ -50,6 +52,12 @@ for (const result of packed) {
   }
 
   const files = new Set(result.files.map((file) => file.path.replaceAll('\\', '/')));
+
+  if (result.version !== manifest.version || result.version !== releaseVersion) {
+    problems.push(
+      `${result.name}: packed version ${result.version} does not match manifest/release version ${manifest.version}`,
+    );
+  }
 
   for (const target of exportTargets(manifest.exports)) {
     if (!files.has(target)) {

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// Publishes workspace packages sequentially in dependency order. npm versions are immutable, so
+// true transactionality is impossible; a registry preflight plus idempotent skips makes a retry
+// the safe recovery path if a later package fails after earlier ones were published.
+
+import { spawnSync } from 'node:child_process';
+import { assertLockstepVersions, readPackageManifests, workspaceRoot } from './workspace.mjs';
+
+const tagIndex = process.argv.indexOf('--tag');
+const distTag = tagIndex < 0 ? undefined : process.argv[tagIndex + 1];
+if (distTag === undefined || !/^[0-9A-Za-z][0-9A-Za-z._-]*$/.test(distTag)) {
+  console.error('Usage: node scripts/publish-packages.mjs --tag <dist-tag>');
+  process.exit(1);
+}
+
+const packages = readPackageManifests();
+const version = assertLockstepVersions(packages);
+const byName = new Map(packages.map((entry) => [entry.manifest.name, entry]));
+
+/** Places internal dependencies before packages that depend on them. */
+function publishOrder() {
+  const ordered = [];
+  const visiting = new Set();
+  const visited = new Set();
+  const visit = (entry) => {
+    const name = entry.manifest.name;
+    if (visited.has(name)) return;
+    if (visiting.has(name)) throw new Error(`Workspace package dependency cycle includes ${name}.`);
+    visiting.add(name);
+    for (const field of ['dependencies', 'optionalDependencies', 'peerDependencies']) {
+      for (const dependency of Object.keys(entry.manifest[field] ?? {})) {
+        const internal = byName.get(dependency);
+        if (internal !== undefined) visit(internal);
+      }
+    }
+    visiting.delete(name);
+    visited.add(name);
+    ordered.push(entry);
+  };
+  for (const entry of packages) visit(entry);
+  return ordered;
+}
+
+const registry = new URL(
+  process.env.npm_config_registry ?? process.env.NPM_CONFIG_REGISTRY ?? 'https://registry.npmjs.org/',
+);
+
+async function isPublished(name) {
+  const url = new URL(`${encodeURIComponent(name)}/${encodeURIComponent(version)}`, registry);
+  const response = await fetch(url, { headers: { accept: 'application/json' } });
+  if (response.status === 404) return false;
+  if (!response.ok) {
+    throw new Error(`Registry preflight failed for ${name}@${version}: HTTP ${response.status}.`);
+  }
+  const metadata = await response.json();
+  return metadata.version === version;
+}
+
+const ordered = publishOrder();
+const status = new Map();
+// Complete the read-only registry preflight before publishing anything.
+for (const { manifest } of ordered) {
+  status.set(manifest.name, await isPublished(manifest.name));
+}
+
+const pending = ordered.filter(({ manifest }) => status.get(manifest.name) !== true);
+console.log(
+  `Release ${version}: ${pending.length} package(s) pending, ${ordered.length - pending.length} already published.`,
+);
+
+for (const { manifest } of ordered) {
+  if (status.get(manifest.name) === true) {
+    console.log(`skip ${manifest.name}@${version} (already published)`);
+    continue;
+  }
+  console.log(`publish ${manifest.name}@${version} with dist-tag ${distTag}`);
+  // Runs through the shell as a single command string: on Windows pnpm is a .cmd shim, which
+  // Node refuses to spawn directly (CVE-2024-27980 hardening). Interpolation is safe — the
+  // dist-tag is validated above and package names come from workspace manifests.
+  const result = spawnSync(
+    `pnpm --filter ${manifest.name} publish --access public --provenance --no-git-checks --tag ${distTag}`,
+    { cwd: workspaceRoot, stdio: 'inherit', shell: true },
+  );
+  if (result.error !== undefined) throw result.error;
+  if (result.status !== 0) {
+    console.error(
+      `Publishing stopped at ${manifest.name}@${version}. Retry the workflow; already published versions will be skipped.`,
+    );
+    process.exit(result.status ?? 1);
+  }
+}
+
+console.log(`Published all packages for ${version}.`);

--- a/scripts/release-check.mjs
+++ b/scripts/release-check.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// Fails closed unless CI is running a v* tag whose version matches every publishable package.
+
+import { assertLockstepVersions, readPackageManifests } from './workspace.mjs';
+
+if (process.env.GITHUB_REF_TYPE !== 'tag') {
+  console.error(
+    `Releases must run from a tag, not '${process.env.GITHUB_REF_TYPE ?? 'an unknown ref type'}'.`,
+  );
+  process.exit(1);
+}
+
+const tag = process.env.GITHUB_REF_NAME;
+if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(tag ?? '')) {
+  console.error(`Release tag '${tag ?? ''}' must have the form v1.2.3 or v1.2.3-rc.1.`);
+  process.exit(1);
+}
+
+let version;
+try {
+  version = assertLockstepVersions(readPackageManifests());
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+if (tag.slice(1) !== version) {
+  console.error(`Tag ${tag} does not match the lockstep package version ${version}.`);
+  process.exit(1);
+}
+
+console.log(`Release invariant verified: ${tag}, all packages at ${version}.`);

--- a/scripts/workspace.mjs
+++ b/scripts/workspace.mjs
@@ -20,7 +20,21 @@ export function assertLockstepVersions(packages = readPackageManifests()) {
     throw new Error('No publishable packages were found under packages/.');
   }
   const versions = new Map();
-  for (const { manifest } of packages) {
+  for (const [index, entry] of packages.entries()) {
+    const source =
+      typeof entry?.path === 'string' && entry.path !== ''
+        ? entry.path
+        : `Package manifest at index ${index}`;
+    const manifest = entry?.manifest;
+    if (typeof manifest !== 'object' || manifest === null || Array.isArray(manifest)) {
+      throw new Error(`${source}: package manifest must be an object.`);
+    }
+    for (const field of ['name', 'version']) {
+      const value = manifest[field];
+      if (typeof value !== 'string' || value.trim() === '') {
+        throw new Error(`${source}: package ${field} must be a non-empty string.`);
+      }
+    }
     const names = versions.get(manifest.version) ?? [];
     names.push(manifest.name);
     versions.set(manifest.version, names);

--- a/scripts/workspace.mjs
+++ b/scripts/workspace.mjs
@@ -13,3 +13,23 @@ export function readPackageManifests() {
     return { path, manifest: JSON.parse(readFileSync(path, 'utf8')) };
   });
 }
+
+/** Returns the one release version shared by every package, or throws when lockstep is broken. */
+export function assertLockstepVersions(packages = readPackageManifests()) {
+  if (packages.length === 0) {
+    throw new Error('No publishable packages were found under packages/.');
+  }
+  const versions = new Map();
+  for (const { manifest } of packages) {
+    const names = versions.get(manifest.version) ?? [];
+    names.push(manifest.name);
+    versions.set(manifest.version, names);
+  }
+  if (versions.size !== 1) {
+    const details = [...versions.entries()]
+      .map(([version, names]) => `${version}: ${names.join(', ')}`)
+      .join('; ');
+    throw new Error(`Publishable package versions are not in lockstep (${details}).`);
+  }
+  return versions.keys().next().value;
+}

--- a/scripts/workspace.test.mjs
+++ b/scripts/workspace.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { assertLockstepVersions } from './workspace.mjs';
+
+function entry(manifest, path = 'packages/example/package.json') {
+  return { path, manifest };
+}
+
+test('returns the shared version for valid package manifests', () => {
+  assert.equal(
+    assertLockstepVersions([
+      entry({ name: '@example/core', version: '1.2.3' }),
+      entry({ name: '@example/provider', version: '1.2.3' }),
+    ]),
+    '1.2.3',
+  );
+});
+
+test('rejects a package manifest whose name or version is not a non-empty string', () => {
+  for (const field of ['name', 'version']) {
+    for (const value of [undefined, '', '   ', 123]) {
+      const manifest = { name: '@example/core', version: '1.2.3', [field]: value };
+
+      assert.throws(
+        () => assertLockstepVersions([entry(manifest, 'packages/broken/package.json')]),
+        new RegExp(`packages[/\\\\]broken[/\\\\]package\\.json: package ${field} must be a non-empty string`),
+      );
+    }
+  }
+});
+
+test('rejects a missing package manifest object clearly', () => {
+  assert.throws(
+    () => assertLockstepVersions([{ path: 'packages/broken/package.json' }]),
+    /packages[/\\]broken[/\\]package\.json: package manifest must be an object/,
+  );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,12 @@ export default defineConfig({
       ],
       reporter: ['text', 'html', 'json-summary'],
       reportsDirectory: 'coverage',
+      thresholds: {
+        lines: 95,
+        statements: 95,
+        functions: 90,
+        branches: 90,
+      },
     },
   },
 });


### PR DESCRIPTION
## What this changes

Hardens approval binding, function-call replay, streaming teardown, raw JSON Schema validation, response typing, serialization, and provider wire conversion across core, OpenAI, Anthropic, A2A, MCP, Agent Server, and Foundry. The affected paths previously trusted mutable or provider-supplied state too far, accepted invalid configuration, lost forward-compatible wire data, or leaked/duplicated work at stream and hosting boundaries.

Also strengthens release and CI safeguards with lockstep/tag validation, sequential idempotent publishing, coverage and dependency gates, opt-in live integration tests, hardened container examples, and regression coverage for the corrected behavior.

## Parity

- Reference checked: .NET first, then Python and Go for approval snapshots, function invocation, stream lifecycle, response folding, serialization, hosted protocols, and provider mappings; deliberate safety hardening is documented where the references are ambiguous or incomplete.
- Wire format affected: yes — unknown provider content is preserved where replayable, Anthropic citations and OpenAI errors are mapped, and structured tool results retain their JSON shape.
- Public API affected: yes — response values now expose possible `undefined`, non-object raw-schema inputs are `unknown`, Anthropic thinking is a validated discriminated union, and Foundry target/client configuration rejects invalid states.
- Breaking change: yes — the intentional type corrections are documented under Unreleased in `CHANGELOG.md`.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`

Additional validation: 1,784 tests passed, 25 opt-in live tests skipped; coverage is 96.31% statements, 90.85% branches, 97.28% functions, and 96.63% lines; all eight packages pack cleanly; dependency audit reports zero advisories.