### PR TITLE
Guide models to pass positional script arguments as a string array

### DIFF
--- a/packages/core/src/skills/provider.test.ts
+++ b/packages/core/src/skills/provider.test.ts
@@ -85,6 +85,22 @@ describe('skillsProvider advertising', () => {
     expect(prompt).not.toContain('Read the table, then run convert.');
   });
 
+  it('distinguishes the two script argument shapes in the default prompt', async () => {
+    const contribution = await runProvider(skillsProvider([unitConverter]));
+
+    const prompt = contribution.instructions.join('\n');
+    const scriptGuidance = prompt.split('\n').filter((line) => line.includes('script'));
+    // Named arguments go as a JSON object — inline scripts included — while file-based scripts
+    // documenting CLI-style positional arguments take a string array.
+    expect(
+      scriptGuidance.some((line) => line.includes('JSON object') && line.includes('inline scripts')),
+    ).toBe(true);
+    expect(
+      scriptGuidance.some((line) => line.includes('array of strings') && line.includes('file-based scripts')),
+    ).toBe(true);
+    expect(prompt).toContain('not as top-level tool parameters');
+  });
+
   it('escapes skill metadata so a crafted description cannot close the element', async () => {
     const injected = inlineSkill({
       name: 'crafted',

--- a/packages/core/src/skills/provider.ts
+++ b/packages/core/src/skills/provider.ts
@@ -65,8 +65,10 @@ const RESOURCE_INSTRUCTIONS =
 
 const SCRIPT_INSTRUCTIONS =
   '- Use `run_skill_script` to run referenced scripts, using the name exactly as listed.\n' +
-  '- Pass script arguments inside `args` as a JSON object' +
-  ' (e.g. `args: {"length": 24}`), not as top-level tool parameters.\n';
+  '- Pass named script arguments inside `args` as a JSON object, including for inline scripts' +
+  ' (e.g. `args: {"length": 24}`), not as top-level tool parameters.\n' +
+  '- For file-based scripts that document CLI-style positional arguments, pass `args` as an array of strings' +
+  ' (e.g. `args: ["input.docx", "--output", "result.idx"]`).\n';
 
 /**
  * Advertises skills to the model and gives it the tools to pull them in.


### PR DESCRIPTION
## Problem

The skills system prompt's script guidance only showed the JSON-object argument form:

> Pass script arguments inside `args` as a JSON object (e.g. `args: {"length": 24}`), not as top-level tool parameters.

The `run_skill_script` tool schema and the script runner have accepted a string array for CLI-style positional arguments all along (`args: ["input.docx", "--output", "result.idx"]`), but models read the prompt before the tool schema, so they leaned toward the object form even for file-based scripts that document positional arguments.

## Change

Prompt wording only — no API or runtime change. The guidance now matches what the Python implementation adopted in microsoft/agent-framework#7695:

- the object form is scoped to **named** arguments, inline scripts included;
- a new line covers file-based scripts documenting CLI-style positional arguments, with the string-array example.

A prompt test mirroring the upstream one asserts both shapes are distinguished in the default prompt.

## Verification

- The new test was written first and observed failing against the previous wording, and failing again after temporarily reverting the fix.
- `pnpm check` passes (exit code verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)