### PR TITLE
Store a streamed background suspension's exchange exactly once

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -472,6 +472,9 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
     let injectedMessages: readonly Message[] = [];
     let afterRunDone = false;
     let activeSession: AgentSession | undefined;
+    // Whether the caller consumed this run as a stream; a streaming run's continuation token
+    // replays the whole exchange, which decides who persists it (see #notifyProvidersAfterRun).
+    let streamedRun = false;
     // The `invoke_agent` span covers the whole run, including the tool loop and history
     // persistence, so it is started in `start` and closed by hand rather than around a call.
     let runSpan: Span | undefined;
@@ -495,10 +498,18 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
         return;
       }
       afterRunDone = true;
-      await this.#notifyProvidersAfterRun(providerContexts, injectedMessages, activeSession, response, error);
+      await this.#notifyProvidersAfterRun(
+        providerContexts,
+        injectedMessages,
+        activeSession,
+        response,
+        error,
+        streamedRun,
+      );
     };
 
     const start = async (ctx: { stream: boolean }): Promise<AsyncIterable<AgentResponseUpdate>> => {
+      streamedRun = ctx.stream;
       const session = presetSession ?? options?.session ?? this.createSession();
       activeSession = session;
       this.#rejectHistoryConflict(session);
@@ -688,13 +699,20 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
     session: AgentSession | undefined,
     response: AgentResponse<unknown> | undefined,
     error: unknown,
+    streamed: boolean,
   ): Promise<void> {
     const serviceOwnsHistory = session?.serviceSessionId !== undefined;
+    // A streaming run that ended suspended does not persist: its continuation token replays the
+    // caller's input and every update already produced, so the run that finally completes stores
+    // the whole exchange in one append — storing the suspended half here too would hand the next
+    // turn the question and the partial answer twice. An awaited run's token carries nothing, so
+    // an awaited suspension still stores its own half and the resumed run appends only its tail.
+    const suspendedStream = streamed && response?.continuationToken !== undefined;
     for (const { provider, ctx } of providerContexts) {
       if (provider.afterRun === undefined) {
         continue;
       }
-      if (serviceOwnsHistory && provider === this.historyProvider) {
+      if ((serviceOwnsHistory || suspendedStream) && provider === this.historyProvider) {
         continue;
       }
       const afterCtx: ProviderAfterRunContext = {
@@ -795,9 +813,11 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
       });
       seen.push(mapped);
       if (mapped.continuationToken !== undefined) {
-        // Both halves ride on the same gate (Go `agent.go`): an awaited run folds its own
-        // updates *and* has already persisted its own input, so carrying either in the token
-        // makes the resumed run store the exchange a second time.
+        // Both halves ride on the same gate: an awaited run folds its own updates *and* has
+        // already persisted its own input, so carrying either in the token makes the resumed run
+        // store the exchange a second time. A streaming run is the mirror image — its token
+        // carries everything, so the suspended run persists nothing and the completing run
+        // stores the whole exchange (see #notifyProvidersAfterRun).
         mapped.continuationToken = wrapContinuationToken(
           mapped.continuationToken,
           wantsTokenReplay ? inputMessages : [],

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -39,7 +39,7 @@ import { createResponseStream } from '../streaming/response-stream.js';
 import type { StandardSchemaV1 } from '../tools/standard-schema.js';
 import type { FunctionTool, Tool } from '../tools/tool.js';
 import type { AgentRunInput, Message } from '../types/message.js';
-import { normalizeInput } from '../types/message.js';
+import { normalizeInput, notSourceTypes } from '../types/message.js';
 import type {
   AgentResponse,
   AgentResponseUpdate,
@@ -524,7 +524,9 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
         }
       }
 
-      injectedMessages = [...prepared.accumulator.messages];
+      // A resumed run injected nothing itself; what the suspended run injected rides its token,
+      // so the completing run can still hand it to the providers that persist it.
+      injectedMessages = resuming ? continuation.contextMessages : [...prepared.accumulator.messages];
       const messages: Message[] = resuming ? [] : [...prepared.accumulator.messages, ...inputMessages];
       const chatOptions = this.#mergeOptions(options, prepared.accumulator, session, continuation.innerToken);
       const client = this.#approvalClient(session, functionMiddleware);
@@ -541,6 +543,9 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
       const mapUpdate = this.#createUpdateMapper({
         session,
         inputMessages,
+        // Replayed history stays out of the token: the store already holds it, and a long
+        // transcript would dwarf everything else the token carries.
+        contextMessages: notSourceTypes('ChatHistory')(injectedMessages),
         seen,
         wantsTokenReplay: ctx.stream,
       });
@@ -763,12 +768,14 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
   #createUpdateMapper(run: {
     session: AgentSession;
     inputMessages: Message[];
+    /** What this run's providers injected, minus replayed history; a streaming token carries it. */
+    contextMessages: readonly Message[];
     /** Shared with the caller; every mapped update is appended so a token can carry them. */
     seen: AgentResponseUpdate[];
     /** `true` for a streaming run, whose token must replay input and updates on resume. */
     wantsTokenReplay: boolean;
   }): (update: ChatResponseUpdate) => AgentResponseUpdate {
-    const { session, inputMessages, seen, wantsTokenReplay } = run;
+    const { session, inputMessages, contextMessages, seen, wantsTokenReplay } = run;
     const agentName = this.name;
     const agentId = this.id;
 
@@ -822,6 +829,7 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
           mapped.continuationToken,
           wantsTokenReplay ? inputMessages : [],
           wantsTokenReplay ? seen : [],
+          wantsTokenReplay ? contextMessages : [],
         );
       }
       return mapped;

--- a/packages/core/src/agent/continuation.test.ts
+++ b/packages/core/src/agent/continuation.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ChatClient, ChatOptions, ChatResponseStream } from '../client/chat-client.js';
+import type { ContextProvider } from '../context/context-provider.js';
+import { InMemoryHistoryProvider } from '../context/in-memory-history-provider.js';
 import { ConfigurationError } from '../errors.js';
 import { createResponseStream } from '../streaming/response-stream.js';
 import { textContent } from '../types/content.js';
@@ -126,7 +128,11 @@ describe('token payload round trip', () => {
   });
 
   it('parses an absent token to empty state and rejects a foreign one', () => {
-    expect(parseContinuationToken(undefined)).toEqual({ inputMessages: [], updates: [] });
+    expect(parseContinuationToken(undefined)).toEqual({
+      inputMessages: [],
+      updates: [],
+      contextMessages: [],
+    });
     expect(() => parseContinuationToken({ responseId: 'raw' })).toThrow(ConfigurationError);
   });
 });
@@ -332,6 +338,47 @@ describe('continuation tokens', () => {
     expect(replayed.filter((text) => text.includes('one'))).toHaveLength(1);
     expect(replayed.filter((text) => text.includes('two'))).toHaveLength(1);
     expect(replayed.join('')).toContain('three');
+  });
+
+  it('stores the injected context of a suspended stream once it completes', async () => {
+    const client = new BackgroundClient([
+      { text: 'working ', token: { responseId: 'resp_1' } },
+      { text: 'done' },
+      { text: 'next turn' },
+    ]);
+    // Injects once, so the count below reads what the *store* holds rather than mixing in a
+    // fresh injection on the follow-up turn.
+    let injected = false;
+    const docs: ContextProvider = {
+      sourceId: 'docs',
+      beforeRun: (ctx) => {
+        if (!injected) {
+          injected = true;
+          ctx.extendMessages([{ role: 'user', contents: [textContent('retrieved doc')] }]);
+        }
+      },
+    };
+    const agent = new Agent({
+      client,
+      historyProvider: new InMemoryHistoryProvider({ storeContextMessages: true }),
+      contextProviders: [docs],
+    });
+    const session = agent.createSession();
+
+    let token: ContinuationToken | undefined;
+    for await (const update of agent.run('long job', { session, allowBackgroundResponses: true })) {
+      token = update.continuationToken ?? token;
+    }
+    await agent.run(undefined, { session, continuationToken: must(token) });
+
+    // The suspended run defers persistence to the completing run, so the injected context has to
+    // ride the continuation token alongside the input — otherwise it would never be stored.
+    await agent.run('and now?', { session });
+    const replayed = must(client.seen[2]).messages.flatMap((msg) =>
+      msg.contents.flatMap((c) => (c.type === 'text' ? [c.text] : [])),
+    );
+    expect(replayed.filter((text) => text === 'retrieved doc')).toHaveLength(1);
+    expect(replayed.filter((text) => text === 'long job')).toHaveLength(1);
   });
 
   it('skips history replay on resume but still persists the exchange', async () => {

--- a/packages/core/src/agent/continuation.test.ts
+++ b/packages/core/src/agent/continuation.test.ts
@@ -271,6 +271,69 @@ describe('continuation tokens', () => {
     expect(resumed.value).toEqual({ ok: true });
   });
 
+  it('stores a streamed suspension exactly once, when the resumed run completes', async () => {
+    const client = new BackgroundClient([
+      { text: 'part one ', token: { responseId: 'resp_1' } },
+      { text: 'part two' },
+      { text: 'next turn' },
+    ]);
+    const agent = new Agent({ client });
+    const session = agent.createSession();
+
+    let token: ContinuationToken | undefined;
+    for await (const update of agent.run('long job', { session, allowBackgroundResponses: true })) {
+      token = update.continuationToken ?? token;
+    }
+    const resumed = await agent.run(undefined, { session, continuationToken: must(token) });
+    expect(resumed.continuationToken).toBeUndefined();
+    expect(resumed.text).toContain('part one');
+    expect(resumed.text).toContain('part two');
+
+    // A streaming token replays the input and every update already produced, so the completing
+    // run stores the whole exchange; the suspended run storing its half too would make the next
+    // turn replay the question and the partial answer twice.
+    await agent.run('and now?', { session });
+    const replayed = must(client.seen[2]).messages.flatMap((msg) =>
+      msg.contents.flatMap((c) => (c.type === 'text' ? [c.text] : [])),
+    );
+    expect(replayed.filter((text) => text === 'long job')).toHaveLength(1);
+    expect(replayed.filter((text) => text.includes('part one'))).toHaveLength(1);
+    expect(replayed.join('')).toContain('part two');
+  });
+
+  it('stores a twice-suspended streamed exchange exactly once', async () => {
+    const client = new BackgroundClient([
+      { text: 'one ', token: { responseId: 'r1' } },
+      { text: 'two ', token: { responseId: 'r2' } },
+      { text: 'three' },
+      { text: 'next turn' },
+    ]);
+    const agent = new Agent({ client });
+    const session = agent.createSession();
+
+    let token1: ContinuationToken | undefined;
+    for await (const update of agent.run('long job', { session, allowBackgroundResponses: true })) {
+      token1 = update.continuationToken ?? token1;
+    }
+    // The second run resumes as a stream and suspends again; its token carries the whole
+    // exchange so far, so only the run that finally completes appends to history.
+    let token2: ContinuationToken | undefined;
+    for await (const update of agent.run(undefined, { session, continuationToken: must(token1) })) {
+      token2 = update.continuationToken ?? token2;
+    }
+    const resumed = await agent.run(undefined, { session, continuationToken: must(token2) });
+    expect(resumed.continuationToken).toBeUndefined();
+
+    await agent.run('and now?', { session });
+    const replayed = must(client.seen[3]).messages.flatMap((msg) =>
+      msg.contents.flatMap((c) => (c.type === 'text' ? [c.text] : [])),
+    );
+    expect(replayed.filter((text) => text === 'long job')).toHaveLength(1);
+    expect(replayed.filter((text) => text.includes('one'))).toHaveLength(1);
+    expect(replayed.filter((text) => text.includes('two'))).toHaveLength(1);
+    expect(replayed.join('')).toContain('three');
+  });
+
   it('skips history replay on resume but still persists the exchange', async () => {
     const client = new BackgroundClient([
       { text: 'working…', token: { responseId: 'resp_1' } },

--- a/packages/core/src/agent/continuation.ts
+++ b/packages/core/src/agent/continuation.ts
@@ -24,6 +24,14 @@ export interface AgentContinuationToken extends ContinuationToken {
   inputMessages?: SerializedMessage[];
   /** Every update produced before the run was suspended. */
   responseUpdates?: SerializedUpdate[];
+  /**
+   * What the context providers injected into the original run, minus replayed history.
+   *
+   * A suspended streaming run defers persistence to the run that completes the exchange, so the
+   * injected context has to travel with the token for a store configured to keep it. Replayed
+   * history is excluded: it is already in the store, and it can dwarf the rest of the token.
+   */
+  contextMessages?: SerializedMessage[];
 }
 
 /** An {@link AgentResponseUpdate} reduced to its JSON-safe fields. */
@@ -89,6 +97,7 @@ export function wrapContinuationToken(
   innerToken: ContinuationToken,
   inputMessages: readonly Message[],
   updates: readonly AgentResponseUpdate[],
+  contextMessages: readonly Message[] = [],
 ): AgentContinuationToken {
   const token: AgentContinuationToken = { type: AGENT_TOKEN_TYPE, innerToken };
   if (inputMessages.length > 0) {
@@ -96,6 +105,9 @@ export function wrapContinuationToken(
   }
   if (updates.length > 0) {
     token.responseUpdates = updates.map(serializeUpdate);
+  }
+  if (contextMessages.length > 0) {
+    token.contextMessages = serializeMessages(contextMessages);
   }
   return token;
 }
@@ -105,6 +117,7 @@ export interface ContinuationState {
   innerToken?: ContinuationToken;
   inputMessages: Message[];
   updates: AgentResponseUpdate[];
+  contextMessages: Message[];
 }
 
 /**
@@ -114,7 +127,7 @@ export interface ContinuationState {
  */
 export function parseContinuationToken(token: ContinuationToken | undefined): ContinuationState {
   if (token === undefined) {
-    return { inputMessages: [], updates: [] };
+    return { inputMessages: [], updates: [], contextMessages: [] };
   }
   if (!isAgentContinuationToken(token)) {
     throw new ConfigurationError(
@@ -126,5 +139,6 @@ export function parseContinuationToken(token: ContinuationToken | undefined): Co
     innerToken: token.innerToken,
     inputMessages: deserializeMessages(token.inputMessages ?? []),
     updates: (token.responseUpdates ?? []).map(deserializeUpdate),
+    contextMessages: deserializeMessages(token.contextMessages ?? []),
   };
 }

--- a/packages/core/src/context/context-provider.ts
+++ b/packages/core/src/context/context-provider.ts
@@ -40,8 +40,10 @@ export interface ProviderAfterRunContext extends ProviderRunContext {
    *
    * Each message carries the source stamp of the provider that contributed it, so a history
    * provider can persist retrieved documents or replayed memories alongside the exchange — see
-   * {@link HistoryStoreOptions.storeContextMessages}. Empty during a resumed run, which re-enters
-   * after the context was already applied.
+   * {@link HistoryStoreOptions.storeContextMessages}. A resumed run re-enters after the context
+   * was already applied, so it injects nothing itself; when resuming a streamed suspension this
+   * carries what the suspended run injected (minus replayed history, which the store already
+   * holds), since that run deferred persistence to the one that completes the exchange.
    */
   readonly contextMessages: readonly Message[];
 }

--- a/packages/core/src/context/context-provider.ts
+++ b/packages/core/src/context/context-provider.ts
@@ -94,6 +94,10 @@ export function sourceTypeOf(provider: ContextProvider): MessageSourceType {
  *
  * - `saveMessages` is handed **only the messages new to that turn**. The transcript is never
  *   re-sent, so an implementation appends what it is given and never has to diff or de-duplicate.
+ *   A background turn split across a suspension and a resume still appends once: a streaming run
+ *   that ends suspended stores nothing (its continuation token replays the whole exchange, and
+ *   the run that completes stores it), while an awaited suspension stores its own half and the
+ *   resumed run appends only its tail.
  * - It is called once per run, not once per round of the tool loop, so one turn's function calls
  *   and their results arrive together with the answer they produced.
  * - `getMessages` returns the transcript oldest first, and whatever it returns is replayed ahead


### PR DESCRIPTION
## Problem

Interrupting a streamed run with `allowBackgroundResponses` and resuming it with the `continuationToken` double-saved the exchange:

1. The suspended run itself persisted the input and the partial updates through its `afterRun` hook (a suspended stream still finalizes).
2. The resumed run's context carried the token's replayed input, and its folded response included the carried updates, so it persisted the input and the partial a second time alongside the tail.

The next turn then replayed the question and the partial answer twice. This violated the documented `HistoryProvider` contract: `saveMessages` is handed only the messages new to that turn, so implementations append without de-duplicating.

## Change

A streaming run that ends suspended (its merged response still carries a continuation token) skips history persistence. Its token replays the caller's input and every update already produced, so the run that finally completes stores the whole exchange in one append — with partial messages merged by the fold rather than split across store entries. This matches the resumed-run semantics the .NET test suite locks in (`RunStreamingAsync_WhenResumingStreaming_UsesUpdatesFromInitialRunForContextProviderAndChatHistoryProviderAsync`: the resumed run notifies the history provider with the carried-plus-new exchange, exactly once).

The invariant: **a run whose outgoing token replays everything it saw stores nothing.**

- Streaming tokens carry the input and the cumulative updates → the suspended run stores nothing; chained suspensions keep deferring until completion.
- Awaited tokens carry nothing → an awaited suspension keeps storing its own half and the resumed run appends only its tail (existing behavior, unchanged and covered by an existing test).
- Mixed awaited/streaming chains store each fragment exactly once under the same rule.

The fold takes the continuation token from the latest update (matching Go `Response.Update`), so a completed background response reliably clears it — a background stream that runs to completion persists normally.

Context providers other than history are still notified of a suspended run, unchanged. A discarded token now leaves nothing in history rather than an unanswered question — the shape the provider contract already documents as desired. The `HistoryProvider` contract docs now state the suspension behavior explicitly.

## Verification

- Two reproduction tests (single suspension, and a twice-suspended chain) were written first and observed failing — the replayed transcript contained the input twice / three times.
- After the fix, the implementation was temporarily reverted to confirm both tests fail again, then restored.
- The existing awaited-suspension test (input stored exactly once) passes unchanged.
- `pnpm check` passes (exit code verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)