### PR TITLE
Centralize Foundry credentials and endpoint in a shared FoundryProject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **[BREAKING] `@polymind-inc/agent-framework-foundry`** — Foundry credentials and the project
+  endpoint are centralized in the new `FoundryProject` handle
+  (`new FoundryProject(endpoint, credential, { scope?, fetch? })`, mirroring
+  `new AIProjectClient(endpoint, credential)` from `@azure/ai-projects`: both arguments are
+  required, and neither is resolved from the environment or constructed implicitly).
+  `FoundryChatClient`, `FoundryMemoryProvider`, `FoundryToolbox` and `FoundryResponseStore` take a
+  required `project` instead of the removed per-component `credential`, `scope` and
+  `projectEndpoint` options — previously each component silently constructed its own
+  `DefaultAzureCredential` chain, and a stale `FOUNDRY_PROJECT_ENDPOINT` could silently decide
+  where bearer tokens were sent. Every component built from one project shares one per-scope
+  bearer-token cache. The `tokenProvider` export is removed; `project.getToken()` is its
+  successor. The one remaining implicit default is inside the hosting bootstrap: a hosted
+  container's default response store still assembles its project from the platform-injected
+  endpoint and `DefaultAzureCredential`, the same default the Python agent server's Foundry
+  storage applies. The reference implementations all demand this explicitness: .NET and Python
+  hang every Foundry feature off an explicitly constructed `AIProjectClient` (Python requires
+  `credential` whenever no `project_client` is given), and Go takes a credential as a required
+  constructor argument.
 - **[BREAKING] `@polymind-inc/agent-framework-core`** — `ResponseBase<T>.value` is now
   `T | undefined`. A suspended run (for example, one waiting for tool approval) and a response
   created without a structured-output value have always carried `undefined` at runtime; callers
@@ -21,9 +39,14 @@ contain breaking changes**; patch releases are fixes only.
   `{ type: 'disabled' }` cannot carry a budget. Invalid configurations now fail at construction
   instead of reaching Anthropic as an invalid request.
 - **[BREAKING] `@polymind-inc/agent-framework-foundry`** — `FoundryTarget` now enforces exactly one
-  of `modelDeployment` and `serverAgent`. When an already-configured SDK `client` is supplied,
-  `projectEndpoint` is optional and `baseURL` reports the client's actual URL; configurations
-  without a client still require a project endpoint.
+  of its two selectors. When an already-configured SDK `client` is supplied, `baseURL` reports the
+  client's actual URL.
+- **[BREAKING] `@polymind-inc/agent-framework-foundry`** — `FoundryTarget`'s `modelDeployment`
+  selector is renamed `model`, and the exported guard `isModelDeployment` is renamed
+  `isModelTarget`. The value still names a model *deployment* in the project; `model` is what both
+  .NET (the `model` parameter on `FoundryAgent` and `AsAIAgent`) and Python (the `model` keyword,
+  `FOUNDRY_MODEL`) call it, while Go's `ModelDeployment` is a per-mode *type* name in a design
+  TypeScript's discriminated union does not share.
 - **Security:** approval requests are immutable snapshots before they reach callers, so mutating a
   streamed or awaited request cannot change the arguments later executed after approval. Raw JSON
   Schema arguments are checked locally, executable-only approval bypassing no longer consumes

--- a/examples/02-foundry/01-foundry-chat.ts
+++ b/examples/02-foundry/01-foundry-chat.ts
@@ -11,19 +11,22 @@
  *   AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini \
  *   pnpm --filter example-02-foundry chat
  */
+import { DefaultAzureCredential } from '@azure/identity';
 import { Agent, tool } from '@polymind-inc/agent-framework';
-import { FoundryChatClient } from '@polymind-inc/agent-framework/foundry';
+import { FoundryChatClient, FoundryProject } from '@polymind-inc/agent-framework/foundry';
 
 const projectEndpoint = process.env.FOUNDRY_PROJECT_ENDPOINT;
 if (projectEndpoint === undefined) {
   throw new Error('Set FOUNDRY_PROJECT_ENDPOINT to your Foundry project endpoint.');
 }
 
-// `DefaultAzureCredential` is used unless a `credential` is passed, so `az login` is enough
-// locally and a managed identity works unchanged in Azure.
+// One project handle carries the endpoint and the identity for every Foundry component.
+// `DefaultAzureCredential` covers `az login` locally and a managed identity in Azure.
+const project = new FoundryProject(projectEndpoint, new DefaultAzureCredential());
+
 const client = new FoundryChatClient({
-  projectEndpoint,
-  target: { modelDeployment: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini' },
+  project,
+  target: { model: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini' },
 });
 
 const getWeather = tool({
@@ -64,7 +67,7 @@ process.stdout.write('\n');
 const serverAgentName = process.env.FOUNDRY_SERVER_AGENT;
 if (serverAgentName !== undefined) {
   const serverAgent = new Agent({
-    client: new FoundryChatClient({ projectEndpoint, target: { serverAgent: serverAgentName } }),
+    client: new FoundryChatClient({ project, target: { serverAgent: serverAgentName } }),
   });
   console.log('[server agent]', (await serverAgent.run('Hello')).text);
 }

--- a/examples/02-foundry/02-hosted-agent/main.ts
+++ b/examples/02-foundry/02-hosted-agent/main.ts
@@ -12,9 +12,10 @@
  * On Foundry: see README.md.
  */
 
+import { DefaultAzureCredential } from '@azure/identity';
 import { Agent, tool } from '@polymind-inc/agent-framework';
 import { serve } from '@polymind-inc/agent-framework/agentserver/node';
-import { FoundryChatClient } from '@polymind-inc/agent-framework/foundry';
+import { FoundryChatClient, FoundryProject } from '@polymind-inc/agent-framework/foundry';
 import { ResponsesHostServer } from '@polymind-inc/agent-framework/foundry/hosting';
 
 const getWeather = tool({
@@ -38,8 +39,10 @@ if (projectEndpoint === undefined) {
 
 const agent = new Agent({
   client: new FoundryChatClient({
-    projectEndpoint,
-    target: { modelDeployment: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini' },
+    // `DefaultAzureCredential` covers `az login` locally and the container's managed identity on
+    // Foundry.
+    project: new FoundryProject(projectEndpoint, new DefaultAzureCredential()),
+    target: { model: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini' },
   }),
   name: 'weather-agent',
   instructions: 'You are a helpful assistant. Answer in one short sentence.',

--- a/examples/02-foundry/04-toolbox.ts
+++ b/examples/02-foundry/04-toolbox.ts
@@ -15,8 +15,9 @@
  *   FOUNDRY_TOOLBOX_NAME=<toolbox> \
  *   pnpm --filter example-02-foundry toolbox
  */
+import { DefaultAzureCredential } from '@azure/identity';
 import { Agent } from '@polymind-inc/agent-framework';
-import { FoundryChatClient } from '@polymind-inc/agent-framework/foundry';
+import { FoundryChatClient, FoundryProject } from '@polymind-inc/agent-framework/foundry';
 import { FoundryToolbox } from '@polymind-inc/agent-framework/foundry/hosting';
 
 const projectEndpoint = process.env.FOUNDRY_PROJECT_ENDPOINT;
@@ -25,9 +26,12 @@ if (projectEndpoint === undefined || toolboxName === undefined) {
   throw new Error('Set FOUNDRY_PROJECT_ENDPOINT and FOUNDRY_TOOLBOX_NAME.');
 }
 
+// One project handle for both components, so they share one identity and one token cache.
+const project = new FoundryProject(projectEndpoint, new DefaultAzureCredential());
+
 const toolbox = new FoundryToolbox({
   name: toolboxName,
-  projectEndpoint,
+  project,
   // Narrow what the model may call with `allowedTools: ['...']`. The toolbox may expose more than
   // this agent should be able to reach.
 });
@@ -38,8 +42,8 @@ try {
 
   const agent = new Agent({
     client: new FoundryChatClient({
-      projectEndpoint,
-      target: { modelDeployment: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini' },
+      project,
+      target: { model: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini' },
     }),
     name: 'toolbox-agent',
     instructions:

--- a/examples/02-foundry/05-invocations-agent/main.ts
+++ b/examples/02-foundry/05-invocations-agent/main.ts
@@ -13,9 +13,10 @@
  * On Foundry: see README.md.
  */
 
+import { DefaultAzureCredential } from '@azure/identity';
 import { Agent } from '@polymind-inc/agent-framework';
 import { serve } from '@polymind-inc/agent-framework/agentserver/node';
-import { FoundryChatClient } from '@polymind-inc/agent-framework/foundry';
+import { FoundryChatClient, FoundryProject } from '@polymind-inc/agent-framework/foundry';
 import { InvocationsHostServer } from '@polymind-inc/agent-framework/foundry/hosting';
 
 const projectEndpoint = process.env.FOUNDRY_PROJECT_ENDPOINT;
@@ -25,8 +26,10 @@ if (projectEndpoint === undefined) {
 
 const agent = new Agent({
   client: new FoundryChatClient({
-    projectEndpoint,
-    target: { modelDeployment: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini' },
+    // `DefaultAzureCredential` covers `az login` locally and the container's managed identity on
+    // Foundry.
+    project: new FoundryProject(projectEndpoint, new DefaultAzureCredential()),
+    target: { model: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini' },
   }),
   name: 'invocations-agent',
   instructions: 'You are a friendly assistant. Keep your answers brief.',

--- a/examples/02-foundry/06-memory-agent/main.ts
+++ b/examples/02-foundry/06-memory-agent/main.ts
@@ -15,9 +15,14 @@
  * On Foundry: see README.md.
  */
 
+import { DefaultAzureCredential } from '@azure/identity';
 import { Agent } from '@polymind-inc/agent-framework';
 import { serve } from '@polymind-inc/agent-framework/agentserver/node';
-import { FoundryChatClient, FoundryMemoryProvider } from '@polymind-inc/agent-framework/foundry';
+import {
+  FoundryChatClient,
+  FoundryMemoryProvider,
+  FoundryProject,
+} from '@polymind-inc/agent-framework/foundry';
 import { hostedUserScope, ResponsesHostServer } from '@polymind-inc/agent-framework/foundry/hosting';
 
 const projectEndpoint = process.env.FOUNDRY_PROJECT_ENDPOINT;
@@ -29,8 +34,13 @@ if (memoryStoreName === undefined) {
   throw new Error('Set MEMORY_STORE_NAME to the memory store provisioned for this agent.');
 }
 
+// One project handle for the chat client and the memory provider: one identity, one token cache.
+// `DefaultAzureCredential` covers `az login` locally and the container's managed identity on
+// Foundry.
+const project = new FoundryProject(projectEndpoint, new DefaultAzureCredential());
+
 const memory = new FoundryMemoryProvider({
-  projectEndpoint,
+  project,
   memoryStoreName,
   // Every user of this container gets their own partition of the store. `hostedUserScope()` reads
   // the end-user id the platform injects per request, so one provider instance serves all of them
@@ -43,8 +53,8 @@ const memory = new FoundryMemoryProvider({
 
 const agent = new Agent({
   client: new FoundryChatClient({
-    projectEndpoint,
-    target: { modelDeployment: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini' },
+    project,
+    target: { model: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini' },
   }),
   name: 'memory-agent',
   instructions:

--- a/examples/02-foundry/06-memory-agent/provision.ts
+++ b/examples/02-foundry/06-memory-agent/provision.ts
@@ -10,7 +10,8 @@
  * clean slate while trying the sample out.
  */
 
-import { FoundryMemoryProvider } from '@polymind-inc/agent-framework/foundry';
+import { DefaultAzureCredential } from '@azure/identity';
+import { FoundryMemoryProvider, FoundryProject } from '@polymind-inc/agent-framework/foundry';
 
 const projectEndpoint = process.env.FOUNDRY_PROJECT_ENDPOINT;
 if (projectEndpoint === undefined) {
@@ -26,7 +27,7 @@ if (memoryStoreName === undefined) {
 const resetIndex = process.argv.indexOf('--reset');
 const resetUser = resetIndex === -1 ? undefined : process.argv[resetIndex + 1];
 const memory = new FoundryMemoryProvider({
-  projectEndpoint,
+  project: new FoundryProject(projectEndpoint, new DefaultAzureCredential()),
   memoryStoreName,
   scope: resetUser ?? 'provisioning',
 });

--- a/examples/02-foundry/07-toolbox-skills/main.ts
+++ b/examples/02-foundry/07-toolbox-skills/main.ts
@@ -16,9 +16,10 @@
  * On Foundry: see README.md.
  */
 
+import { DefaultAzureCredential } from '@azure/identity';
 import { Agent } from '@polymind-inc/agent-framework';
 import { serve } from '@polymind-inc/agent-framework/agentserver/node';
-import { FoundryChatClient } from '@polymind-inc/agent-framework/foundry';
+import { FoundryChatClient, FoundryProject } from '@polymind-inc/agent-framework/foundry';
 import { FoundryToolbox, ResponsesHostServer } from '@polymind-inc/agent-framework/foundry/hosting';
 
 const projectEndpoint = process.env.FOUNDRY_PROJECT_ENDPOINT;
@@ -30,9 +31,14 @@ if (toolboxName === undefined) {
   throw new Error('Set FOUNDRY_TOOLBOX_NAME to the toolbox whose skills this agent should use.');
 }
 
+// One project handle for both components, so they share one identity and one token cache.
+// `DefaultAzureCredential` covers `az login` locally and the container's managed identity on
+// Foundry.
+const project = new FoundryProject(projectEndpoint, new DefaultAzureCredential());
+
 const toolbox = new FoundryToolbox({
-  projectEndpoint,
   name: toolboxName,
+  project,
   // Skills only: `getTools()` answers with nothing and the gateway is never asked to list tools.
   // Drop this line to give the model the toolbox's tools as well — the two compose, and a skill
   // body is often instructions for using exactly those tools.
@@ -47,8 +53,8 @@ const server = new ResponsesHostServer({
   agent: async () =>
     new Agent({
       client: new FoundryChatClient({
-        projectEndpoint,
-        target: { modelDeployment: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini' },
+        project,
+        target: { model: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? 'gpt-4o-mini' },
       }),
       name: 'toolbox-skills-agent',
       instructions:

--- a/examples/02-foundry/package.json
+++ b/examples/02-foundry/package.json
@@ -23,6 +23,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@azure/identity": "^4.13.2",
     "@polymind-inc/agent-framework": "workspace:^"
   },
   "devDependencies": {

--- a/packages/foundry/README.md
+++ b/packages/foundry/README.md
@@ -7,8 +7,10 @@
 > works and resolves to the same modules, but examples and documentation import through the main
 > package.
 
-Microsoft Foundry provider for the Agent Framework: `FoundryChatClient` talks to a Foundry
-project (model deployments or server agents) with Microsoft Entra authentication,
+Microsoft Foundry provider for the Agent Framework: `FoundryProject` names the project — the
+endpoint requests go to and the Microsoft Entra identity they carry — and is shared by every
+component here, the way an `AIProjectClient` is shared in the Azure SDKs. `FoundryChatClient`
+talks to the project (model deployments or server agents),
 `FoundryMemoryProvider` gives an agent persistent memory backed by a Foundry Memory Store, and the
 `@polymind-inc/agent-framework-foundry/hosting` subpath publishes an `Agent` as a Foundry Hosted
 Agent — `ResponsesHostServer` over the Responses container protocol, `InvocationsHostServer` over

--- a/packages/foundry/src/chat-client.test.ts
+++ b/packages/foundry/src/chat-client.test.ts
@@ -3,7 +3,7 @@ import { ConfigurationError, textContent } from '@polymind-inc/agent-framework-c
 import type OpenAI from 'openai';
 import { describe, expect, it, vi } from 'vitest';
 import { FoundryChatClient } from './chat-client.js';
-import { tokenProvider } from './credential.js';
+import { FoundryProject } from './project.js';
 import { normalizeProjectEndpoint, resolveEndpoint } from './target.js';
 
 const PROJECT = 'https://my-resource.services.ai.azure.com/api/projects/my-project';
@@ -20,9 +20,13 @@ function fakeCredential(ttlMs = 60 * 60 * 1000): TokenCredential & { calls: numb
   return credential;
 }
 
+function fakeProject(): FoundryProject {
+  return new FoundryProject(PROJECT, fakeCredential());
+}
+
 describe('Foundry endpoint construction', () => {
   it('builds the project OpenAI endpoint for a model deployment', () => {
-    expect(resolveEndpoint(PROJECT, { modelDeployment: 'gpt-4o' })).toEqual({
+    expect(resolveEndpoint(PROJECT, { model: 'gpt-4o' })).toEqual({
       baseURL: `${PROJECT}/openai/v1/`,
     });
   });
@@ -47,68 +51,26 @@ describe('Foundry endpoint construction', () => {
   it('rejects an endpoint that is empty, relative, or an empty target', () => {
     expect(() => normalizeProjectEndpoint('  ')).toThrow(ConfigurationError);
     expect(() => normalizeProjectEndpoint('/api/projects/p')).toThrow(ConfigurationError);
-    expect(() => resolveEndpoint(PROJECT, { modelDeployment: ' ' })).toThrow(ConfigurationError);
+    expect(() => resolveEndpoint(PROJECT, { model: ' ' })).toThrow(ConfigurationError);
     expect(() => resolveEndpoint(PROJECT, { serverAgent: '' })).toThrow(ConfigurationError);
   });
 
   it('rejects a target with both selectors at runtime', () => {
-    expect(() =>
-      resolveEndpoint(PROJECT, { modelDeployment: 'gpt-4o', serverAgent: 'support-bot' } as never),
-    ).toThrow(ConfigurationError);
-  });
-});
-
-describe('Foundry token provider', () => {
-  it('reuses a live token instead of calling the credential per request', async () => {
-    const credential = fakeCredential();
-    const provider = tokenProvider(credential);
-
-    expect(await provider()).toBe('token-1');
-    expect(await provider()).toBe('token-1');
-    expect(credential.calls).toBe(1);
-  });
-
-  it('refreshes a token that is about to expire', async () => {
-    // Inside the refresh margin, so the cached token is never considered usable.
-    const credential = fakeCredential(60 * 1000);
-    const provider = tokenProvider(credential);
-
-    expect(await provider()).toBe('token-1');
-    expect(await provider()).toBe('token-2');
-  });
-
-  it('shares one refresh between concurrent requests', async () => {
-    const credential = fakeCredential();
-    const provider = tokenProvider(credential);
-
-    const tokens = await Promise.all([provider(), provider(), provider()]);
-
-    expect(tokens).toEqual(['token-1', 'token-1', 'token-1']);
-    expect(credential.calls).toBe(1);
-  });
-
-  it('requests the Foundry data-plane scope by default', async () => {
-    const getToken = vi.fn(async () => ({ token: 't', expiresOnTimestamp: Date.now() + 3_600_000 }));
-    await tokenProvider({ getToken } as unknown as TokenCredential)();
-
-    expect(getToken).toHaveBeenCalledWith('https://ai.azure.com/.default');
-  });
-
-  it('reports a credential that cannot produce a token', async () => {
-    const provider = tokenProvider({ getToken: async () => null } as unknown as TokenCredential);
-    await expect(provider()).rejects.toThrow(/Could not acquire a Microsoft Entra token/);
+    expect(() => resolveEndpoint(PROJECT, { model: 'gpt-4o', serverAgent: 'support-bot' } as never)).toThrow(
+      ConfigurationError,
+    );
   });
 });
 
 describe('FoundryChatClient', () => {
-  it('uses a preconfigured SDK endpoint without requiring or resolving projectEndpoint', () => {
+  it('uses a preconfigured SDK endpoint without requiring or resolving a project', () => {
     const sdk = {
       responses: { create: vi.fn() },
       baseURL: 'https://custom.example/v1',
     } as unknown as OpenAI;
 
     const client = new FoundryChatClient({
-      target: { modelDeployment: 'gpt-4o' },
+      target: { model: 'gpt-4o' },
       client: sdk,
     });
 
@@ -118,9 +80,8 @@ describe('FoundryChatClient', () => {
 
   it('points at the right endpoint and reports the Foundry provider', () => {
     const deployment = new FoundryChatClient({
-      projectEndpoint: PROJECT,
-      target: { modelDeployment: 'gpt-4o' },
-      credential: fakeCredential(),
+      project: fakeProject(),
+      target: { model: 'gpt-4o' },
     });
 
     expect(deployment.baseURL).toBe(`${PROJECT}/openai/v1/`);
@@ -133,9 +94,8 @@ describe('FoundryChatClient', () => {
 
   it('declares conv_ conversation ids stable for the tool loop, like the inner client', () => {
     const stable = new FoundryChatClient({
-      projectEndpoint: PROJECT,
-      target: { modelDeployment: 'gpt-4o' },
-      credential: fakeCredential(),
+      project: fakeProject(),
+      target: { model: 'gpt-4o' },
     }).metadata.stableConversationId;
     expect(stable).toBeDefined();
     expect(stable?.('conv_123')).toBe(true);
@@ -144,9 +104,8 @@ describe('FoundryChatClient', () => {
 
   it('exposes the SDK client and the hosted tool declarations of the inner client', () => {
     const client = new FoundryChatClient({
-      projectEndpoint: PROJECT,
-      target: { modelDeployment: 'gpt-4o' },
-      credential: fakeCredential(),
+      project: fakeProject(),
+      target: { model: 'gpt-4o' },
     });
 
     // Thin delegations, but public API: each must reach the inner OpenAI client rather than
@@ -169,9 +128,8 @@ describe('FoundryChatClient', () => {
     // `$.model` from the request and Go leaves it unset; reporting a made-up name here would put
     // it on the wire, in `metadata.modelId`, and in every telemetry span.
     const server = new FoundryChatClient({
-      projectEndpoint: PROJECT,
+      project: fakeProject(),
       target: { serverAgent: 'support-bot' },
-      credential: fakeCredential(),
     });
 
     expect(server.baseURL).toBe(`${PROJECT}/agents/support-bot/endpoint/protocols/openai/`);
@@ -180,7 +138,6 @@ describe('FoundryChatClient', () => {
 
   it('omits model from a server agent request body', () => {
     const client = new FoundryChatClient({
-      projectEndpoint: PROJECT,
       target: { serverAgent: 'support-bot' },
       client: { responses: { create: vi.fn() }, baseURL: PROJECT } as unknown as OpenAI,
     });
@@ -196,8 +153,7 @@ describe('FoundryChatClient', () => {
   it('reuses the OpenAI request mapping unchanged', () => {
     const create = vi.fn();
     const client = new FoundryChatClient({
-      projectEndpoint: PROJECT,
-      target: { modelDeployment: 'gpt-4o' },
+      target: { model: 'gpt-4o' },
       client: { responses: { create }, baseURL: PROJECT } as unknown as OpenAI,
     });
 
@@ -213,8 +169,7 @@ describe('FoundryChatClient', () => {
   // request that asks for it. Asking implicitly would make those deployments unreachable.
   it('does not request encrypted reasoning by default', () => {
     const client = new FoundryChatClient({
-      projectEndpoint: PROJECT,
-      target: { modelDeployment: 'gpt-4o' },
+      target: { model: 'gpt-4o' },
       client: { responses: { create: vi.fn() }, baseURL: PROJECT } as unknown as OpenAI,
     });
 
@@ -225,8 +180,7 @@ describe('FoundryChatClient', () => {
 
   it('preserves an explicit encrypted reasoning opt-in', () => {
     const client = new FoundryChatClient({
-      projectEndpoint: PROJECT,
-      target: { modelDeployment: 'gpt-4o' },
+      target: { model: 'gpt-4o' },
       client: { responses: { create: vi.fn() }, baseURL: PROJECT } as unknown as OpenAI,
     });
 
@@ -241,8 +195,7 @@ describe('FoundryChatClient', () => {
   // typed list wholesale — would drop the opt-in and fail the stateless replay it was there for.
   it('preserves an explicit opt-in that additionalProperties replaced', () => {
     const client = new FoundryChatClient({
-      projectEndpoint: PROJECT,
-      target: { modelDeployment: 'gpt-4o' },
+      target: { model: 'gpt-4o' },
       client: { responses: { create: vi.fn() }, baseURL: PROJECT } as unknown as OpenAI,
     });
 
@@ -258,8 +211,7 @@ describe('FoundryChatClient', () => {
     const completed = { id: 'resp_1', object: 'response', status: 'completed', output: [] };
     const create = vi.fn().mockResolvedValue(completed);
     const client = new FoundryChatClient({
-      projectEndpoint: PROJECT,
-      target: { modelDeployment: 'gpt-4o' },
+      target: { model: 'gpt-4o' },
       client: { responses: { create }, baseURL: PROJECT } as unknown as OpenAI,
     });
 
@@ -269,7 +221,7 @@ describe('FoundryChatClient', () => {
     expect(create.mock.calls[0]?.[0]).not.toHaveProperty('include');
   });
 
-  it('sends the credential token as the bearer, to the target endpoint', async () => {
+  it("sends the project's token as the bearer, to the target endpoint", async () => {
     const credential = fakeCredential();
     const seen: Array<{ url: string; authorization: string | null }> = [];
     const fetchStub = (async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
@@ -293,9 +245,8 @@ describe('FoundryChatClient', () => {
     }) as unknown as OpenAI['fetch'];
 
     const client = new FoundryChatClient({
-      projectEndpoint: PROJECT,
+      project: new FoundryProject(PROJECT, credential),
       target: { serverAgent: 'support-bot' },
-      credential,
       fetch: fetchStub,
     });
 
@@ -307,5 +258,25 @@ describe('FoundryChatClient', () => {
     expect(seen[0]?.url).toBe(
       `${PROJECT}/agents/support-bot/endpoint/protocols/openai/responses?api-version=v1`,
     );
+  });
+
+  it("inherits the project's fetch when no override is given", async () => {
+    const seen: string[] = [];
+    const fetchStub = (async (url: string | URL | Request): Promise<Response> => {
+      seen.push(String(url));
+      return new Response(
+        JSON.stringify({ id: 'resp_1', object: 'response', status: 'completed', output: [] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const client = new FoundryChatClient({
+      project: new FoundryProject(PROJECT, fakeCredential(), { fetch: fetchStub }),
+      target: { model: 'gpt-4o' },
+    });
+
+    await client.getResponse([{ role: 'user', contents: [textContent('hi')] }]);
+
+    expect(seen).toHaveLength(1);
   });
 });

--- a/packages/foundry/src/chat-client.ts
+++ b/packages/foundry/src/chat-client.ts
@@ -1,21 +1,13 @@
-import type { TokenCredential } from '@azure/identity';
-import { DefaultAzureCredential } from '@azure/identity';
 import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
 import OpenAI from 'openai';
-import { tokenProvider } from './credential.js';
+import type { FoundryProject } from './project.js';
 import type { FoundryTarget } from './target.js';
-import { FOUNDRY_SCOPE, isModelDeployment, resolveEndpoint } from './target.js';
+import { isModelTarget, resolveEndpoint } from './target.js';
 
 /** Options shared by both construction paths for {@link FoundryChatClient}. */
 interface FoundryChatClientConfigBase {
   /** Which agent to talk to: a model deployment in the project, or an existing server agent. */
   target: FoundryTarget;
-  /** Defaults to {@link DefaultAzureCredential}. */
-  credential?: TokenCredential;
-  /** Entra scope for the token. Defaults to `https://ai.azure.com/.default`. */
-  scope?: string;
-  /** A preconfigured SDK client. Supplying it bypasses endpoint construction and `credential`. */
-  client?: OpenAI;
   /** Extra headers on every request, for example `x-client-*` correlation headers. */
   defaultHeaders?: Record<string, string>;
   /** Replaces the SDK's `fetch`, for proxies, custom agents, or tests. */
@@ -26,15 +18,14 @@ interface FoundryChatClientConfigBase {
 export type FoundryChatClientConfig = FoundryChatClientConfigBase &
   (
     | {
-        /** A preconfigured SDK client. Its endpoint is used directly. */
+        /** A preconfigured SDK client. Its endpoint and authentication are used directly. */
         client: OpenAI;
-        /** Ignored when `client` is supplied; retained for source compatibility. */
-        projectEndpoint?: string;
+        project?: undefined;
       }
     | {
         client?: undefined;
-        /** The Foundry project endpoint, for example `https://my-project.services.ai.azure.com/api/projects/p`. */
-        projectEndpoint: string;
+        /** The project to talk to: the endpoint requests go to and the identity they carry. */
+        project: FoundryProject;
       }
   );
 
@@ -47,25 +38,21 @@ export type FoundryChatClientConfig = FoundryChatClientConfigBase &
  * tools, streaming, structured output — is the OpenAI one.
  *
  * ```ts
+ * const project = new FoundryProject(process.env.FOUNDRY_PROJECT_ENDPOINT!, new DefaultAzureCredential());
+ *
  * // The framework's agent, running on a model deployed in the project.
- * const client = new FoundryChatClient({
- *   projectEndpoint: process.env.FOUNDRY_PROJECT_ENDPOINT!,
- *   target: { modelDeployment: 'gpt-4o' },
- * });
+ * const client = new FoundryChatClient({ project, target: { model: 'gpt-4o' } });
  *
  * // An agent that already exists in the project; the service owns its instructions and model.
- * const server = new FoundryChatClient({
- *   projectEndpoint: process.env.FOUNDRY_PROJECT_ENDPOINT!,
- *   target: { serverAgent: 'support-bot' },
- * });
+ * const server = new FoundryChatClient({ project, target: { serverAgent: 'support-bot' } });
  * ```
  *
  * ## Security considerations
  *
  * - **The token is scoped to the project, not to a conversation.** Anything that can call this
  *   client can reach every model and tool the project's identity can reach.
- * - **`projectEndpoint` decides where the bearer token goes.** Treat it as trusted configuration;
- *   never build it from user input.
+ * - **The project's endpoint decides where the bearer token goes.** Treat it as trusted
+ *   configuration; never build it from user input.
  * - The OpenAI notes apply unchanged: messages leave the process, and `store` is pass-through.
  */
 export class FoundryChatClient extends OpenAIChatClient {
@@ -75,22 +62,20 @@ export class FoundryChatClient extends OpenAIChatClient {
     // A server agent is addressed by its endpoint, and the agent definition picks the model, so
     // there is nothing to name here: .NET removes `$.model` from the request and Go leaves it
     // unset. Sending a placeholder would reach the wire, `metadata.modelId` and telemetry alike.
-    const model = isModelDeployment(config.target) ? config.target.modelDeployment : undefined;
-    const endpoint =
-      config.client === undefined ? resolveEndpoint(config.projectEndpoint, config.target) : undefined;
+    const model = isModelTarget(config.target) ? config.target.model : undefined;
+    const project = config.client === undefined ? config.project : undefined;
+    const endpoint = project === undefined ? undefined : resolveEndpoint(project.endpoint, config.target);
+    const fetch = config.fetch ?? project?.fetch;
 
     const client =
       config.client ??
       new OpenAI({
         baseURL: (endpoint as { baseURL: string }).baseURL,
         // The SDK calls this before every request, so rotation is handled for us.
-        apiKey: tokenProvider(
-          config.credential ?? new DefaultAzureCredential(),
-          config.scope ?? FOUNDRY_SCOPE,
-        ),
+        apiKey: () => (project as FoundryProject).getToken(),
         ...(endpoint?.defaultQuery === undefined ? {} : { defaultQuery: endpoint.defaultQuery }),
         ...(config.defaultHeaders === undefined ? {} : { defaultHeaders: config.defaultHeaders }),
-        ...(config.fetch === undefined ? {} : { fetch: config.fetch }),
+        ...(fetch === undefined ? {} : { fetch }),
       });
 
     super({

--- a/packages/foundry/src/hosting.ts
+++ b/packages/foundry/src/hosting.ts
@@ -6,15 +6,17 @@
  * the toolbox.
  *
  * ```ts
+ * import { DefaultAzureCredential } from '@azure/identity';
  * import { Agent } from '@polymind-inc/agent-framework-core';
- * import { FoundryChatClient } from '@polymind-inc/agent-framework-foundry';
+ * import { FoundryChatClient, FoundryProject } from '@polymind-inc/agent-framework-foundry';
  * import { ResponsesHostServer } from '@polymind-inc/agent-framework-foundry/hosting';
  * import { serve } from '@polymind-inc/agent-framework-agentserver/node';
  *
  * const agent = new Agent({
  *   client: new FoundryChatClient({
- *     projectEndpoint: process.env.FOUNDRY_PROJECT_ENDPOINT!,
- *     target: { modelDeployment: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME! },
+ *     // The platform injects the endpoint; the managed identity is the container's credential.
+ *     project: new FoundryProject(process.env.FOUNDRY_PROJECT_ENDPOINT!, new DefaultAzureCredential()),
+ *     target: { model: process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME! },
  *   }),
  *   instructions: 'You are a helpful assistant.',
  *   // The hosting infrastructure owns the transcript, so the provider must not store it too.

--- a/packages/foundry/src/hosting/foundry-storage-client.ts
+++ b/packages/foundry/src/hosting/foundry-storage-client.ts
@@ -1,8 +1,6 @@
-import type { TokenCredential } from '@azure/identity';
-import { DefaultAzureCredential } from '@azure/identity';
 import { platformHeaders } from '@polymind-inc/agent-framework-agentserver';
-import { tokenProvider } from '../credential.js';
-import { FOUNDRY_API_VERSION, normalizeProjectEndpoint } from '../target.js';
+import type { FoundryProject } from '../project.js';
+import { FOUNDRY_API_VERSION } from '../target.js';
 
 /** The statuses worth another attempt, matching the reference retry policy's set. */
 const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([408, 429, 500, 502, 503, 504]);
@@ -15,7 +13,6 @@ function delay(ms: number): Promise<void> {
 }
 
 interface FoundryStorageClientConfig {
-  credential?: TokenCredential;
   fetch?: typeof globalThis.fetch;
   forwardCallId?: boolean;
   retry?: { baseDelayMs?: number };
@@ -46,10 +43,10 @@ export class FoundryStorageClient {
   readonly #forwardCallId: boolean;
   readonly #retryBaseDelayMs: number;
 
-  constructor(projectEndpoint: string, options: FoundryStorageClientConfig = {}) {
-    this.#endpoint = normalizeProjectEndpoint(projectEndpoint);
-    this.#getToken = tokenProvider(options.credential ?? new DefaultAzureCredential());
-    this.#fetch = options.fetch ?? globalThis.fetch;
+  constructor(project: FoundryProject, options: FoundryStorageClientConfig = {}) {
+    this.#endpoint = project.endpoint;
+    this.#getToken = () => project.getToken();
+    this.#fetch = options.fetch ?? project.fetch ?? globalThis.fetch;
     this.#forwardCallId = options.forwardCallId ?? true;
     this.#retryBaseDelayMs = options.retry?.baseDelayMs ?? 500;
   }

--- a/packages/foundry/src/hosting/hosting.test.ts
+++ b/packages/foundry/src/hosting/hosting.test.ts
@@ -30,6 +30,7 @@ import {
 import type { MockTurn } from '@polymind-inc/agent-framework-core/testing';
 import { MockChatClient } from '@polymind-inc/agent-framework-core/testing';
 import { describe, expect, it } from 'vitest';
+import { FoundryProject } from '../project.js';
 import { FileApprovalStorage, InMemoryApprovalStorage } from './approval-storage.js';
 import { consentRequestsFromMessage, ToolboxConsentRequiredError } from './consent.js';
 import { reportConsent as reportToolboxConsent } from './consent-channel.js';
@@ -1644,10 +1645,9 @@ describe('background execution with the Foundry store', () => {
     const service = storageServiceDouble(options);
     const client = new MockChatClient(turns);
     const store = new FoundryResponseStore({
-      projectEndpoint: 'https://my-resource.services.ai.azure.com/api/projects/my-project',
-      credential: {
+      project: new FoundryProject('https://my-resource.services.ai.azure.com/api/projects/my-project', {
         getToken: async () => ({ token: 'mi-token', expiresOnTimestamp: Date.now() + 3_600_000 }),
-      },
+      }),
       fetch: service.fetch,
       replayRoot: await mkdtemp(join(tmpdir(), 'afjs-fdry-')),
       retry: { baseDelayMs: 0 },

--- a/packages/foundry/src/hosting/invocations.ts
+++ b/packages/foundry/src/hosting/invocations.ts
@@ -258,7 +258,10 @@ function invocationHandler(
  *
  * ```ts
  * const agent = new Agent({
- *   client: new FoundryChatClient({ projectEndpoint, target: { modelDeployment } }),
+ *   client: new FoundryChatClient({
+ *     project: new FoundryProject(process.env.FOUNDRY_PROJECT_ENDPOINT!, new DefaultAzureCredential()),
+ *     target: { model },
+ *   }),
  *   instructions: 'You are a helpful assistant.',
  * });
  *

--- a/packages/foundry/src/hosting/memory-scope.ts
+++ b/packages/foundry/src/hosting/memory-scope.ts
@@ -13,7 +13,7 @@ import { getHostedAgentContext } from './hosted-context.js';
  * Scopes memories to the end user of the hosted turn.
  *
  * ```ts
- * new FoundryMemoryProvider({ memoryStoreName: 'assistant-memories', scope: hostedUserScope() });
+ * new FoundryMemoryProvider({ project, memoryStoreName: 'assistant-memories', scope: hostedUserScope() });
  * ```
  *
  * Throws outside a hosted turn, and when the platform supplied no user id, rather than falling

--- a/packages/foundry/src/hosting/response-store.test.ts
+++ b/packages/foundry/src/hosting/response-store.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@polymind-inc/agent-framework-agentserver';
 import { ConfigurationError } from '@polymind-inc/agent-framework-core';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { FoundryProject } from '../project.js';
 import { FoundryResponseStore } from './response-store.js';
 import { defaultStore } from './server.js';
 
@@ -70,8 +71,7 @@ function store(
 
   return {
     store: new FoundryResponseStore({
-      projectEndpoint: PROJECT,
-      credential: options.credential ?? credential,
+      project: new FoundryProject(PROJECT, options.credential ?? credential),
       fetch: fetchStub,
       replayRoot: options.replayRoot ?? join(replayScratch, `store-${replayDirCount++}`),
       retry: { baseDelayMs: 0 },
@@ -119,26 +119,10 @@ describe('FoundryResponseStore', () => {
     expect(subject.baseUrl).toBe(`${PROJECT}/storage/`);
   });
 
-  it('refuses to be built without a project endpoint', () => {
-    // Cleared explicitly rather than assumed absent: a developer whose shell is configured for a
-    // real project (as the integration tests need) would otherwise see this unit test fail.
-    const previous = process.env.FOUNDRY_PROJECT_ENDPOINT;
-    delete process.env.FOUNDRY_PROJECT_ENDPOINT;
-    try {
-      expect(() => new FoundryResponseStore({ credential })).toThrow(/needs a project endpoint/);
-    } finally {
-      if (previous !== undefined) {
-        process.env.FOUNDRY_PROJECT_ENDPOINT = previous;
-      }
-    }
-  });
-
   it('refuses a relative endpoint at construction rather than failing on the first request', () => {
     // A misconfigured endpoint should surface where it was configured, not as a broken URL on the
     // first storage call.
-    expect(() => new FoundryResponseStore({ projectEndpoint: '/api/projects/p', credential })).toThrow(
-      ConfigurationError,
-    );
+    expect(() => new FoundryProject('/api/projects/p', credential)).toThrow(ConfigurationError);
   });
 
   it('uses the routes and verbs the service defines', async () => {

--- a/packages/foundry/src/hosting/response-store.ts
+++ b/packages/foundry/src/hosting/response-store.ts
@@ -1,4 +1,3 @@
-import type { TokenCredential } from '@azure/identity';
 import type {
   OutputItem,
   ResponseEvent,
@@ -12,19 +11,19 @@ import {
   FileResponseProvider,
   historyOf,
   ID_PREFIX,
-  projectEndpoint,
   resolveAgentReference,
   stateRoot,
 } from '@polymind-inc/agent-framework-agentserver';
-import { ConfigurationError } from '@polymind-inc/agent-framework-core';
+import type { FoundryProject } from '../project.js';
 import { FoundryStorageClient } from './foundry-storage-client.js';
 
 /** Construction options for {@link FoundryResponseStore}. */
 export interface FoundryResponseStoreConfig {
   /**
-   * The Foundry **project** endpoint — not a storage URL. Defaults to `FOUNDRY_PROJECT_ENDPOINT`.
+   * The project whose storage service holds the responses.
    *
-   * `/storage/` is appended unconditionally, so a value that already ends in `/storage` produces
+   * The project's endpoint must be the **project** endpoint — not a storage URL. `/storage/` is
+   * appended unconditionally, so a value that already ends in `/storage` produces
    * `.../storage/storage/`. That is deliberate parity, not an oversight: both response-store
    * references append without looking (Python `store/_foundry_settings.py:55`
    * `endpoint.rstrip("/") + "/storage/"`, .NET `ResponsesServerServiceCollectionExtensions.cs:170`
@@ -35,10 +34,8 @@ export interface FoundryResponseStoreConfig {
    * wider contract, for the state store, which this package does not have. Narrowing the accepted
    * form keeps a misconfigured endpoint a visible 404 rather than something silently repaired.
    */
-  projectEndpoint?: string;
-  /** Defaults to {@link DefaultAzureCredential}. */
-  credential?: TokenCredential;
-  /** Overridable for tests and proxies. */
+  project: FoundryProject;
+  /** Overridable for tests and proxies. Defaults to the project's transport. */
   fetch?: typeof globalThis.fetch;
   /**
    * Whether to forward `x-agent-foundry-call-id` on storage requests. Defaults to `true`.
@@ -242,15 +239,8 @@ export class FoundryResponseStore implements ResponseProvider {
   /** The local half of the split: the replay log and the generation fence. */
   readonly #replay: FileResponseProvider;
 
-  constructor(options: FoundryResponseStoreConfig = {}) {
-    const endpoint = options.projectEndpoint ?? projectEndpoint();
-    if (endpoint === undefined) {
-      throw new ConfigurationError(
-        'FoundryResponseStore needs a project endpoint. Set FOUNDRY_PROJECT_ENDPOINT or pass ' +
-          '`projectEndpoint`.',
-      );
-    }
-    this.#client = new FoundryStorageClient(endpoint, options);
+  constructor(options: FoundryResponseStoreConfig) {
+    this.#client = new FoundryStorageClient(options.project, options);
     this.#replay = new FileResponseProvider({
       root: options.replayRoot ?? `${stateRoot()}/foundry-responses`,
     });

--- a/packages/foundry/src/hosting/server.ts
+++ b/packages/foundry/src/hosting/server.ts
@@ -1,3 +1,4 @@
+import { DefaultAzureCredential } from '@azure/identity';
 import type { ResponseProvider, ResponsesServerConfig } from '@polymind-inc/agent-framework-agentserver';
 import {
   FileResponseProvider,
@@ -6,6 +7,7 @@ import {
   projectEndpoint,
   ResponsesServer,
 } from '@polymind-inc/agent-framework-agentserver';
+import { FoundryProject } from '../project.js';
 import type { FoundryHandlerConfig } from './handler.js';
 import { createFoundryHandler } from './handler.js';
 import { FoundryResponseStore } from './response-store.js';
@@ -46,7 +48,14 @@ export function defaultStore(hosted: boolean): ResponseProvider {
     // A local run is self-contained; nothing should outlive the process.
     return new InMemoryResponseProvider();
   }
-  return projectEndpoint() === undefined ? new FileResponseProvider() : new FoundryResponseStore();
+  const endpoint = projectEndpoint();
+  if (endpoint === undefined) {
+    return new FileResponseProvider();
+  }
+  // The platform injects the endpoint and the managed identity, so this is the one place a
+  // project is assembled from the environment rather than passed in — the same default the
+  // Python agent server's Foundry storage applies when no credential is supplied.
+  return new FoundryResponseStore({ project: new FoundryProject(endpoint, new DefaultAzureCredential()) });
 }
 
 /**
@@ -54,7 +63,10 @@ export function defaultStore(hosted: boolean): ResponseProvider {
  *
  * ```ts
  * const agent = new Agent({
- *   client: new FoundryChatClient({ projectEndpoint, target: { modelDeployment } }),
+ *   client: new FoundryChatClient({
+ *     project: new FoundryProject(process.env.FOUNDRY_PROJECT_ENDPOINT!, new DefaultAzureCredential()),
+ *     target: { model },
+ *   }),
  *   instructions: 'You are a helpful assistant.',
  *   // The hosting infrastructure owns the transcript, so the provider must not store it too.
  *   defaultOptions: { store: false },

--- a/packages/foundry/src/hosting/toolbox.test.ts
+++ b/packages/foundry/src/hosting/toolbox.test.ts
@@ -9,6 +9,7 @@ import {
 import type { ContextProvider, Tool } from '@polymind-inc/agent-framework-core';
 import { AgentSession, ConfigurationError, isFunctionTool } from '@polymind-inc/agent-framework-core';
 import { describe, expect, it, vi } from 'vitest';
+import { FoundryProject } from '../project.js';
 import { ToolboxConsentRequiredError } from './consent.js';
 import { FoundryToolbox } from './toolbox.js';
 
@@ -161,8 +162,7 @@ function stubToolbox(
   return {
     toolbox: new FoundryToolbox({
       name: 'my-toolbox',
-      projectEndpoint: PROJECT,
-      credential,
+      project: new FoundryProject(PROJECT, credential),
       fetch: fetchStub,
       ...(options.allowedTools === undefined ? {} : { allowedTools: options.allowedTools }),
       ...(options.loadTools === undefined ? {} : { loadTools: options.loadTools }),
@@ -185,32 +185,15 @@ describe('FoundryToolbox endpoint', () => {
   it('escapes the toolbox name so it cannot climb out of the path', () => {
     const toolbox = new FoundryToolbox({
       name: 'a/../../evil',
-      projectEndpoint: PROJECT,
-      credential,
+      project: new FoundryProject(PROJECT, credential),
     });
     expect(toolbox.url).toBe(`${PROJECT}/toolboxes/a%2F..%2F..%2Fevil/mcp?api-version=v1`);
-  });
-
-  it('refuses to be built without a project endpoint', () => {
-    // Cleared explicitly rather than assumed absent: a developer whose shell is configured for a
-    // real project (as the integration tests need) would otherwise see this unit test fail.
-    const previous = process.env.FOUNDRY_PROJECT_ENDPOINT;
-    delete process.env.FOUNDRY_PROJECT_ENDPOINT;
-    try {
-      expect(() => new FoundryToolbox({ name: 'x', credential })).toThrow(/needs a project endpoint/);
-    } finally {
-      if (previous !== undefined) {
-        process.env.FOUNDRY_PROJECT_ENDPOINT = previous;
-      }
-    }
   });
 
   it('refuses a relative endpoint at construction rather than failing on the first request', () => {
     // A misconfigured endpoint should surface where it was configured, not as a broken MCP URL on
     // the first tool call.
-    expect(() => new FoundryToolbox({ name: 'x', projectEndpoint: '/api/projects/p', credential })).toThrow(
-      ConfigurationError,
-    );
+    expect(() => new FoundryProject('/api/projects/p', credential)).toThrow(ConfigurationError);
   });
 
   it('retries the connection on the next request after a failed attempt', async () => {

--- a/packages/foundry/src/hosting/toolbox.ts
+++ b/packages/foundry/src/hosting/toolbox.ts
@@ -1,7 +1,5 @@
-import type { TokenCredential } from '@azure/identity';
-import { DefaultAzureCredential } from '@azure/identity';
 import type { CallToolResult } from '@modelcontextprotocol/client';
-import { platformHeaders, projectEndpoint } from '@polymind-inc/agent-framework-agentserver';
+import { platformHeaders } from '@polymind-inc/agent-framework-agentserver';
 import type {
   Content,
   ContextProvider,
@@ -11,7 +9,6 @@ import type {
   ToolContext,
 } from '@polymind-inc/agent-framework-core';
 import {
-  ConfigurationError,
   skillsProvider,
   ToolInvocationError,
   textOfContents,
@@ -19,8 +16,8 @@ import {
 } from '@polymind-inc/agent-framework-core';
 import type { McpSkillsSourceConfig } from '@polymind-inc/agent-framework-mcp';
 import { McpConnection, mcpSkillsSource } from '@polymind-inc/agent-framework-mcp';
-import { tokenProvider } from '../credential.js';
-import { FOUNDRY_API_VERSION, normalizeProjectEndpoint } from '../target.js';
+import type { FoundryProject } from '../project.js';
+import { FOUNDRY_API_VERSION } from '../target.js';
 import { consentRequestsOf, ToolboxConsentRequiredError } from './consent.js';
 import { reportConsent } from './consent-channel.js';
 
@@ -41,10 +38,8 @@ function withConsentTyped(error: unknown): unknown {
 export interface FoundryToolboxConfig {
   /** The toolbox registered in the project. */
   name: string;
-  /** Defaults to `FOUNDRY_PROJECT_ENDPOINT`. */
-  projectEndpoint?: string;
-  /** Defaults to {@link DefaultAzureCredential}. */
-  credential?: TokenCredential;
+  /** The project hosting the toolbox. */
+  project: FoundryProject;
   /** Restricts which of the toolbox's tools are exposed to the model. */
   allowedTools?: string[];
   /**
@@ -89,27 +84,22 @@ export class FoundryToolbox {
   readonly #connection: McpConnection;
 
   constructor(options: FoundryToolboxConfig) {
-    const endpoint = options.projectEndpoint ?? projectEndpoint();
-    if (endpoint === undefined) {
-      throw new ConfigurationError(
-        'FoundryToolbox needs a project endpoint. Set FOUNDRY_PROJECT_ENDPOINT or pass `projectEndpoint`.',
-      );
-    }
+    const project = options.project;
     this.#name = options.name;
-    this.#endpoint = normalizeProjectEndpoint(endpoint);
+    this.#endpoint = project.endpoint;
     this.#allowedTools = options.allowedTools === undefined ? undefined : new Set(options.allowedTools);
     this.#loadTools = options.loadTools ?? true;
 
-    const getToken = tokenProvider(options.credential ?? new DefaultAzureCredential());
+    const fetch = options.fetch ?? project.fetch;
     this.#connection = new McpConnection({
       url: this.url,
       // Per-request rather than per-connection: see the class note on why this cannot be a
       // static header set.
       headers: async () => ({
-        authorization: `Bearer ${await getToken()}`,
+        authorization: `Bearer ${await project.getToken()}`,
         ...platformHeaders(),
       }),
-      ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+      ...(fetch === undefined ? {} : { fetch }),
     });
   }
 
@@ -214,7 +204,7 @@ export class FoundryToolbox {
    * Serves the toolbox's Agent Skills to an agent.
    *
    * ```ts
-   * const toolbox = new FoundryToolbox({ name: 'support', loadTools: false });
+   * const toolbox = new FoundryToolbox({ name: 'support', project, loadTools: false });
    * const agent = new Agent({
    *   client,
    *   instructions: 'You are a support assistant.',

--- a/packages/foundry/src/index.ts
+++ b/packages/foundry/src/index.ts
@@ -10,7 +10,6 @@
 export type { OpenAIChatOptions } from '@polymind-inc/agent-framework-openai';
 export type { FoundryChatClientConfig } from './chat-client.js';
 export { FoundryChatClient } from './chat-client.js';
-export { tokenProvider } from './credential.js';
 // The memory-store client itself (memory/client.ts) is the provider's transport, not a public
 // surface; only the error it raises and the store definition a caller has to supply are exported.
 export type { MemoryOperation, MemoryStoreDefinition, MemoryStoreObject } from './memory/client.js';
@@ -21,11 +20,13 @@ export type {
   FoundryMemoryScope,
 } from './memory/provider.js';
 export { FoundryMemoryProvider } from './memory/provider.js';
+export type { FoundryProjectOptions } from './project.js';
+export { FoundryProject } from './project.js';
 export type { FoundryEndpoint, FoundryTarget } from './target.js';
 export {
   FOUNDRY_API_VERSION,
   FOUNDRY_SCOPE,
-  isModelDeployment,
+  isModelTarget,
   normalizeProjectEndpoint,
   resolveEndpoint,
 } from './target.js';

--- a/packages/foundry/src/integration-extensibility.test.ts
+++ b/packages/foundry/src/integration-extensibility.test.ts
@@ -11,6 +11,7 @@
  * See `integration.test.ts` for the environment variables.
  */
 
+import { DefaultAzureCredential } from '@azure/identity';
 import { metrics } from '@opentelemetry/api';
 import {
   AggregationTemporality,
@@ -32,6 +33,7 @@ import {
 } from '@polymind-inc/agent-framework-core';
 import { describe, expect, it } from 'vitest';
 import { FoundryChatClient } from './chat-client.js';
+import { FoundryProject } from './project.js';
 
 const projectEndpoint = process.env.FOUNDRY_PROJECT_ENDPOINT;
 const modelDeployment =
@@ -45,7 +47,10 @@ function must<T>(value: T | null | undefined): T {
 }
 
 const deploymentClient = (): FoundryChatClient =>
-  new FoundryChatClient({ projectEndpoint: must(projectEndpoint), target: { modelDeployment } });
+  new FoundryChatClient({
+    project: new FoundryProject(must(projectEndpoint), new DefaultAzureCredential()),
+    target: { model: modelDeployment },
+  });
 
 /** A weather tool, the smallest thing that makes a real model call a function. */
 const getWeather = tool({

--- a/packages/foundry/src/integration.test.ts
+++ b/packages/foundry/src/integration.test.ts
@@ -13,6 +13,7 @@
  * - `FOUNDRY_STORAGE_WRITABLE=1` — optional; opts into the storage write tests, which only pass
  *   from inside a deployed container (see the block at the bottom)
  */
+import { DefaultAzureCredential } from '@azure/identity';
 import type { ResponseObject } from '@polymind-inc/agent-framework-agentserver';
 import { ID_PREFIX, newId, newResponseId } from '@polymind-inc/agent-framework-agentserver';
 import { Agent, tool } from '@polymind-inc/agent-framework-core';
@@ -20,6 +21,7 @@ import { describe, expect, it } from 'vitest';
 import { FoundryChatClient } from './chat-client.js';
 import { FoundryResponseStore } from './hosting/response-store.js';
 import { FoundryToolbox } from './hosting/toolbox.js';
+import { FoundryProject } from './project.js';
 
 const projectEndpoint = process.env.FOUNDRY_PROJECT_ENDPOINT;
 const modelDeployment =
@@ -35,8 +37,10 @@ function must<T>(value: T | null | undefined): T {
   return value;
 }
 
+const project = (): FoundryProject => new FoundryProject(must(projectEndpoint), new DefaultAzureCredential());
+
 const deploymentClient = (): FoundryChatClient =>
-  new FoundryChatClient({ projectEndpoint: must(projectEndpoint), target: { modelDeployment } });
+  new FoundryChatClient({ project: project(), target: { model: modelDeployment } });
 
 describe.runIf(runIntegration && projectEndpoint !== undefined && projectEndpoint !== '')(
   'Foundry (integration)',
@@ -79,7 +83,7 @@ describe.runIf(runIntegration && projectEndpoint !== undefined && projectEndpoin
       { timeout: TIMEOUT },
       async () => {
         const client = new FoundryChatClient({
-          projectEndpoint: must(projectEndpoint),
+          project: project(),
           target: { serverAgent: must(serverAgent) },
         });
 
@@ -103,8 +107,7 @@ describe.runIf(
     toolboxName !== undefined &&
     toolboxName !== '',
 )('Foundry Toolbox (integration)', () => {
-  const toolbox = (): FoundryToolbox =>
-    new FoundryToolbox({ name: must(toolboxName), projectEndpoint: must(projectEndpoint) });
+  const toolbox = (): FoundryToolbox => new FoundryToolbox({ name: must(toolboxName), project: project() });
 
   it('lists the toolbox tools over MCP', { timeout: TIMEOUT }, async () => {
     const box = toolbox();
@@ -158,8 +161,7 @@ describe.runIf(
 describe.runIf(runIntegration && projectEndpoint !== undefined && projectEndpoint !== '')(
   'Foundry storage (integration)',
   () => {
-    const store = (): FoundryResponseStore =>
-      new FoundryResponseStore({ projectEndpoint: must(projectEndpoint) });
+    const store = (): FoundryResponseStore => new FoundryResponseStore({ project: project() });
 
     it('reaches the service and reports an unknown response as absent', { timeout: TIMEOUT }, async () => {
       const subject = store();
@@ -190,8 +192,7 @@ describe.runIf(
     projectEndpoint !== '' &&
     process.env.FOUNDRY_STORAGE_WRITABLE === '1',
 )('Foundry storage writes (integration)', () => {
-  const store = (): FoundryResponseStore =>
-    new FoundryResponseStore({ projectEndpoint: must(projectEndpoint) });
+  const store = (): FoundryResponseStore => new FoundryResponseStore({ project: project() });
 
   function draft(id: string): ResponseObject {
     return {

--- a/packages/foundry/src/memory/client.test.ts
+++ b/packages/foundry/src/memory/client.test.ts
@@ -1,5 +1,6 @@
 import type { AccessToken, TokenCredential } from '@azure/identity';
 import { describe, expect, it } from 'vitest';
+import { FoundryProject } from '../project.js';
 import { FoundryMemoryError, MemoryStoreClient } from './client.js';
 
 const PROJECT = 'https://my-resource.services.ai.azure.com/api/projects/my-project';
@@ -45,7 +46,7 @@ function client(replies: Array<{ status?: number; body?: unknown; text?: string 
   }) as typeof globalThis.fetch;
 
   return {
-    client: new MemoryStoreClient({ projectEndpoint: PROJECT, credential, fetch: fetchStub }),
+    client: new MemoryStoreClient({ project: new FoundryProject(PROJECT, credential), fetch: fetchStub }),
     calls,
   };
 }
@@ -204,8 +205,7 @@ describe('MemoryStoreClient', () => {
     const controller = new AbortController();
     controller.abort();
     const memory = new MemoryStoreClient({
-      projectEndpoint: PROJECT,
-      credential,
+      project: new FoundryProject(PROJECT, credential),
       fetch: (async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
         init?.signal?.throwIfAborted();
         return new Response('{}');

--- a/packages/foundry/src/memory/client.ts
+++ b/packages/foundry/src/memory/client.ts
@@ -12,10 +12,9 @@
  * and neither does this.
  */
 
-import type { TokenCredential } from '@azure/identity';
 import { AgentFrameworkError } from '@polymind-inc/agent-framework-core';
-import { tokenProvider } from '../credential.js';
-import { FOUNDRY_API_VERSION, normalizeProjectEndpoint } from '../target.js';
+import type { FoundryProject } from '../project.js';
+import { FOUNDRY_API_VERSION } from '../target.js';
 
 /**
  * The preview opt-in every memory-store route requires.
@@ -106,11 +105,9 @@ export class FoundryMemoryError extends AgentFrameworkError {
 
 /** Construction options for {@link MemoryStoreClient}. */
 export interface MemoryStoreClientOptions {
-  /** The Foundry **project** endpoint. */
-  projectEndpoint: string;
-  /** The credential every call is authorized with. */
-  credential: TokenCredential;
-  /** Overridable for tests and proxies. */
+  /** The project every call goes to and is authorized against. */
+  project: FoundryProject;
+  /** Overridable for tests and proxies. Defaults to the project's transport. */
   fetch?: typeof globalThis.fetch;
 }
 
@@ -138,9 +135,9 @@ export class MemoryStoreClient {
   readonly #fetch: typeof globalThis.fetch;
 
   constructor(options: MemoryStoreClientOptions) {
-    this.#endpoint = normalizeProjectEndpoint(options.projectEndpoint);
-    this.#getToken = tokenProvider(options.credential);
-    this.#fetch = options.fetch ?? globalThis.fetch;
+    this.#endpoint = options.project.endpoint;
+    this.#getToken = () => options.project.getToken();
+    this.#fetch = options.fetch ?? options.project.fetch ?? globalThis.fetch;
   }
 
   /** Memories relevant to `items`, or the scope's profile memories when `items` is absent. */

--- a/packages/foundry/src/memory/provider.test.ts
+++ b/packages/foundry/src/memory/provider.test.ts
@@ -3,6 +3,7 @@ import type { AgentSession, Message } from '@polymind-inc/agent-framework-core';
 import { Agent, ConfigurationError, none, textContent } from '@polymind-inc/agent-framework-core';
 import { MockChatClient } from '@polymind-inc/agent-framework-core/testing';
 import { describe, expect, it } from 'vitest';
+import { FoundryProject } from '../project.js';
 import { FoundryMemoryError } from './client.js';
 import type { FoundryMemoryFailure, FoundryMemoryProviderConfig, FoundryMemoryScope } from './provider.js';
 import { FoundryMemoryProvider } from './provider.js';
@@ -66,8 +67,7 @@ function provider(
 
   return {
     memory: new FoundryMemoryProvider({
-      projectEndpoint: PROJECT,
-      credential,
+      project: new FoundryProject(PROJECT, credential),
       memoryStoreName: 'my-store',
       scope: options.scope ?? 'user-1',
       fetch: fetchStub,
@@ -104,29 +104,24 @@ describe('FoundryMemoryProvider', () => {
   describe('configuration', () => {
     it('rejects an empty store name', () => {
       expect(
-        () => new FoundryMemoryProvider({ projectEndpoint: PROJECT, memoryStoreName: ' ', scope: 'user-1' }),
+        () =>
+          new FoundryMemoryProvider({
+            project: new FoundryProject(PROJECT, credential),
+            memoryStoreName: ' ',
+            scope: 'user-1',
+          }),
       ).toThrow(ConfigurationError);
     });
 
     it('rejects an empty scope', () => {
       expect(
         () =>
-          new FoundryMemoryProvider({ projectEndpoint: PROJECT, memoryStoreName: 'my-store', scope: ' ' }),
+          new FoundryMemoryProvider({
+            project: new FoundryProject(PROJECT, credential),
+            memoryStoreName: 'my-store',
+            scope: ' ',
+          }),
       ).toThrow(ConfigurationError);
-    });
-
-    it('rejects a missing project endpoint', () => {
-      const saved = process.env.FOUNDRY_PROJECT_ENDPOINT;
-      delete process.env.FOUNDRY_PROJECT_ENDPOINT;
-      try {
-        expect(() => new FoundryMemoryProvider({ memoryStoreName: 'my-store', scope: 'user-1' })).toThrow(
-          ConfigurationError,
-        );
-      } finally {
-        if (saved !== undefined) {
-          process.env.FOUNDRY_PROJECT_ENDPOINT = saved;
-        }
-      }
     });
 
     it('names its state partition foundry_memory unless told otherwise', () => {
@@ -518,8 +513,7 @@ describe('FoundryMemoryProvider', () => {
       }) as typeof globalThis.fetch;
       return {
         memory: new FoundryMemoryProvider({
-          projectEndpoint: PROJECT,
-          credential,
+          project: new FoundryProject(PROJECT, credential),
           memoryStoreName: 'my-store',
           scope: 'user-1',
           fetch: fetchStub,

--- a/packages/foundry/src/memory/provider.ts
+++ b/packages/foundry/src/memory/provider.ts
@@ -1,5 +1,3 @@
-import type { TokenCredential } from '@azure/identity';
-import { DefaultAzureCredential } from '@azure/identity';
 import type {
   ContextProvider,
   Message,
@@ -14,6 +12,7 @@ import {
   textContent,
   textOf,
 } from '@polymind-inc/agent-framework-core';
+import type { FoundryProject } from '../project.js';
 import type { MemoryInputItem, MemoryOperation, MemoryStoreDefinition, MemoryStoreObject } from './client.js';
 import { FoundryMemoryError, MemoryStoreClient } from './client.js';
 
@@ -58,10 +57,8 @@ export interface FoundryMemoryProviderConfig {
    * `@polymind-inc/agent-framework-foundry/hosting`.
    */
   scope: FoundryMemoryScope;
-  /** The Foundry **project** endpoint. Defaults to `FOUNDRY_PROJECT_ENDPOINT`. */
-  projectEndpoint?: string;
-  /** Defaults to {@link DefaultAzureCredential}. */
-  credential?: TokenCredential;
+  /** The project holding the memory store. */
+  project: FoundryProject;
   /** This provider's session-state partition and the source stamped on injected messages. */
   sourceId?: string;
   /** Prefixed to the retrieved memories. Defaults to a "## Memories" heading. */
@@ -125,7 +122,7 @@ interface MemoryState {
  *
  * ```ts
  * const memory = new FoundryMemoryProvider({
- *   projectEndpoint: process.env.FOUNDRY_PROJECT_ENDPOINT!,
+ *   project: new FoundryProject(process.env.FOUNDRY_PROJECT_ENDPOINT!, new DefaultAzureCredential()),
  *   memoryStoreName: 'assistant-memories',
  *   scope: userId,
  * });
@@ -169,18 +166,10 @@ export class FoundryMemoryProvider implements ContextProvider {
     if (typeof config.scope === 'string' && config.scope.trim() === '') {
       throw new ConfigurationError('FoundryMemoryProvider needs a non-empty scope.');
     }
-    const endpoint = config.projectEndpoint ?? process.env.FOUNDRY_PROJECT_ENDPOINT;
-    if (endpoint === undefined || endpoint.trim() === '') {
-      throw new ConfigurationError(
-        'FoundryMemoryProvider needs a project endpoint. Set FOUNDRY_PROJECT_ENDPOINT or pass ' +
-          '`projectEndpoint`.',
-      );
-    }
 
     this.sourceId = config.sourceId ?? DEFAULT_SOURCE_ID;
     this.#client = new MemoryStoreClient({
-      projectEndpoint: endpoint,
-      credential: config.credential ?? new DefaultAzureCredential(),
+      project: config.project,
       ...(config.fetch === undefined ? {} : { fetch: config.fetch }),
     });
     this.#storeName = config.memoryStoreName;

--- a/packages/foundry/src/project.test.ts
+++ b/packages/foundry/src/project.test.ts
@@ -1,0 +1,101 @@
+import type { AccessToken, TokenCredential } from '@azure/identity';
+import { ConfigurationError } from '@polymind-inc/agent-framework-core';
+import { describe, expect, it, vi } from 'vitest';
+import { FoundryProject } from './project.js';
+
+const PROJECT = 'https://my-resource.services.ai.azure.com/api/projects/my-project';
+
+/** A credential whose tokens expire `ttlMs` from now. */
+function fakeCredential(ttlMs = 60 * 60 * 1000): TokenCredential & { calls: number } {
+  const credential = {
+    calls: 0,
+    async getToken(): Promise<AccessToken> {
+      credential.calls++;
+      return { token: `token-${credential.calls}`, expiresOnTimestamp: Date.now() + ttlMs };
+    },
+  };
+  return credential;
+}
+
+describe('FoundryProject', () => {
+  it('normalizes the endpoint and exposes it', () => {
+    const project = new FoundryProject(`${PROJECT}///?x=1#frag`, fakeCredential());
+    expect(project.endpoint).toBe(PROJECT);
+  });
+
+  it('rejects an endpoint that is empty or relative', () => {
+    expect(() => new FoundryProject('  ', fakeCredential())).toThrow(ConfigurationError);
+    expect(() => new FoundryProject('/api/projects/p', fakeCredential())).toThrow(ConfigurationError);
+  });
+
+  it('exposes the configured default transport', () => {
+    const transport = (async () => new Response()) as unknown as typeof globalThis.fetch;
+    expect(new FoundryProject(PROJECT, fakeCredential(), { fetch: transport }).fetch).toBe(transport);
+    expect(new FoundryProject(PROJECT, fakeCredential()).fetch).toBeUndefined();
+  });
+
+  it('reuses a live token instead of calling the credential per request', async () => {
+    const credential = fakeCredential();
+    const project = new FoundryProject(PROJECT, credential);
+
+    expect(await project.getToken()).toBe('token-1');
+    expect(await project.getToken()).toBe('token-1');
+    expect(credential.calls).toBe(1);
+  });
+
+  it('refreshes a token that is about to expire', async () => {
+    // Inside the refresh margin, so the cached token is never considered usable.
+    const credential = fakeCredential(60 * 1000);
+    const project = new FoundryProject(PROJECT, credential);
+
+    expect(await project.getToken()).toBe('token-1');
+    expect(await project.getToken()).toBe('token-2');
+  });
+
+  it('shares one refresh between concurrent requests', async () => {
+    const credential = fakeCredential();
+    const project = new FoundryProject(PROJECT, credential);
+
+    const tokens = await Promise.all([project.getToken(), project.getToken(), project.getToken()]);
+
+    expect(tokens).toEqual(['token-1', 'token-1', 'token-1']);
+    expect(credential.calls).toBe(1);
+  });
+
+  it('requests the Foundry data-plane scope by default', async () => {
+    const getToken = vi.fn(async () => ({ token: 't', expiresOnTimestamp: Date.now() + 3_600_000 }));
+    await new FoundryProject(PROJECT, { getToken } as unknown as TokenCredential).getToken();
+
+    expect(getToken).toHaveBeenCalledWith('https://ai.azure.com/.default');
+  });
+
+  it('requests the configured scope instead when one is given', async () => {
+    const getToken = vi.fn(async () => ({ token: 't', expiresOnTimestamp: Date.now() + 3_600_000 }));
+    const project = new FoundryProject(PROJECT, { getToken } as unknown as TokenCredential, {
+      scope: 'https://sovereign.example/.default',
+    });
+
+    await project.getToken();
+
+    expect(getToken).toHaveBeenCalledWith('https://sovereign.example/.default');
+  });
+
+  it('caches tokens per scope, not per call', async () => {
+    const credential = fakeCredential();
+    const project = new FoundryProject(PROJECT, credential);
+
+    await project.getToken();
+    await project.getToken('https://other.example/.default');
+    await project.getToken();
+    await project.getToken('https://other.example/.default');
+
+    expect(credential.calls).toBe(2);
+  });
+
+  it('reports a credential that cannot produce a token', async () => {
+    const project = new FoundryProject(PROJECT, {
+      getToken: async () => null,
+    } as unknown as TokenCredential);
+    await expect(project.getToken()).rejects.toThrow(/Could not acquire a Microsoft Entra token/);
+  });
+});

--- a/packages/foundry/src/project.ts
+++ b/packages/foundry/src/project.ts
@@ -1,0 +1,88 @@
+import type { TokenCredential } from '@azure/identity';
+import { tokenProvider } from './credential.js';
+import { FOUNDRY_SCOPE, normalizeProjectEndpoint } from './target.js';
+
+/** Optional settings for {@link FoundryProject}. */
+export interface FoundryProjectOptions {
+  /** Entra scope tokens are acquired for. Defaults to `https://ai.azure.com/.default`. */
+  scope?: string;
+  /**
+   * Default transport for every component built from this project, for proxies and tests. A
+   * component's own `fetch` option takes precedence.
+   */
+  fetch?: typeof globalThis.fetch;
+}
+
+/**
+ * A Microsoft Foundry project: the endpoint requests go to and the identity they carry.
+ *
+ * Construct one per project and hand it to every Foundry component — chat client, memory
+ * provider, toolbox, response store — the way an `AIProjectClient` is shared in the Azure SDKs.
+ * All components built from the same project share one bearer-token cache per scope, so tokens
+ * are acquired once, not once per component. The constructor mirrors
+ * `new AIProjectClient(endpoint, credential)` from `@azure/ai-projects` deliberately — including
+ * that the endpoint and the credential are always passed in, never resolved from the environment
+ * or constructed implicitly — so code holding that pair can build either. Reading
+ * `FOUNDRY_PROJECT_ENDPOINT` and choosing the credential are the caller's decisions, made where
+ * the values are checked:
+ *
+ * ```ts
+ * const project = new FoundryProject(process.env.FOUNDRY_PROJECT_ENDPOINT!, new DefaultAzureCredential());
+ *
+ * const client  = new FoundryChatClient({ project, target: { model: 'gpt-4o' } });
+ * const memory  = new FoundryMemoryProvider({ project, memoryStoreName: 'memories', scope: userId });
+ * ```
+ *
+ * ## Security considerations
+ *
+ * `endpoint` decides where bearer tokens for this project's identity are sent. Treat it as
+ * trusted configuration; never build it from user input.
+ */
+export class FoundryProject {
+  readonly #endpoint: string;
+  readonly #credential: TokenCredential;
+  readonly #scope: string;
+  readonly #fetch: typeof globalThis.fetch | undefined;
+  /** One cached provider per scope, shared by every component built from this project. */
+  readonly #tokens = new Map<string, () => Promise<string>>();
+
+  /**
+   * @param endpoint The Foundry **project** endpoint, for example
+   *   `https://my-resource.services.ai.azure.com/api/projects/my-project`.
+   * @param credential The identity every call is authorized with. `DefaultAzureCredential` covers
+   *   `az login` locally and a managed identity in Azure.
+   * @param options Scope and transport defaults.
+   */
+  constructor(endpoint: string, credential: TokenCredential, options?: FoundryProjectOptions) {
+    this.#endpoint = normalizeProjectEndpoint(endpoint);
+    this.#credential = credential;
+    this.#scope = options?.scope ?? FOUNDRY_SCOPE;
+    this.#fetch = options?.fetch;
+  }
+
+  /** The normalized project endpoint. */
+  get endpoint(): string {
+    return this.#endpoint;
+  }
+
+  /** The default transport components built from this project use, when one was configured. */
+  get fetch(): typeof globalThis.fetch | undefined {
+    return this.#fetch;
+  }
+
+  /**
+   * A bearer token for the project, from the shared per-scope cache.
+   *
+   * Tokens are refreshed ahead of expiry and concurrent callers share one acquisition, so this is
+   * safe to call per request.
+   */
+  getToken(scope?: string): Promise<string> {
+    const resolved = scope ?? this.#scope;
+    let provider = this.#tokens.get(resolved);
+    if (provider === undefined) {
+      provider = tokenProvider(this.#credential, resolved);
+      this.#tokens.set(resolved, provider);
+    }
+    return provider();
+  }
+}

--- a/packages/foundry/src/target.ts
+++ b/packages/foundry/src/target.ts
@@ -9,8 +9,9 @@ export const FOUNDRY_API_VERSION = 'v1';
 /**
  * Which Foundry agent to talk to.
  *
- * - `modelDeployment` runs the framework's own agent against a model deployed in the project, over
- *   the project's OpenAI-compatible endpoint. Instructions, tools and the loop stay on this side.
+ * - `model` names a model deployment in the project and runs the framework's own agent against
+ *   it, over the project's OpenAI-compatible endpoint. Instructions, tools and the loop stay on
+ *   this side.
  * - `serverAgent` calls an agent that already exists in the project. The service owns its
  *   instructions and model, so passing them from here has no effect.
  *
@@ -19,20 +20,16 @@ export const FOUNDRY_API_VERSION = 'v1';
  * version field could only ever be ignored — and a caller who set one would reasonably believe it
  * pinned something.
  */
-export type FoundryTarget =
-  | { modelDeployment: string; serverAgent?: never }
-  | { serverAgent: string; modelDeployment?: never };
+export type FoundryTarget = { model: string; serverAgent?: never } | { serverAgent: string; model?: never };
 
 /** Narrows a {@link FoundryTarget} to the model-deployment case. */
-export function isModelDeployment(target: FoundryTarget): target is { modelDeployment: string } {
-  const hasModelDeployment = typeof target.modelDeployment === 'string';
+export function isModelTarget(target: FoundryTarget): target is { model: string } {
+  const hasModel = typeof target.model === 'string';
   const hasServerAgent = typeof target.serverAgent === 'string';
-  if (hasModelDeployment === hasServerAgent) {
-    throw new ConfigurationError(
-      'Foundry target must specify exactly one of modelDeployment or serverAgent.',
-    );
+  if (hasModel === hasServerAgent) {
+    throw new ConfigurationError('Foundry target must specify exactly one of model or serverAgent.');
   }
-  return hasModelDeployment;
+  return hasModel;
 }
 
 /**
@@ -76,9 +73,9 @@ export interface FoundryEndpoint {
  */
 export function resolveEndpoint(projectEndpoint: string, target: FoundryTarget): FoundryEndpoint {
   const project = normalizeProjectEndpoint(projectEndpoint);
-  if (isModelDeployment(target)) {
-    if (target.modelDeployment.trim() === '') {
-      throw new ConfigurationError('modelDeployment must be a non-empty deployment name.');
+  if (isModelTarget(target)) {
+    if (target.model.trim() === '') {
+      throw new ConfigurationError('model must be a non-empty deployment name.');
     }
     return { baseURL: `${project}/openai/v1/` };
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
 
   examples/02-foundry:
     dependencies:
+      '@azure/identity':
+        specifier: ^4.13.2
+        version: 4.13.2(supports-color@7.2.0)
       '@polymind-inc/agent-framework':
         specifier: workspace:^
         version: link:../../packages/meta


### PR DESCRIPTION
## What this changes

Adds a `FoundryProject` handle — `new FoundryProject(endpoint, credential, { scope?, fetch? })`, mirroring `new AIProjectClient(endpoint, credential)` from `@azure/ai-projects` — and makes it the required receipt on `FoundryChatClient`, `FoundryMemoryProvider`, `FoundryToolbox` and `FoundryResponseStore`, replacing the per-component `credential` / `scope` / `projectEndpoint` options and their silently constructed per-component `DefaultAzureCredential` chains with one shared per-scope token cache. Also renames `FoundryTarget.modelDeployment` to `model` (`isModelDeployment` → `isModelTarget`) and removes the `tokenProvider` export in favor of `project.getToken()`. Closes #90.

## Parity

- Reference checked: .NET `AIProjectClientExtensions.cs` and `Memory/FoundryMemoryProvider.cs` (everything hangs off one explicitly constructed `AIProjectClient`; the model-deployment value is the `model` parameter), Python `agent_framework_foundry/_chat_client.py` / `_memory_provider.py` (`project_client` receipt; `credential` required whenever no project client is given; the value is the `model` keyword) and `azure-ai-agentserver-activity/_foundry_storage.py` (the `DefaultAzureCredential` fallback the hosted default store keeps), Go `provider/foundryprovider/agent.go` + `internal/azaiprojects/client.go` (required credential argument, internal endpoint+credential client). Deliberate divergence: Go names its per-mode target *type* `ModelDeployment`; the field name here follows .NET/Python since the discriminated union does not share Go's type-per-mode design.
- Wire format affected: no
- Public API affected: yes
- Breaking change: yes

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
