### PR TITLE
Consolidate redundant implementations behind shared helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ contain breaking changes**; patch releases are fixes only.
   predicate remain: use the predicate to test an individual event type. Code that enumerated or
   iterated the exported tuple has no direct replacement.
 - **`@polymind-inc/agent-framework-core`** — a new `/internal` subpath holds the utilities the
-  framework's own packages and test suites share. Like the other `/internal` entries, it is a
+  framework's own packages share. Like the other `/internal` entries, it is a
   contract between the framework's packages and not part of the supported surface.
 - **`@polymind-inc/agent-framework-anthropic`** — a replayed `function_call` whose string
   arguments parse to a JSON array or scalar no longer reaches the API as `tool_use.input`; it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **[BREAKING] `@polymind-inc/agent-framework-core`** — the `MiddlewareKind` type is removed. It
+  was a free-standing alias nothing in the framework consumed; the discriminant lives on the
+  middleware objects themselves, so `Middleware['kind']` expresses the same type where one is
+  needed.
+- **[BREAKING] `@polymind-inc/agent-framework-agentserver`** — the `TERMINAL_EVENT_TYPES`
+  constant is no longer exported. The `TerminalEventType` type and the `isTerminalEventType`
+  predicate remain: use the predicate to test an individual event type. Code that enumerated or
+  iterated the exported tuple has no direct replacement.
+- **`@polymind-inc/agent-framework-core`** — a new `/internal` subpath holds the utilities the
+  framework's own packages and test suites share. Like the other `/internal` entries, it is a
+  contract between the framework's packages and not part of the supported surface.
+- **`@polymind-inc/agent-framework-anthropic`** — a replayed `function_call` whose string
+  arguments parse to a JSON array or scalar no longer reaches the API as `tool_use.input`; it
+  degrades to `{}` like every other non-object payload, keeping `input` the JSON object the
+  Messages API requires.
 - **[BREAKING] `@polymind-inc/agent-framework-foundry`** — Foundry credentials and the project
   endpoint are centralized in the new `FoundryProject` handle
   (`new FoundryProject(endpoint, credential, { scope?, fetch? })`, mirroring

--- a/packages/a2a/src/agent.test.ts
+++ b/packages/a2a/src/agent.test.ts
@@ -1,18 +1,12 @@
 import { UnsupportedOperationError } from '@a2a-js/sdk/errors';
 import type { AgentResponseUpdate, ContinuationToken } from '@polymind-inc/agent-framework-core';
 import { AgentSession, ConfigurationError, isAbortError } from '@polymind-inc/agent-framework-core';
+import { must } from '@polymind-inc/agent-framework-core/internal';
 import { describe, expect, it } from 'vitest';
 import { A2AAgent } from './agent.js';
 import { A2AAgentError } from './errors.js';
 import { readA2ASessionState } from './session.js';
 import { agentCard, fakeClient, message, streamEvent, task } from './test-support.js';
-
-function must<T>(value: T | undefined): T {
-  if (value === undefined) {
-    throw new Error('expected a value');
-  }
-  return value;
-}
 
 const answer = message({
   messageId: 'm1',

--- a/packages/a2a/src/agent.test.ts
+++ b/packages/a2a/src/agent.test.ts
@@ -1,8 +1,7 @@
 import { UnsupportedOperationError } from '@a2a-js/sdk/errors';
 import type { AgentResponseUpdate, ContinuationToken } from '@polymind-inc/agent-framework-core';
 import { AgentSession, ConfigurationError, isAbortError } from '@polymind-inc/agent-framework-core';
-import { must } from '@polymind-inc/agent-framework-core/internal';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import { A2AAgent } from './agent.js';
 import { A2AAgentError } from './errors.js';
 import { readA2ASessionState } from './session.js';
@@ -63,11 +62,15 @@ describe('a blocking turn', () => {
 
     const response = await agent.run('Is invoice 42 paid?');
 
-    expect(must(transport.calls[0]).method).toBe('sendMessage');
-    expect(sentMessage(must(transport.calls[0]).params).parts).toHaveLength(1);
+    const [call] = transport.calls;
+    const [responseMessage] = response.messages;
+    assert.exists(call);
+    assert.exists(responseMessage);
+    expect(call.method).toBe('sendMessage');
+    expect(sentMessage(call.params).parts).toHaveLength(1);
     expect(response.text).toBe('Invoice 42 is paid.');
     expect(response.agentId).toBe('a1');
-    expect(must(response.messages[0]).authorName).toBe('Invoice agent');
+    expect(responseMessage.authorName).toBe('Invoice agent');
     expect(response.finishReason).toBe('stop');
   });
 
@@ -76,9 +79,9 @@ describe('a blocking turn', () => {
 
     await new A2AAgent({ client }).run('hello');
 
-    const configuration = (
-      must(transport.calls[0]).params as { configuration: { returnImmediately: boolean } }
-    ).configuration;
+    const [call] = transport.calls;
+    assert.exists(call);
+    const configuration = (call.params as { configuration: { returnImmediately: boolean } }).configuration;
     expect(configuration.returnImmediately).toBe(false);
   });
 
@@ -91,9 +94,9 @@ describe('a blocking turn', () => {
 
     const response = await agent.run('long one', { session, allowBackgroundResponses: true });
 
-    const configuration = (
-      must(transport.calls[0]).params as { configuration: { returnImmediately: boolean } }
-    ).configuration;
+    const [call] = transport.calls;
+    assert.exists(call);
+    const configuration = (call.params as { configuration: { returnImmediately: boolean } }).configuration;
     expect(configuration.returnImmediately).toBe(true);
     expect(response.continuationToken).toEqual({ taskId: 'task-1' });
   });
@@ -110,8 +113,10 @@ describe('a blocking turn', () => {
 
     await agent.run('long one', { session: agent.createSession(), allowBackgroundResponses: true });
 
+    const [call] = transport.calls;
+    assert.exists(call);
     const configuration = (
-      must(transport.calls[0]).params as {
+      call.params as {
         configuration: { returnImmediately: boolean; acceptedOutputModes: string[] };
       }
     ).configuration;
@@ -146,7 +151,9 @@ describe('a blocking turn', () => {
 
     await new A2AAgent({ client }).run('hi', { metadata: { tenantHint: 'acme' } });
 
-    expect((must(transport.calls[0]).params as { metadata: unknown }).metadata).toEqual({
+    const [call] = transport.calls;
+    assert.exists(call);
+    expect((call.params as { metadata: unknown }).metadata).toEqual({
       tenantHint: 'acme',
     });
   });
@@ -188,7 +195,9 @@ describe('a streamed turn', () => {
     }
     const response = await stream.finalResponse();
 
-    expect(must(transport.calls[0]).method).toBe('sendMessageStream');
+    const [call] = transport.calls;
+    assert.exists(call);
+    expect(call.method).toBe('sendMessageStream');
     expect(updates).toHaveLength(4);
     expect(response.text).toBe('Invoice 42 is paid.');
     expect(session.serviceSessionId).toBe('ctx-1');
@@ -302,7 +311,9 @@ describe('a streamed turn', () => {
 
     expect(response.text).toBe('Invoice 42 is paid.');
     expect(response.messages).toHaveLength(1);
-    expect(must(response.messages[0]).contents).toHaveLength(1);
+    const [responseMessage] = response.messages;
+    assert.exists(responseMessage);
+    expect(responseMessage.contents).toHaveLength(1);
   });
 
   it('leaves the session alone when the caller stops early', async () => {
@@ -346,7 +357,9 @@ describe('linking turns together', () => {
     transport.calls.length = 0;
     await agent.run('42', { session });
 
-    const sent = sentMessage(must(transport.calls[0]).params);
+    const [call] = transport.calls;
+    assert.exists(call);
+    const sent = sentMessage(call.params);
     expect(sent.taskId).toBe('task-1');
     expect(sent.referenceTaskIds).toEqual([]);
     expect(sent.contextId).toBe('ctx-1');
@@ -367,7 +380,9 @@ describe('linking turns together', () => {
     transport.calls.length = 0;
     await agent.run('and invoice 43?', { session });
 
-    const sent = sentMessage(must(transport.calls[0]).params);
+    const [call] = transport.calls;
+    assert.exists(call);
+    const sent = sentMessage(call.params);
     expect(sent.taskId).toBe('');
     expect(sent.referenceTaskIds).toEqual(['task-1']);
   });
@@ -478,7 +493,9 @@ describe('a session whose conversation is gone', () => {
 
     // A task id means nothing outside the conversation it was created in: referencing it here
     // would point the remote agent at a task belonging to a context this message does not name.
-    const sent = sentMessage(must(transport.calls[0]).params);
+    const [call] = transport.calls;
+    assert.exists(call);
+    const sent = sentMessage(call.params);
     expect(sent.contextId).toBe('');
     expect(sent.referenceTaskIds).toEqual([]);
     expect(sent.taskId).toBe('');
@@ -507,7 +524,9 @@ describe('a session whose conversation is gone', () => {
 
     // Neither continued nor referenced: the recorded task belongs to ctx-2, and this message is
     // being sent in ctx-1.
-    const sent = sentMessage(must(transport.calls[0]).params);
+    const [call] = transport.calls;
+    assert.exists(call);
+    const sent = sentMessage(call.params);
     expect(sent.contextId).toBe('ctx-1');
     expect(sent.taskId).toBe('');
     expect(sent.referenceTaskIds).toEqual([]);
@@ -532,8 +551,10 @@ describe('resuming a background turn', () => {
       continuationToken: { taskId: 'task-1' },
     });
 
-    expect(must(transport.calls[0]).method).toBe('getTask');
-    expect(must(transport.calls[0]).params).toMatchObject({ id: 'task-1' });
+    const [call] = transport.calls;
+    assert.exists(call);
+    expect(call.method).toBe('getTask');
+    expect(call.params).toMatchObject({ id: 'task-1' });
     expect(response.text).toBe('done');
     expect(response.continuationToken).toBeUndefined();
   });
@@ -553,7 +574,9 @@ describe('resuming a background turn', () => {
       continuationToken: { taskId: 'task-1' },
     });
 
-    expect(must(transport.calls[0]).method).toBe('getTask');
+    const [call] = transport.calls;
+    assert.exists(call);
+    expect(call.method).toBe('getTask');
     expect(response.text).toBe('done');
   });
 
@@ -591,7 +614,9 @@ describe('resuming a background turn', () => {
       // Drain.
     }
 
-    expect(must(transport.calls[0]).method).toBe('resubscribeTask');
+    const [call] = transport.calls;
+    assert.exists(call);
+    expect(call.method).toBe('resubscribeTask');
   });
 
   it('reads the final state when the task can no longer be subscribed to', async () => {
@@ -618,7 +643,9 @@ describe('resuming a background turn', () => {
     }
 
     expect(transport.calls.map((call) => call.method)).toEqual(['resubscribeTask', 'getTask']);
-    expect(must(updates[0]).text).toBe('done');
+    const [update] = updates;
+    assert.exists(update);
+    expect(update.text).toBe('done');
   });
 
   it('reports any other subscription failure', async () => {
@@ -726,7 +753,9 @@ describe('failures', () => {
 
     await new A2AAgent({ client }).run('hi', { signal: controller.signal });
 
-    expect(must(transport.calls[0]).options?.signal).toBe(controller.signal);
+    const [call] = transport.calls;
+    assert.exists(call);
+    expect(call.options?.signal).toBe(controller.signal);
   });
 });
 

--- a/packages/a2a/src/agent.ts
+++ b/packages/a2a/src/agent.ts
@@ -21,14 +21,16 @@ import {
   createClientErrorNormalizer,
   createResponseStream,
   type FunctionTool,
+  type Message,
   mergeUpdates,
   normalizeInput,
   startAgentRunSpan,
 } from '@polymind-inc/agent-framework-core';
+import { errorMessageOf } from '@polymind-inc/agent-framework-core/internal';
 import { parseA2AContinuationToken } from './continuation.js';
 import { type A2APayload, type ObservedTaskState, toA2AMessage, updatesFromPayload } from './convert.js';
 import { A2AAgentError } from './errors.js';
-import { A2A_STATE_KEY, contextMismatch, readA2ASessionState, writeA2ASessionState } from './session.js';
+import { contextMismatch, readA2ASessionState, writeA2ASessionState } from './session.js';
 
 /** Goes to `gen_ai.provider.name`, lower-case as the conventions spell provider names. */
 const PROVIDER_NAME = 'a2a';
@@ -189,7 +191,7 @@ export class A2AAgent implements AgentLike {
             // A card that names no transport this client speaks is a mismatched configuration, not
             // a failed request, and it reports as one wherever it is first noticed.
             throw new ConfigurationError(
-              `No usable transport for this agent card: ${error instanceof Error ? error.message : String(error)}`,
+              `No usable transport for this agent card: ${errorMessageOf(error)}`,
               { cause: error },
             );
           })
@@ -215,9 +217,7 @@ export class A2AAgent implements AgentLike {
       ...(options?.serviceSessionId === undefined ? {} : { serviceSessionId: options.serviceSessionId }),
     });
     if (options?.taskId !== undefined && options.serviceSessionId !== undefined) {
-      const partition = session.partition(A2A_STATE_KEY);
-      partition.contextId = options.serviceSessionId;
-      partition.taskId = options.taskId;
+      writeA2ASessionState(session, { contextId: options.serviceSessionId, taskId: options.taskId });
     }
     return session;
   }
@@ -342,7 +342,7 @@ export class A2AAgent implements AgentLike {
   /** Sends this turn's message, blocking or streaming according to how the caller consumes it. */
   async *#send(
     client: Client,
-    inputMessages: readonly import('@polymind-inc/agent-framework-core').Message[],
+    inputMessages: readonly Message[],
     ctx: {
       stream: boolean;
       background: boolean;

--- a/packages/a2a/src/convert.test.ts
+++ b/packages/a2a/src/convert.test.ts
@@ -7,6 +7,7 @@ import type {
   UriContent,
 } from '@polymind-inc/agent-framework-core';
 import { dataContent, textContent, uriContent } from '@polymind-inc/agent-framework-core';
+import { must } from '@polymind-inc/agent-framework-core/internal';
 import { describe, expect, it } from 'vitest';
 import {
   fromA2AParts,
@@ -17,14 +18,6 @@ import {
 } from './convert.js';
 import { A2AAgentError } from './errors.js';
 import { message, streamEvent, task } from './test-support.js';
-
-/** Fails the test rather than returning `undefined`, so a missing item is reported where it happens. */
-function must<T>(value: T | undefined): T {
-  if (value === undefined) {
-    throw new Error('expected a value');
-  }
-  return value;
-}
 
 describe('framework content to A2A parts', () => {
   it('sends text as a text part and carries its metadata', () => {

--- a/packages/a2a/src/convert.test.ts
+++ b/packages/a2a/src/convert.test.ts
@@ -7,8 +7,7 @@ import type {
   UriContent,
 } from '@polymind-inc/agent-framework-core';
 import { dataContent, textContent, uriContent } from '@polymind-inc/agent-framework-core';
-import { must } from '@polymind-inc/agent-framework-core/internal';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import {
   fromA2AParts,
   type ObservedTaskState,
@@ -24,8 +23,10 @@ describe('framework content to A2A parts', () => {
     const parts = toA2AParts([textContent('hello', { additionalProperties: { lang: 'en' } })]);
 
     expect(parts).toHaveLength(1);
-    expect(must(parts[0]).content).toEqual({ $case: 'text', value: 'hello' });
-    expect(must(parts[0]).metadata).toEqual({ lang: 'en' });
+    const [part] = parts;
+    assert.exists(part);
+    expect(part.content).toEqual({ $case: 'text', value: 'hello' });
+    expect(part.metadata).toEqual({ lang: 'en' });
   });
 
   it('skips empty text, which some agents reject', () => {
@@ -37,9 +38,11 @@ describe('framework content to A2A parts', () => {
       uriContent('https://example.test/a.pdf', 'application/pdf', { name: 'a.pdf' }),
     ]);
 
-    expect(must(parts[0]).content).toEqual({ $case: 'url', value: 'https://example.test/a.pdf' });
-    expect(must(parts[0]).mediaType).toBe('application/pdf');
-    expect(must(parts[0]).filename).toBe('a.pdf');
+    const [part] = parts;
+    assert.exists(part);
+    expect(part.content).toEqual({ $case: 'url', value: 'https://example.test/a.pdf' });
+    expect(part.mediaType).toBe('application/pdf');
+    expect(part.filename).toBe('a.pdf');
   });
 
   it('sends data content as raw bytes, decoded from its data URI', () => {
@@ -47,25 +50,33 @@ describe('framework content to A2A parts', () => {
 
     const parts = toA2AParts([dataContent(bytes, 'application/octet-stream')]);
 
-    const content = must(must(parts[0]).content);
+    const [part] = parts;
+    assert.exists(part);
+    const { content } = part;
+    assert.exists(content);
     expect(content.$case).toBe('raw');
     expect(Array.from(content.value as Uint8Array)).toEqual([1, 2, 3, 250]);
     // Round-trips through the SDK's own encoder rather than stopping at our object.
-    expect(Part.toJSON(must(parts[0]))).toEqual({ raw: 'AQID+g==', mediaType: 'application/octet-stream' });
+    expect(Part.toJSON(part)).toEqual({ raw: 'AQID+g==', mediaType: 'application/octet-stream' });
   });
 
   it('sends a hosted file as a url part carrying its id', () => {
     const parts = toA2AParts([{ type: 'hosted_file', fileId: 'file-1', name: 'report.csv' }]);
 
-    expect(must(parts[0]).content).toEqual({ $case: 'url', value: 'file-1' });
-    expect(must(parts[0]).filename).toBe('report.csv');
+    const [part] = parts;
+    assert.exists(part);
+    expect(part.content).toEqual({ $case: 'url', value: 'file-1' });
+    expect(part.filename).toBe('report.csv');
   });
 
   it('sends error content as text, with a stand-in when it has no message', () => {
     const parts = toA2AParts([{ type: 'error' }, { type: 'error', message: 'boom' }]);
 
-    expect(must(parts[0]).content).toEqual({ $case: 'text', value: 'An error occurred.' });
-    expect(must(parts[1]).content).toEqual({ $case: 'text', value: 'boom' });
+    const [withoutMessage, withMessage] = parts;
+    assert.exists(withoutMessage);
+    assert.exists(withMessage);
+    expect(withoutMessage.content).toEqual({ $case: 'text', value: 'An error occurred.' });
+    expect(withMessage.content).toEqual({ $case: 'text', value: 'boom' });
   });
 
   it('drops content the protocol cannot carry instead of failing', () => {
@@ -79,7 +90,9 @@ describe('framework content to A2A parts', () => {
     const parts = toA2AParts(contents);
 
     expect(parts).toHaveLength(1);
-    expect(must(parts[0]).content).toEqual({ $case: 'text', value: 'kept' });
+    const [part] = parts;
+    assert.exists(part);
+    expect(part.content).toEqual({ $case: 'text', value: 'kept' });
   });
 
   it('refuses data content whose URI is not base64, without quoting the payload', () => {
@@ -214,13 +227,15 @@ describe('payloads to response updates', () => {
     );
 
     expect(updates).toHaveLength(1);
-    expect(must(updates[0])).toMatchObject({
+    const [update] = updates;
+    assert.exists(update);
+    expect(update).toMatchObject({
       role: 'assistant',
       responseId: 'm1',
       messageId: 'm1',
       finishReason: 'stop',
     });
-    expect(must(updates[0]).text).toBe('hi');
+    expect(update.text).toBe('hi');
     expect(observed).toEqual({ contextId: 'ctx-1' });
   });
 
@@ -230,7 +245,9 @@ describe('payloads to response updates', () => {
       {},
     );
 
-    expect(must(updates[0]).role).toBe('user');
+    const [update] = updates;
+    assert.exists(update);
+    expect(update.role).toBe('user');
   });
 
   it('emits one update per artifact and merges task metadata into each', () => {
@@ -254,11 +271,14 @@ describe('payloads to response updates', () => {
     );
 
     expect(updates.map((update) => update.messageId)).toEqual(['a1', 'a2']);
-    expect(must(updates[0]).additionalProperties).toEqual({ seq: 1, turn: 1 });
+    const [first, second] = updates;
+    assert.exists(first);
+    assert.exists(second);
+    expect(first.additionalProperties).toEqual({ seq: 1, turn: 1 });
     expect(updates.every((update) => update.createdAt === '2026-08-03T10:00:00Z')).toBe(true);
     // Only the last update ends the turn, so folding does not stop at the first artifact.
-    expect(must(updates[0]).finishReason).toBeUndefined();
-    expect(must(updates[1]).finishReason).toBe('stop');
+    expect(first.finishReason).toBeUndefined();
+    expect(second.finishReason).toBe('stop');
     expect(observed).toEqual({
       contextId: 'ctx-1',
       taskId: 'task-1',
@@ -285,7 +305,9 @@ describe('payloads to response updates', () => {
 
     expect(updates.map((update) => update.text)).toEqual(['found two', 'which invoice?']);
     // An interrupted task waits for the caller, not for the agent: there is nothing to resume.
-    expect(must(updates[1]).continuationToken).toBeUndefined();
+    const [, question] = updates;
+    assert.exists(question);
+    expect(question.continuationToken).toBeUndefined();
   });
 
   it('surfaces a terminal status message, including a failure reason', () => {
@@ -348,7 +370,9 @@ describe('payloads to response updates', () => {
       const updates = updatesFromPayload({ $case: 'task', value: working }, {});
 
       expect(updates.map((update) => update.text)).not.toContain('stale answer');
-      expect(must(updates.at(-1)).continuationToken).toEqual({ taskId: 'task-1' });
+      const last = updates.at(-1);
+      assert.exists(last);
+      expect(last.continuationToken).toEqual({ taskId: 'task-1' });
     }
   });
 
@@ -361,7 +385,9 @@ describe('payloads to response updates', () => {
         artifact: { artifactId: 'a1', parts: [{ text: 'the answer' }] },
       },
     });
-    updatesFromPayload(must(streamed.payload), observed);
+    const { payload } = streamed;
+    assert.exists(payload);
+    updatesFromPayload(payload, observed);
 
     const terminal = updatesFromPayload(
       {
@@ -409,7 +435,9 @@ describe('payloads to response updates', () => {
         artifact: { artifactId: 'a1', parts: [{ text: 'once' }] },
       },
     });
-    const first = updatesFromPayload(must(streamed.payload), observed);
+    const { payload } = streamed;
+    assert.exists(payload);
+    const first = updatesFromPayload(payload, observed);
     const terminal = updatesFromPayload(
       {
         $case: 'task',
@@ -442,7 +470,8 @@ describe('payloads to response updates', () => {
       {},
     );
 
-    const last = must(updates.at(-1));
+    const last = updates.at(-1);
+    assert.exists(last);
     expect(last.continuationToken).toEqual(resumable ? { taskId: 'task-1' } : undefined);
     expect(last.finishReason).toBe(finishReason);
   });
@@ -457,8 +486,10 @@ describe('payloads to response updates', () => {
     );
 
     expect(updates).toHaveLength(1);
-    expect(must(updates[0]).contents).toEqual([]);
-    expect(must(updates[0]).continuationToken).toEqual({ taskId: 'task-1' });
+    const [update] = updates;
+    assert.exists(update);
+    expect(update.contents).toEqual([]);
+    expect(update.continuationToken).toEqual({ taskId: 'task-1' });
   });
 
   it('keeps progress commentary out of the transcript', () => {
@@ -473,12 +504,16 @@ describe('payloads to response updates', () => {
       },
     });
 
-    const updates = updatesFromPayload(must(event.payload), {});
+    const { payload } = event;
+    assert.exists(payload);
+    const updates = updatesFromPayload(payload, {});
 
-    expect(must(updates[0]).contents).toEqual([]);
+    const [update] = updates;
+    assert.exists(update);
+    expect(update.contents).toEqual([]);
     // Not even identified: a message id whose content was dropped would start an empty message
     // during folding and split the surrounding artifact in two.
-    expect(must(updates[0]).messageId).toBeUndefined();
+    expect(update.messageId).toBeUndefined();
   });
 
   it('surfaces a status message when the state is input-required', () => {
@@ -494,9 +529,13 @@ describe('payloads to response updates', () => {
     });
     const observed: ObservedTaskState = {};
 
-    const updates = updatesFromPayload(must(event.payload), observed);
+    const { payload } = event;
+    assert.exists(payload);
+    const updates = updatesFromPayload(payload, observed);
 
-    expect(must(updates[0]).text).toBe('which invoice?');
+    const [update] = updates;
+    assert.exists(update);
+    expect(update.text).toBe('which invoice?');
     expect(observed.taskState).toBe('TASK_STATE_INPUT_REQUIRED');
   });
 
@@ -510,10 +549,14 @@ describe('payloads to response updates', () => {
       },
     });
 
-    const updates = updatesFromPayload(must(event.payload), {});
+    const { payload } = event;
+    assert.exists(payload);
+    const updates = updatesFromPayload(payload, {});
 
-    expect(must(updates[0])).toMatchObject({ responseId: 'task-1', messageId: 'a1' });
-    expect(must(updates[0]).additionalProperties).toEqual({ seq: 1, from: 'event' });
+    const [update] = updates;
+    assert.exists(update);
+    expect(update).toMatchObject({ responseId: 'task-1', messageId: 'a1' });
+    expect(update.additionalProperties).toEqual({ seq: 1, from: 'event' });
   });
 
   it('keeps the last reported task state when an artifact update carries no status', () => {
@@ -530,7 +573,9 @@ describe('payloads to response updates', () => {
       },
     });
 
-    updatesFromPayload(must(event.payload), observed);
+    const { payload } = event;
+    assert.exists(payload);
+    updatesFromPayload(payload, observed);
 
     expect(observed.taskState).toBe('TASK_STATE_WORKING');
   });

--- a/packages/a2a/src/convert.ts
+++ b/packages/a2a/src/convert.ts
@@ -250,9 +250,9 @@ function update(init: {
  * `auth-required`) is waiting for the *caller*, not for the agent: that is continued by sending
  * the next message, not by resuming the run.
  */
-function tokenFor(task: { id: string; state: TaskState | undefined }): { taskId: string } | undefined {
-  return task.state === TaskState.TASK_STATE_SUBMITTED || task.state === TaskState.TASK_STATE_WORKING
-    ? a2aContinuationToken(task.id)
+function tokenFor(taskId: string, state: TaskState | undefined): { taskId: string } | undefined {
+  return state === TaskState.TASK_STATE_SUBMITTED || state === TaskState.TASK_STATE_WORKING
+    ? a2aContinuationToken(taskId)
     : undefined;
 }
 
@@ -294,14 +294,15 @@ function isTerminalState(state: TaskState | undefined): boolean {
 function updatesFromTask(task: Task, observed: ObservedTaskState): AgentResponseUpdate[] {
   const state = task.status?.state;
   const alreadyStreamed = observed.streamedArtifacts;
-  const updates: AgentResponseUpdate[] = (task.artifacts ?? [])
+  const artifacts = task.artifacts ?? [];
+  const updates: AgentResponseUpdate[] = artifacts
     .filter((artifact) => !alreadyStreamed?.has(artifactKey(task.id, artifact.artifactId)))
     .map((artifact) =>
       artifactUpdate(artifact, task.id, mergeMetadata(artifact.metadata, task.metadata), task),
     );
 
   const statusMessage = task.status?.message;
-  if (isTerminalState(state) && (task.artifacts ?? []).length === 0) {
+  if (isTerminalState(state) && artifacts.length === 0) {
     // A finished task that produced no artifacts at all may still have answered as a plain
     // message, kept in its history. Only that case falls back to the history: an unfinished
     // task's history would be replayed by every poll, a task whose artifacts were merely
@@ -353,7 +354,7 @@ function updatesFromTask(task: Task, observed: ObservedTaskState): AgentResponse
   if (finishReason !== undefined) {
     last.finishReason = finishReason;
   }
-  const token = tokenFor({ id: task.id, state });
+  const token = tokenFor(task.id, state);
   if (token !== undefined) {
     last.continuationToken = token;
   }

--- a/packages/agentserver/src/background-driver.ts
+++ b/packages/agentserver/src/background-driver.ts
@@ -1,16 +1,16 @@
 import type { IdClaim } from './background-run.js';
 import { BackgroundRun } from './background-run.js';
-import { sseKeepAliveSeconds } from './config.js';
+import { sseKeepAliveMs } from './config.js';
 import { HEADERS } from './context.js';
 import { ProtocolError } from './errors.js';
-import { jsonResponse } from './http.js';
+import { jsonResponse, sseResponse } from './http.js';
 import type { ResponseTracker } from './lifecycle.js';
-import { applyCancelledTerminal } from './lifecycle.js';
+import { applyCancelledTerminal, failedTerminal, messageOf } from './lifecycle.js';
 import { flushTelemetry } from './observability/flush.js';
-import { SequenceNumberWriter, SSE_HEADERS, toSseStream } from './sse.js';
+import { SequenceNumberWriter } from './sse.js';
 import type { ResponseOwner, ResponseProvider } from './store/provider.js';
 import { TerminalPersister } from './terminal.js';
-import type { OutputItem, ResponseEvent, ResponseObject } from './wire.js';
+import type { OutputItem, ResponseEvent, ResponseLifecycleEvent, ResponseObject } from './wire.js';
 import { isTerminalEventType } from './wire.js';
 
 /**
@@ -24,7 +24,7 @@ import { isTerminalEventType } from './wire.js';
  * The event keeps the type `response.failed`, as the reference's override does: the protocol has
  * no `response.cancelled` event, so the status on the carried resource is what says what happened.
  */
-function cancelledTerminal(tracker: ResponseTracker): ResponseEvent {
+function cancelledTerminal(tracker: ResponseTracker): ResponseLifecycleEvent {
   const response = applyCancelledTerminal(tracker.response);
   tracker.replace(response);
   return { type: 'response.failed', response };
@@ -91,11 +91,7 @@ export async function startBackground(args: {
   args.claim.settle(run.done);
 
   if (args.streamed) {
-    const keepAliveMs = sseKeepAliveSeconds() * 1000;
-    return new Response(toSseStream(run.follow(-1), { keepAliveMs }), {
-      status: 200,
-      headers: { ...SSE_HEADERS, [HEADERS.sessionId]: args.sessionId },
-    });
+    return sseResponse(run.follow(-1), { keepAliveMs: sseKeepAliveMs(), sessionId: args.sessionId });
   }
   await run.firstEvent;
   return jsonResponse(run.tracker.response, 200, { [HEADERS.sessionId]: args.sessionId });
@@ -123,7 +119,7 @@ async function runBackground(args: {
     try {
       for await (const raw of events) {
         let event = raw;
-        if (isTerminalEventType(String(event.type))) {
+        if (isTerminalEventType(event.type)) {
           if (run.cancelRequested) {
             // The caller was already promised `cancelled`; whatever terminal the handler
             // reached does not get to overrule that (Python `_maybe_override_to_cancelled`).
@@ -145,16 +141,12 @@ async function runBackground(args: {
       // `response.failed`, this terminal state is the only place left
       // for the caller to learn why the turn failed.
       const cause = error instanceof ProtocolError && error.cause !== undefined ? error.cause : error;
-      const message =
-        cause instanceof Error ? (cause.message === '' ? cause.name : cause.message) : String(cause);
       const event = run.cancelRequested
         ? // Same override as the loop above: a handler that throws *after* the cancel route
           // answered still ends as `cancelled`, not as `failed` (the reference applies
           // `_maybe_override_to_cancelled` on the resolved terminal whatever produced it).
           cancelledTerminal(run.tracker)
-        : run.tracker.lifecycleEvent('response.failed', 'failed', {
-            error: { code: 'server_error', message, type: 'server_error' },
-          });
+        : failedTerminal(run.tracker, messageOf(cause));
       run.deliver(sequence.stamp(await persister.onTerminal(event)));
     }
     // Unreachable while `enforceLifecycle` guarantees a terminal event; kept so a future

--- a/packages/agentserver/src/background.test.ts
+++ b/packages/agentserver/src/background.test.ts
@@ -9,16 +9,8 @@ import type {
   ResponseProvider,
   StoredResponse,
 } from './store/provider.js';
+import { lifecycleHandler, makeServer, must, post, readSse } from './test-helpers.js';
 import type { CreateResponseRequest, OutputItem, ResponseEvent, ResponseObject } from './wire.js';
-
-/** A promise with its resolver in hand — the gate the tests hold a handler on. */
-function deferred(): { promise: Promise<void>; resolve: () => void } {
-  let resolve!: () => void;
-  const promise = new Promise<void>((r) => {
-    resolve = r;
-  });
-  return { promise, resolve };
-}
 
 /** The reader of a streaming response's body; a body-less response fails the test outright. */
 function bodyReader(res: Response): ReadableStreamDefaultReader<Uint8Array> {
@@ -37,85 +29,13 @@ function firstDataLine(text: string): string {
   return line.slice(6);
 }
 
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}
-
-function onAbort(signal: AbortSignal): Promise<void> {
-  return new Promise((resolve) => {
-    if (signal.aborted) {
-      resolve();
-      return;
-    }
-    signal.addEventListener('abort', () => resolve(), { once: true });
-  });
-}
-
 /**
  * The reference echo shape, optionally held open on `gate` between `in_progress` and the output.
  * When the abort signal fires while waiting, it winds down as a cancellation (`AbortError`), the
  * way a well-behaved handler is documented to.
  */
 function gatedHandler(gate?: Promise<void>): ResponseHandler {
-  return async function* (_request: CreateResponseRequest, context: HandlerContext) {
-    const response = (status: ResponseObject['status']): ResponseObject => ({
-      ...context.response,
-      status,
-    });
-    yield { type: 'response.created', response: response('queued') };
-    yield { type: 'response.in_progress', response: response('in_progress') };
-    if (gate !== undefined) {
-      await Promise.race([gate, onAbort(context.signal)]);
-      // The real shape, not a hand-named `Error`: this is the `DOMException` the platform puts on
-      // `signal.reason`, and the same value the framework's providers propagate for an
-      // interrupted model call (`@polymind-inc/agent-framework-core`'s `abortErrorFrom`).
-      context.signal.throwIfAborted();
-    }
-    yield {
-      type: 'response.output_item.done',
-      output_index: 0,
-      item: {
-        type: 'message',
-        id: 'msg_bg',
-        role: 'assistant',
-        status: 'completed',
-        content: [{ type: 'output_text', text: 'done', annotations: [] }],
-      },
-    };
-    yield { type: 'response.completed', response: response('completed') };
-  };
-}
-
-/**
- * The same shape as {@link gatedHandler}, with its output item tagged.
- *
- * For the tests that put two turns under one id and have to be able to tell their event logs
- * apart — untagged, two runs of the echo handler produce byte-identical streams, and "the stale
- * log replaced the fresh one" is indistinguishable from success.
- */
-function labelledHandler(label: string): ResponseHandler {
-  return async function* (_request: CreateResponseRequest, context: HandlerContext) {
-    const response = (status: ResponseObject['status']): ResponseObject => ({
-      ...context.response,
-      status,
-    });
-    yield { type: 'response.created', response: response('queued') };
-    yield { type: 'response.in_progress', response: response('in_progress') };
-    yield {
-      type: 'response.output_item.done',
-      output_index: 0,
-      item: {
-        type: 'message',
-        id: `msg_${label}`,
-        role: 'assistant',
-        status: 'completed',
-        content: [{ type: 'output_text', text: label, annotations: [] }],
-      },
-    };
-    yield { type: 'response.completed', response: response('completed') };
-  };
+  return lifecycleHandler({ label: 'bg', gate });
 }
 
 /**
@@ -126,37 +46,17 @@ function labelledHandler(label: string): ResponseHandler {
  * handler's own terminal must not be honoured however long after the promise it arrives.
  */
 function stubbornHandler(gate: Promise<void>): ResponseHandler {
-  return async function* (_request: CreateResponseRequest, context: HandlerContext) {
-    const response = (status: ResponseObject['status']): ResponseObject => ({
-      ...context.response,
-      status,
-    });
-    yield { type: 'response.created', response: response('queued') };
-    yield {
-      type: 'response.in_progress',
-      // Fields only a handler can put on the resource. The cancelled snapshot has to strip both:
-      // `error` and `completed_at` must be absent on a `cancelled` response.
-      response: {
-        ...response('in_progress'),
-        error: { code: 'server_error', message: 'handler-owned', type: 'server_error' },
-        completed_at: 1234,
-      },
-    };
-    yield {
-      type: 'response.output_item.done',
-      output_index: 0,
-      item: {
-        type: 'message',
-        id: 'msg_stubborn',
-        role: 'assistant',
-        status: 'completed',
-        content: [{ type: 'output_text', text: 'produced anyway', annotations: [] }],
-      },
-    };
-    // Deliberately *not* racing `context.signal`: this handler does not honour cancellation.
-    await gate;
-    yield { type: 'response.completed', response: response('completed') };
-  };
+  return lifecycleHandler({
+    label: 'stubborn',
+    gate,
+    ignoreAbort: true,
+    // Fields only a handler can put on the resource. The cancelled snapshot has to strip both:
+    // `error` and `completed_at` must be absent on a `cancelled` response.
+    inProgressResponse: {
+      error: { code: 'server_error', message: 'handler-owned', type: 'server_error' },
+      completed_at: 1234,
+    },
+  });
 }
 
 /**
@@ -229,21 +129,6 @@ class ObservableStore implements ResponseProvider {
   }
 }
 
-function makeServer(
-  handler: ResponseHandler,
-  store: ResponseProvider = new InMemoryResponseProvider(),
-): ResponsesServer {
-  return new ResponsesServer({ handler, store });
-}
-
-function post(body: unknown): Request {
-  return new Request('http://localhost:8088/responses', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-}
-
 /**
  * A create whose *body* only arrives once `gate` opens.
  *
@@ -289,21 +174,6 @@ async function waitFor(predicate: () => boolean, what: string): Promise<void> {
   throw new Error(`timed out waiting for ${what}`);
 }
 
-async function readSse(response: Response): Promise<Array<{ event: string; data: Record<string, unknown> }>> {
-  const text = await response.text();
-  return text
-    .split('\n\n')
-    .filter((block) => block.trim() !== '' && !block.startsWith(':'))
-    .map((block) => {
-      const eventLine = must(block.split('\n').find((line) => line.startsWith('event: ')));
-      const dataLine = must(block.split('\n').find((line) => line.startsWith('data: ')));
-      return {
-        event: eventLine.slice('event: '.length),
-        data: JSON.parse(dataLine.slice('data: '.length)) as Record<string, unknown>,
-      };
-    });
-}
-
 /** Polls `GET /responses/{id}` until the predicate holds; the background turn's clock. */
 async function pollUntil(
   server: ResponsesServer,
@@ -330,7 +200,7 @@ async function errorOf(response: Response): Promise<{ code: string; message: str
 
 describe('background non-stream', () => {
   it('answers immediately with the queued/in_progress snapshot and completes detached', async () => {
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const server = makeServer(gatedHandler(gate.promise));
 
     const created = await server.handle(post({ input: 'hi', background: true }));
@@ -372,7 +242,7 @@ describe('background non-stream', () => {
   });
 
   it('serves input_items from the in-flight run before anything is persisted', async () => {
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const server = makeServer(gatedHandler(gate.promise));
     const inputs = [
       { type: 'message', id: 'bg_i1', role: 'user', content: [{ type: 'input_text', text: 'a' }] },
@@ -411,7 +281,7 @@ describe('background + stream', () => {
   });
 
   it('does not cancel the run when the streaming client disconnects', async () => {
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const server = makeServer(gatedHandler(gate.promise));
 
     const created = await server.handle(post({ input: 'hi', background: true, stream: true }));
@@ -460,7 +330,7 @@ describe('streamed replay', () => {
   });
 
   it('replays the retained prefix of a still-running stream, then follows it live', async () => {
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const server = makeServer(gatedHandler(gate.promise));
 
     const created = await server.handle(post({ input: 'hi', background: true, stream: true }));
@@ -518,7 +388,7 @@ describe('streamed replay', () => {
   });
 
   it('drops replay when a stream crosses the retention cap, without cutting the live subscriber', async () => {
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const server = new ResponsesServer({
       handler: gatedHandler(gate.promise),
       store: new InMemoryResponseProvider(),
@@ -552,7 +422,7 @@ describe('streamed replay', () => {
   });
 
   it('keeps a mid-run subscriber to the terminal once the cap has already bitten', async () => {
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const server = new ResponsesServer({
       handler: gatedHandler(gate.promise),
       store: new InMemoryResponseProvider(),
@@ -578,8 +448,8 @@ describe('streamed replay', () => {
   it('carries a subscriber that stopped draining to the terminal, past a moving window', async () => {
     // `created` → hold1 → `in_progress` → hold2 → the output item and the terminal, so the test
     // decides exactly when the window moves relative to a parked subscriber.
-    const hold1 = deferred();
-    const hold2 = deferred();
+    const hold1 = Promise.withResolvers<void>();
+    const hold2 = Promise.withResolvers<void>();
     const server = new ResponsesServer({
       handler: async function* (_request: CreateResponseRequest, context: HandlerContext) {
         const response = (status: ResponseObject['status']): ResponseObject => ({
@@ -665,7 +535,7 @@ describe('streamed replay', () => {
     const server = new ResponsesServer({
       handler: (request, context) => {
         turn += 1;
-        return labelledHandler(`turn${turn}`)(request, context);
+        return lifecycleHandler({ label: `turn${turn}` })(request, context);
       },
       store,
     });
@@ -709,7 +579,7 @@ describe('stores without event persistence stay fail-closed', () => {
   }
 
   it('answers 501 for a background create, after the store=true validation', async () => {
-    const server = makeServer(gatedHandler(), baseStore());
+    const server = makeServer(gatedHandler(), { store: baseStore() });
 
     // The store=false violation is still the caller's 400, learned first.
     const invalid = await server.handle(post({ input: 'x', background: true, store: false }));
@@ -733,7 +603,7 @@ describe('stores without event persistence stay fail-closed', () => {
         background: true,
       },
     };
-    const server = makeServer(gatedHandler(), baseStore(canned));
+    const server = makeServer(gatedHandler(), { store: baseStore(canned) });
 
     const replay = await server.handle(get(`/responses/${responseId}?stream=true`));
     expect(replay.status).toBe(501);
@@ -748,7 +618,7 @@ describe('stores without event persistence stay fail-closed', () => {
 
 describe('cancel', () => {
   it('cancels an in-flight background run; cancellation wins and is idempotent', async () => {
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const server = makeServer(gatedHandler(gate.promise));
 
     const created = await server.handle(post({ input: 'hi', background: true }));
@@ -801,7 +671,7 @@ describe('cancel', () => {
 
 describe('delete', () => {
   it('refuses to delete an in-flight run, then deletes the finished turn and its replay log', async () => {
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const server = makeServer(gatedHandler(gate.promise));
 
     const created = await server.handle(post({ input: 'hi', background: true, stream: true }));
@@ -842,7 +712,7 @@ describe('cancellation always wins over the handler', () => {
 
   it('is not overwritten when the handler ignores the signal and finishes past the grace', async () => {
     shortGrace();
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const store = new ObservableStore();
     const server = new ResponsesServer({ handler: stubbornHandler(gate.promise), store });
     const id = newResponseId();
@@ -870,7 +740,7 @@ describe('cancellation always wins over the handler', () => {
 
   it('overrides the terminal on the wire too, so no follower reads `completed`', async () => {
     shortGrace();
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const server = makeServer(stubbornHandler(gate.promise));
     const id = newResponseId();
 
@@ -891,7 +761,7 @@ describe('cancellation always wins over the handler', () => {
   it('reports cancelled to GET while the winddown is still inside its grace', async () => {
     // Long enough that every GET below happens while the cancel route is still waiting.
     vi.stubEnv('AGENTSERVER_CANCEL_GRACE_MS', '60000');
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const server = makeServer(stubbornHandler(gate.promise));
     const id = newResponseId();
 
@@ -928,7 +798,7 @@ describe('cancellation always wins over the handler', () => {
 
   it('does not write its terminal into the turn that reused its id', async () => {
     shortGrace();
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const store = new ObservableStore();
     // The first turn ignores its cancellation and stays gated; the second is an ordinary turn that
     // takes the same id once the first has been cancelled and deleted.
@@ -963,7 +833,7 @@ describe('cancellation always wins over the handler', () => {
 
   it('clears output, error and completed_at from the cancelled snapshot', async () => {
     shortGrace();
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const store = new ObservableStore();
     const server = new ResponsesServer({ handler: stubbornHandler(gate.promise), store });
     const id = newResponseId();
@@ -1005,14 +875,14 @@ describe('a registered run that has already finished', () => {
     release: () => void;
   }> {
     const store = new ObservableStore();
-    const hold = deferred();
+    const hold = Promise.withResolvers<void>();
     store.putEventsGate = hold.promise;
     // Each turn under this id is tagged, so a replay log can be attributed to the run that made it.
     let turn = 0;
     const server = new ResponsesServer({
       handler: (request, context) => {
         turn += 1;
-        return labelledHandler(`turn${turn}`)(request, context);
+        return lifecycleHandler({ label: `turn${turn}` })(request, context);
       },
       store,
     });
@@ -1101,10 +971,10 @@ describe('a registered run that has already finished', () => {
 
   it('fences stale replay writes across two server instances sharing one store', async () => {
     const store = new ObservableStore();
-    const hold = deferred();
+    const hold = Promise.withResolvers<void>();
     store.putEventsGate = hold.promise;
-    const firstServer = new ResponsesServer({ handler: labelledHandler('server1'), store });
-    const secondServer = new ResponsesServer({ handler: labelledHandler('server2'), store });
+    const firstServer = new ResponsesServer({ handler: lifecycleHandler({ label: 'server1' }), store });
+    const secondServer = new ResponsesServer({ handler: lifecycleHandler({ label: 'server2' }), store });
     const id = newResponseId();
 
     const first = await firstServer.handle(
@@ -1164,7 +1034,7 @@ describe('a registered run that has already finished', () => {
 
 describe('the background registry survives a reused id', () => {
   it('refuses a second background run under an id that is already in flight', async () => {
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const server = makeServer(gatedHandler(gate.promise));
     const id = newResponseId();
 
@@ -1188,7 +1058,7 @@ describe('the background registry survives a reused id', () => {
   });
 
   it('admits exactly one of two simultaneous creates under one id', async () => {
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const server = makeServer(gatedHandler(gate.promise));
     const id = newResponseId();
 
@@ -1236,7 +1106,7 @@ describe('the background registry survives a reused id', () => {
   });
 
   it('tells a different user nothing at all about an id that is busy', async () => {
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const server = makeServer(gatedHandler(gate.promise));
     const id = newResponseId();
 
@@ -1264,9 +1134,9 @@ describe('the background registry survives a reused id', () => {
 
   it('lets a finishing run deregister only its own registration', async () => {
     const store = new ObservableStore();
-    const hold = deferred();
+    const hold = Promise.withResolvers<void>();
     store.putEventsGate = hold.promise;
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     // The first turn runs straight through; the second is held open, so it is still registered
     // when the first one's teardown finally runs.
     let turn = 0;
@@ -1303,7 +1173,7 @@ describe('the background registry survives a reused id', () => {
 
 describe('draining background runs', () => {
   it('winds an in-flight run down to a persisted incomplete terminal on drain', async () => {
-    const gate = deferred();
+    const gate = Promise.withResolvers<void>();
     const store = new InMemoryResponseProvider();
     const server = new ResponsesServer({ handler: gatedHandler(gate.promise), store });
 
@@ -1324,7 +1194,7 @@ describe('draining background runs', () => {
     // the writability check, the session lookup, the handler's own setup — before there is a run
     // to register. A drain that only knows about *runs* sees an empty registry here and returns
     // while the turn it was supposed to wind down is still coming.
-    const setup = deferred();
+    const setup = Promise.withResolvers<void>();
     const store = new ObservableStore();
     store.assertWritableGate = setup.promise;
     const server = new ResponsesServer({ handler: gatedHandler(), store });
@@ -1408,7 +1278,7 @@ describe('draining background runs', () => {
     // `#route` checks the draining flag, but the body read that follows is an await: a request
     // admitted a moment before `drain()` can still claim an id after drain has taken its snapshot
     // of what to wait for, and that run would outlive the drain unobserved.
-    const body = deferred();
+    const body = Promise.withResolvers<void>();
     const store = new ObservableStore();
     const server = new ResponsesServer({ handler: gatedHandler(), store });
 

--- a/packages/agentserver/src/background.test.ts
+++ b/packages/agentserver/src/background.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
 import { newResponseId } from './ids.js';
 import type { HandlerContext, ResponseHandler } from './server.js';
 import { ResponsesServer } from './server.js';
@@ -9,7 +9,7 @@ import type {
   ResponseProvider,
   StoredResponse,
 } from './store/provider.js';
-import { lifecycleHandler, makeServer, must, post, readSse } from './test-helpers.js';
+import { lifecycleHandler, makeServer, post, readSse } from './test-helpers.js';
 import type { CreateResponseRequest, OutputItem, ResponseEvent, ResponseObject } from './wire.js';
 
 /** The reader of a streaming response's body; a body-less response fails the test outright. */
@@ -165,13 +165,7 @@ function deleteRequest(id: string): Request {
 
 /** Waits for a condition a *detached* run makes true; the only clock these tests have. */
 async function waitFor(predicate: () => boolean, what: string): Promise<void> {
-  for (let attempt = 0; attempt < 600; attempt += 1) {
-    if (predicate()) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 5));
-  }
-  throw new Error(`timed out waiting for ${what}`);
+  await vi.waitFor(() => expect(predicate(), what).toBe(true), { timeout: 3_000, interval: 5 });
 }
 
 /** Polls `GET /responses/{id}` until the predicate holds; the background turn's clock. */
@@ -180,17 +174,19 @@ async function pollUntil(
   id: string,
   predicate: (response: ResponseObject) => boolean,
 ): Promise<ResponseObject> {
-  for (let attempt = 0; attempt < 400; attempt += 1) {
-    const response = await server.handle(get(`/responses/${id}`));
-    if (response.status === 200) {
-      const body = (await response.json()) as ResponseObject;
-      if (predicate(body)) {
-        return body;
+  return vi.waitUntil(
+    async () => {
+      const response = await server.handle(get(`/responses/${id}`));
+      if (response.status === 200) {
+        const body = (await response.json()) as ResponseObject;
+        if (predicate(body)) {
+          return body;
+        }
       }
-    }
-    await new Promise((resolve) => setTimeout(resolve, 5));
-  }
-  throw new Error(`response ${id} never reached the expected state`);
+      return false;
+    },
+    { timeout: 2_000, interval: 5 },
+  );
 }
 
 async function errorOf(response: Response): Promise<{ code: string; message: string; param: string | null }> {
@@ -275,7 +271,9 @@ describe('background + stream', () => {
     expect(events.at(-1)?.event).toBe('response.completed');
     expect(events.map((e) => e.data.sequence_number)).toEqual(events.map((_, index) => index));
 
-    const id = (must(events[0]).data.response as ResponseObject).id;
+    const firstEvent = events[0];
+    assert.exists(firstEvent);
+    const id = (firstEvent.data.response as ResponseObject).id;
     const finished = await pollUntil(server, id, (r) => r.status === 'completed');
     expect(finished.background).toBe(true);
   });
@@ -303,7 +301,9 @@ describe('streamed replay', () => {
   async function completedStream(server: ResponsesServer): Promise<{ id: string; count: number }> {
     const created = await server.handle(post({ input: 'hi', background: true, stream: true }));
     const events = await readSse(created);
-    const id = (must(events[0]).data.response as ResponseObject).id;
+    const firstEvent = events[0];
+    assert.exists(firstEvent);
+    const id = (firstEvent.data.response as ResponseObject).id;
     await pollUntil(server, id, (r) => r.status === 'completed');
     return { id, count: events.length };
   }
@@ -410,7 +410,9 @@ describe('streamed replay', () => {
     expect(events[0]?.event).toBe('response.created');
     expect(events.at(-1)?.event).toBe('response.completed');
     expect(events.map((e) => e.data.sequence_number)).toEqual([0, 1, 2, 3]);
-    const id = (must(events[0]).data.response as ResponseObject).id;
+    const firstEvent = events[0];
+    assert.exists(firstEvent);
+    const id = (firstEvent.data.response as ResponseObject).id;
 
     // The run itself is unharmed: its terminal state is persisted as usual.
     await pollUntil(server, id, (r) => r.status === 'completed');
@@ -701,10 +703,6 @@ describe('delete', () => {
 });
 
 describe('cancellation always wins over the handler', () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
   /** Short enough that the past-grace branch is reachable in a unit test. */
   function shortGrace(): void {
     vi.stubEnv('AGENTSERVER_CANCEL_GRACE_MS', '20');

--- a/packages/agentserver/src/config.ts
+++ b/packages/agentserver/src/config.ts
@@ -59,9 +59,9 @@ export function agentSessionId(): string | undefined {
   return env('FOUNDRY_AGENT_SESSION_ID');
 }
 
-/** Seconds between SSE keep-alive comments. `0` disables them. */
-export function sseKeepAliveSeconds(): number {
-  return intEnv('SSE_KEEPALIVE_INTERVAL', 0);
+/** Milliseconds between SSE keep-alive comments (`SSE_KEEPALIVE_INTERVAL` is in seconds). `0` disables them. */
+export function sseKeepAliveMs(): number {
+  return intEnv('SSE_KEEPALIVE_INTERVAL', 0) * 1000;
 }
 
 /**
@@ -210,7 +210,7 @@ export class UnsupportedOtlpProtocolError extends Error {
  *
  * `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL` is **not** in the parameter type, and its absence is the
  * point. The reference resolves all three protocols in one place
- * (`core/_tracing.py:336-338`) because it builds all three pipelines; it validates the logs
+ * (`core/_tracing.py`) because it builds all three pipelines; it validates the logs
  * protocol as a side effect of needing its value. This package has no log pipeline at all
  * (a deliberate deviation — core emits messages as span events), so there is no logs
  * exporter whose protocol could be read, and no signal a typo there could silently disable.

--- a/packages/agentserver/src/context.ts
+++ b/packages/agentserver/src/context.ts
@@ -69,15 +69,11 @@ function collectClientHeaders(headers: Headers): Record<string, string> {
   return collected;
 }
 
-function newRequestId(): string {
-  return crypto.randomUUID();
-}
-
 /** Builds the context for one inbound request. */
 export function createRequestContext(headers: Headers): RequestContext {
   const userId = headers.get(HEADERS.userId) ?? undefined;
   const foundryCallId = headers.get(HEADERS.foundryCallId) ?? undefined;
-  const requestId = headers.get(HEADERS.requestId) ?? newRequestId();
+  const requestId = headers.get(HEADERS.requestId) ?? crypto.randomUUID();
   const clientHeaders = collectClientHeaders(headers);
   const traceparent = headers.get('traceparent') ?? undefined;
   const tracestate = headers.get('tracestate') ?? undefined;

--- a/packages/agentserver/src/foreground.ts
+++ b/packages/agentserver/src/foreground.ts
@@ -1,10 +1,10 @@
-import { sseKeepAliveSeconds } from './config.js';
+import { sseKeepAliveMs } from './config.js';
 import { HEADERS } from './context.js';
 import { ProtocolError } from './errors.js';
-import { jsonResponse } from './http.js';
+import { jsonResponse, sseResponse } from './http.js';
 import type { ResponseTracker } from './lifecycle.js';
 import { flushTelemetry } from './observability/flush.js';
-import { SequenceNumberWriter, SSE_HEADERS, toSseStream } from './sse.js';
+import { SequenceNumberWriter } from './sse.js';
 import { storageFailed, TerminalPersister } from './terminal.js';
 import type { ResponseEvent } from './wire.js';
 import { isTerminalEventType } from './wire.js';
@@ -93,7 +93,7 @@ export async function streamResponse(
       let pending = first;
       while (pending.done !== true) {
         let event = pending.value;
-        if (isTerminalEventType(String(event.type))) {
+        if (isTerminalEventType(event.type)) {
           event = await persister.onTerminal(event);
         }
         yield sequence.stamp(event);
@@ -113,15 +113,11 @@ export async function streamResponse(
   // source lets a pending pull deliver what the handler winds down with, and whichever of the
   // two paths gets there second is a no-op.
   signal.addEventListener('abort', () => void windDown(), { once: true });
-  // A signal that aborted before the listener went up never fires it; re-read the state after
-  // registering so neither the edge nor the state can be missed.
+  // Re-read after registering — an already-aborted signal never fires a later listener (the same
+  // edge-and-state rule `linkedAbort` documents).
   if (signal.aborted) {
     void windDown();
   }
 
-  const keepAliveMs = sseKeepAliveSeconds() * 1000;
-  return new Response(toSseStream(numbered(), { keepAliveMs }), {
-    status: 200,
-    headers: { ...SSE_HEADERS, [HEADERS.sessionId]: sessionId },
-  });
+  return sseResponse(numbered(), { keepAliveMs: sseKeepAliveMs(), sessionId });
 }

--- a/packages/agentserver/src/http.ts
+++ b/packages/agentserver/src/http.ts
@@ -13,6 +13,8 @@ import type { RequestContext } from './context.js';
 import { HEADERS } from './context.js';
 import type { ProtocolError } from './errors.js';
 import { badRequest, toHeaderValue } from './errors.js';
+import { SSE_HEADERS, toSseStream } from './sse.js';
+import type { ResponseEvent } from './wire.js';
 
 /** A JSON body with the right content type. */
 export function jsonResponse(body: unknown, status: number, headers: Record<string, string> = {}): Response {
@@ -20,6 +22,56 @@ export function jsonResponse(body: unknown, status: number, headers: Record<stri
     status,
     headers: { 'content-type': 'application/json', ...headers },
   });
+}
+
+/**
+ * A committed SSE answer: `events` framed as the SSE body, under the headers every event stream
+ * carries. `keepAliveMs` (default off) and the `x-agent-session-id` header are per-route choices,
+ * so both stay explicit at the call sites.
+ */
+export function sseResponse(
+  events: AsyncIterable<ResponseEvent>,
+  options: { keepAliveMs?: number; sessionId?: string } = {},
+): Response {
+  return new Response(toSseStream(events, { keepAliveMs: options.keepAliveMs ?? 0 }), {
+    status: 200,
+    headers:
+      options.sessionId === undefined
+        ? SSE_HEADERS
+        : { ...SSE_HEADERS, [HEADERS.sessionId]: options.sessionId },
+  });
+}
+
+/**
+ * An `AbortController` linked to the server's shutdown signal and — when the turn is coupled to
+ * its request — the request's own signal.
+ *
+ * `addEventListener` is not a subscription to *state*: an `AbortSignal` that was already aborted
+ * never fires a listener registered afterwards, so a client that hung up before the turn was
+ * routed — or a shutdown that landed between the router's draining check and this registration —
+ * would otherwise hand the handler a signal that reads as live. The sources are therefore re-read
+ * after the listeners are in place, so neither the edge nor the state can be missed.
+ *
+ * `release` removes the listeners and is idempotent. The shutdown signal lives as long as the
+ * server, so a listener left on it after the turn ends is a leak that grows with every request
+ * served — every exit path must release.
+ */
+export function linkedAbort(
+  shutdown: AbortSignal,
+  request?: AbortSignal,
+): { controller: AbortController; release: () => void } {
+  const controller = new AbortController();
+  const onAbort = (): void => controller.abort();
+  shutdown.addEventListener('abort', onAbort, { once: true });
+  request?.addEventListener('abort', onAbort, { once: true });
+  const release = (): void => {
+    shutdown.removeEventListener('abort', onAbort);
+    request?.removeEventListener('abort', onAbort);
+  };
+  if (shutdown.aborted || request?.aborted === true) {
+    onAbort();
+  }
+  return { controller, release };
 }
 
 /**

--- a/packages/agentserver/src/index.ts
+++ b/packages/agentserver/src/index.ts
@@ -60,7 +60,7 @@ export type {
   ResponseUsage,
   TerminalEventType,
 } from './wire.js';
-export { isTerminalEventType, TERMINAL_EVENT_TYPES } from './wire.js';
+export { isTerminalEventType } from './wire.js';
 // The remaining config getters, the SSE framing internals (sse.ts) and the lifecycle
 // enforcement machinery (lifecycle.ts values) are internal — the server owns those
 // responsibilities and handlers must not re-implement them.

--- a/packages/agentserver/src/invocations.test.ts
+++ b/packages/agentserver/src/invocations.test.ts
@@ -3,6 +3,7 @@ import { getRequestContext, HEADERS } from './context.js';
 import { badRequest, ProtocolError } from './errors.js';
 import type { InvocationHandler, InvocationsServerConfig } from './invocations.js';
 import { INVOCATION_ID_HEADER, InvocationsServer } from './invocations.js';
+import { must } from './test-helpers.js';
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
@@ -447,7 +448,7 @@ describe('draining', () => {
 
 describe('cancellation', () => {
   it('aborts the handler when the caller disconnects', async () => {
-    const aborted = deferred<void>();
+    const aborted = Promise.withResolvers<void>();
     const server = makeServer({
       handler: async (_request, context) => {
         if (context.signal.aborted) {
@@ -474,8 +475,8 @@ describe('cancellation', () => {
   });
 
   it('aborts in-flight handlers when the server drains', async () => {
-    const entered = deferred<void>();
-    const aborted = deferred<void>();
+    const entered = Promise.withResolvers<void>();
+    const aborted = Promise.withResolvers<void>();
     const server = makeServer({
       handler: async (_request, context) => {
         context.signal.addEventListener('abort', () => aborted.resolve(), { once: true });
@@ -529,7 +530,7 @@ describe('SSE keep-alive', () => {
   }
 
   it('stays silent by default', async () => {
-    const gate = deferred<void>();
+    const gate = Promise.withResolvers<void>();
     const server = makeServer({ handler: sseHandler(gate.promise) });
     const pending = server.handle(invoke());
     setTimeout(() => gate.resolve(), 50);
@@ -541,7 +542,7 @@ describe('SSE keep-alive', () => {
     vi.stubEnv('SSE_KEEPALIVE_INTERVAL', '1');
     vi.useFakeTimers();
     try {
-      const gate = deferred<void>();
+      const gate = Promise.withResolvers<void>();
       const server = makeServer({ handler: sseHandler(gate.promise) });
       const response = await server.handle(invoke());
       const reader = must(response.body).getReader();
@@ -568,7 +569,7 @@ describe('SSE keep-alive', () => {
     vi.stubEnv('SSE_KEEPALIVE_INTERVAL', '1');
     vi.useFakeTimers();
     try {
-      const gate = deferred<void>();
+      const gate = Promise.withResolvers<void>();
       const server = makeServer({ handler: sseHandler(gate.promise) });
       const response = await server.handle(invoke());
       const reader = must(response.body).getReader();
@@ -594,7 +595,7 @@ describe('SSE keep-alive', () => {
     vi.stubEnv('SSE_KEEPALIVE_INTERVAL', '1');
     vi.useFakeTimers();
     try {
-      const gate = deferred<void>();
+      const gate = Promise.withResolvers<void>();
       const server = makeServer({ handler: sseHandler(gate.promise) });
       const response = await server.handle(invoke());
       const reader = must(response.body).getReader();
@@ -625,7 +626,7 @@ describe('SSE keep-alive', () => {
     vi.stubEnv('SSE_KEEPALIVE_INTERVAL', '1');
     vi.useFakeTimers();
     try {
-      const gate = deferred<void>();
+      const gate = Promise.withResolvers<void>();
       const server = makeServer({
         handler: () =>
           new Response(
@@ -658,7 +659,7 @@ describe('SSE keep-alive', () => {
     vi.stubEnv('SSE_KEEPALIVE_INTERVAL', '1');
     vi.useFakeTimers();
     try {
-      const gate = deferred<void>();
+      const gate = Promise.withResolvers<void>();
       const server = makeServer({
         handler: () =>
           new Response(
@@ -688,18 +689,3 @@ describe('SSE keep-alive', () => {
     }
   });
 });
-
-/** A promise with its `resolve` in hand. */
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void } {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  const promise = new Promise<T>((r) => {
-    resolve = r;
-  });
-  return { promise, resolve };
-}
-
-/** Narrows away null/undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}

--- a/packages/agentserver/src/invocations.test.ts
+++ b/packages/agentserver/src/invocations.test.ts
@@ -1,9 +1,8 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
 import { getRequestContext, HEADERS } from './context.js';
 import { badRequest, ProtocolError } from './errors.js';
 import type { InvocationHandler, InvocationsServerConfig } from './invocations.js';
 import { INVOCATION_ID_HEADER, InvocationsServer } from './invocations.js';
-import { must } from './test-helpers.js';
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
@@ -39,10 +38,6 @@ async function json(response: Response): Promise<Record<string, unknown>> {
 function errorCodeOf(payload: Record<string, unknown>): string {
   return (payload.error as { code: string }).code;
 }
-
-afterEach(() => {
-  vi.unstubAllEnvs();
-});
 
 describe('routes', () => {
   it('answers the readiness probe', async () => {
@@ -187,7 +182,9 @@ describe('routes', () => {
   it('generates the session id echoed on an unregistered-route 404 when nothing names one', async () => {
     const response = await makeServer().handle(new Request('http://localhost:8088/invocations/inv_404'));
     expect(response.status).toBe(404);
-    expect(must(response.headers.get(HEADERS.sessionId))).toMatch(UUID);
+    const sessionId = response.headers.get(HEADERS.sessionId);
+    assert.exists(sessionId);
+    expect(sessionId).toMatch(UUID);
   });
 
   it('mounts under a prefix without claiming sibling paths', async () => {
@@ -220,12 +217,16 @@ describe('invocation id', () => {
     ['overlong', 'a'.repeat(257)],
   ])('replaces an invalid header (%s) with a generated UUID', async (_name, value) => {
     const response = await makeServer().handle(invoke('x', { [INVOCATION_ID_HEADER]: value }));
-    expect(must(response.headers.get(INVOCATION_ID_HEADER))).toMatch(UUID);
+    const invocationId = response.headers.get(INVOCATION_ID_HEADER);
+    assert.exists(invocationId);
+    expect(invocationId).toMatch(UUID);
   });
 
   it('generates a UUID when the header is absent', async () => {
     const response = await makeServer().handle(invoke());
-    expect(must(response.headers.get(INVOCATION_ID_HEADER))).toMatch(UUID);
+    const invocationId = response.headers.get(INVOCATION_ID_HEADER);
+    assert.exists(invocationId);
+    expect(invocationId).toMatch(UUID);
   });
 
   it('overrides an invocation id header the handler set itself', async () => {
@@ -253,7 +254,9 @@ describe('session id', () => {
 
   it('generates a UUID when neither the query nor the environment names one', async () => {
     const response = await makeServer().handle(invoke());
-    expect(must(response.headers.get(HEADERS.sessionId))).toMatch(UUID);
+    const sessionId = response.headers.get(HEADERS.sessionId);
+    assert.exists(sessionId);
+    expect(sessionId).toMatch(UUID);
   });
 
   it('ignores an invalid query value rather than propagating it', async () => {
@@ -278,12 +281,16 @@ describe('header contract', () => {
   it('echoes x-request-id and reports the invocations protocol on x-platform-server', async () => {
     const response = await makeServer().handle(invoke('x', { [HEADERS.requestId]: 'req-1' }));
     expect(response.headers.get(HEADERS.requestId)).toBe('req-1');
-    expect(must(response.headers.get(HEADERS.serverVersion))).toContain('protocol/invocations-2.0.0');
+    const serverVersion = response.headers.get(HEADERS.serverVersion);
+    assert.exists(serverVersion);
+    expect(serverVersion).toContain('protocol/invocations-2.0.0');
   });
 
   it('generates a request id when the caller sent none', async () => {
     const response = await makeServer().handle(invoke());
-    expect(must(response.headers.get(HEADERS.requestId))).toMatch(UUID);
+    const requestId = response.headers.get(HEADERS.requestId);
+    assert.exists(requestId);
+    expect(requestId).toMatch(UUID);
   });
 
   it('hands the platform identity to the handler through the request context', async () => {
@@ -361,7 +368,8 @@ describe('body cancellation', () => {
         ),
     });
     const response = await server.handle(invoke('x', { [HEADERS.requestId]: 'req-cancel' }));
-    const reader = must(response.body).getReader();
+    assert.exists(response.body);
+    const reader = response.body.getReader();
     await reader.read();
     await reader.cancel('abandoned');
     expect(observed).toBe('req-cancel');
@@ -545,7 +553,8 @@ describe('SSE keep-alive', () => {
       const gate = Promise.withResolvers<void>();
       const server = makeServer({ handler: sseHandler(gate.promise) });
       const response = await server.handle(invoke());
-      const reader = must(response.body).getReader();
+      assert.exists(response.body);
+      const reader = response.body.getReader();
       const decoder = new TextDecoder();
 
       expect(decoder.decode((await reader.read()).value)).toBe('data: first\n\n');
@@ -572,7 +581,8 @@ describe('SSE keep-alive', () => {
       const gate = Promise.withResolvers<void>();
       const server = makeServer({ handler: sseHandler(gate.promise) });
       const response = await server.handle(invoke());
-      const reader = must(response.body).getReader();
+      assert.exists(response.body);
+      const reader = response.body.getReader();
       const decoder = new TextDecoder();
 
       expect(decoder.decode((await reader.read()).value)).toBe('data: first\n\n');
@@ -598,7 +608,8 @@ describe('SSE keep-alive', () => {
       const gate = Promise.withResolvers<void>();
       const server = makeServer({ handler: sseHandler(gate.promise) });
       const response = await server.handle(invoke());
-      const reader = must(response.body).getReader();
+      assert.exists(response.body);
+      const reader = response.body.getReader();
       const decoder = new TextDecoder();
 
       expect(decoder.decode((await reader.read()).value)).toBe('data: first\n\n');
@@ -641,7 +652,8 @@ describe('SSE keep-alive', () => {
           ),
       });
       const response = await server.handle(invoke());
-      const reader = must(response.body).getReader();
+      assert.exists(response.body);
+      const reader = response.body.getReader();
 
       await reader.read();
       const next = reader.read();
@@ -675,7 +687,8 @@ describe('SSE keep-alive', () => {
           ),
       });
       const response = await server.handle(invoke());
-      const reader = must(response.body).getReader();
+      assert.exists(response.body);
+      const reader = response.body.getReader();
       const decoder = new TextDecoder();
 
       expect(decoder.decode((await reader.read()).value)).toBe('{"part":1}\n');

--- a/packages/agentserver/src/invocations.ts
+++ b/packages/agentserver/src/invocations.ts
@@ -1,5 +1,5 @@
 import { context as otelContext } from '@opentelemetry/api';
-import { agentSessionId, serverIdentity, sseKeepAliveSeconds } from './config.js';
+import { agentSessionId, serverIdentity, sseKeepAliveMs } from './config.js';
 import type { RequestContext } from './context.js';
 import { createRequestContext, HEADERS, runWithRequestContext } from './context.js';
 import {
@@ -15,6 +15,7 @@ import {
   decodeSegment,
   errorResponse,
   jsonResponse,
+  linkedAbort,
   stripPrefix,
   trimTrailingSlashes,
   withStandardHeaders,
@@ -316,20 +317,9 @@ export class InvocationsServer {
     invocationId: string,
     sessionId: string,
   ): Promise<Response> {
-    const abort = new AbortController();
-    const onShutdown = (): void => abort.abort();
-    this.#shutdown.signal.addEventListener('abort', onShutdown, { once: true });
-    request.signal.addEventListener('abort', onShutdown, { once: true });
-    const releaseSignals = (): void => {
-      this.#shutdown.signal.removeEventListener('abort', onShutdown);
-      request.signal.removeEventListener('abort', onShutdown);
-    };
-    // `addEventListener` is not a subscription to *state*: a signal that aborted before the
-    // listener existed never fires it. Re-read after registration so neither the edge nor the
-    // state can be missed.
-    if (this.#shutdown.signal.aborted || request.signal.aborted) {
-      onShutdown();
-    }
+    // `linkedAbort` re-reads the sources after registering, so an abort that landed before this
+    // request was routed is not missed.
+    const { controller: abort, release: releaseSignals } = linkedAbort(this.#shutdown.signal, request.signal);
 
     const invocationContext: InvocationContext = {
       invocationId,
@@ -389,9 +379,7 @@ export class InvocationsServer {
     releaseSignals: () => void,
   ): ReadableStream<Uint8Array> {
     const contentType = response.headers.get('content-type') ?? '';
-    const keepAliveMs = contentType.toLowerCase().startsWith('text/event-stream')
-      ? sseKeepAliveSeconds() * 1000
-      : 0;
+    const keepAliveMs = contentType.toLowerCase().startsWith('text/event-stream') ? sseKeepAliveMs() : 0;
     // biome-ignore lint/style/noNonNullAssertion: callers checked `body !== null`.
     const reader = response.body!.getReader();
     const keepAliveBytes = new TextEncoder().encode(SSE_KEEPALIVE);

--- a/packages/agentserver/src/lifecycle.ts
+++ b/packages/agentserver/src/lifecycle.ts
@@ -179,6 +179,25 @@ export function applyCancelledTerminal(base: ResponseObject): ResponseObject {
   return cancelled;
 }
 
+/**
+ * The message a thrown value contributes to a failed terminal: an `Error`'s own message, its name
+ * when that message is empty (Python's fallback: `str(ex) or type(ex).__name__`), or the value
+ * stringified.
+ */
+export function messageOf(error: unknown): string {
+  return error instanceof Error ? (error.message === '' ? error.name : error.message) : String(error);
+}
+
+/**
+ * Builds the `response.failed` terminal for an unhandled failure from the tracked resource —
+ * always `server_error`, with `message` the only variable part.
+ */
+export function failedTerminal(tracker: ResponseTracker, message: string): ResponseEvent {
+  return tracker.lifecycleEvent('response.failed', 'failed', {
+    error: { code: 'server_error', message, type: 'server_error' },
+  });
+}
+
 /** Configuration for {@link enforceLifecycle}. */
 export interface EnforceLifecycleOptions {
   /** Called for every correction, so violations are visible rather than silently patched. */
@@ -291,11 +310,7 @@ export async function* enforceLifecycle(
       // The real message, not a fixed one: both hosting references put `ex.Message` /
       // `str(ex) or type name` on the terminal event, because by now the caller holds a 200 and
       // this event is the only place it can learn why the turn failed.
-      const message =
-        error instanceof Error ? (error.message === '' ? error.name : error.message) : String(error);
-      yield tracker.lifecycleEvent('response.failed', 'failed', {
-        error: { code: 'server_error', message, type: 'server_error' },
-      });
+      yield failedTerminal(tracker, messageOf(error));
     }
     return;
   }
@@ -303,12 +318,6 @@ export async function* enforceLifecycle(
   if (!terminated) {
     violation('missing_terminal');
     yield* prefixFor('response.failed');
-    yield tracker.lifecycleEvent('response.failed', 'failed', {
-      error: {
-        code: 'server_error',
-        message: SERVER_ERROR_MESSAGE,
-        type: 'server_error',
-      },
-    });
+    yield failedTerminal(tracker, SERVER_ERROR_MESSAGE);
   }
 }

--- a/packages/agentserver/src/observability.test.ts
+++ b/packages/agentserver/src/observability.test.ts
@@ -6,7 +6,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, describe, expect, it, vi } from 'vitest';
 import { otlpProtocol, UnsupportedOtlpProtocolError } from './config.js';
 import { platformHeaders } from './context.js';
 import { ProtocolError } from './errors.js';
@@ -21,7 +21,7 @@ import type { ResponseHandler } from './server.js';
 import { ResponsesServer } from './server.js';
 import { InMemoryResponseProvider } from './store/memory.js';
 import type { ResponseProvider } from './store/provider.js';
-import { lifecycleHandler, must, post } from './test-helpers.js';
+import { lifecycleHandler, post } from './test-helpers.js';
 import type { ResponseObject } from './wire.js';
 
 /** Resets every piece of global OTel state a test may have registered. */
@@ -39,8 +39,6 @@ function minimalHandler(work?: (stage: 'start' | 'late') => void): ResponseHandl
 }
 
 describe('otlpProtocol', () => {
-  afterEach(() => vi.unstubAllEnvs());
-
   it('defaults to http/protobuf', () => {
     expect(otlpProtocol('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL')).toBe('http/protobuf');
   });
@@ -230,7 +228,6 @@ describe('GenAIMainAgentSpanProcessor', () => {
 
 describe('setupHostObservability', () => {
   afterEach(() => {
-    vi.unstubAllEnvs();
     vi.resetModules();
     vi.restoreAllMocks();
     disableGlobalOtel();
@@ -619,7 +616,8 @@ describe('server trace context', () => {
     expect(response.status).toBe(200);
     expect(requestIdBaggage).toBe('req-42');
     const spans = exporter.getFinishedSpans();
-    const start = must(spans.find((span) => span.name === 'start-span'));
+    const start = spans.find((span) => span.name === 'start-span');
+    assert.exists(start);
     expect(start.spanContext().traceId).toBe('0123456789abcdef0123456789abcdef');
     expect(start.parentSpanContext?.spanId).toBe('0123456789abcdef');
   });
@@ -639,7 +637,8 @@ describe('server trace context', () => {
 
     // The `late-span` is created on a pull made by the SSE writer, outside the request scope —
     // the exact resumption `bindIterable` pins back to the extracted context.
-    const late = must(exporter.getFinishedSpans().find((span) => span.name === 'late-span'));
+    const late = exporter.getFinishedSpans().find((span) => span.name === 'late-span');
+    assert.exists(late);
     expect(late.spanContext().traceId).toBe('0123456789abcdef0123456789abcdef');
     expect(late.parentSpanContext?.spanId).toBe('0123456789abcdef');
   });
@@ -835,9 +834,7 @@ describe('per-turn flush', () => {
     expect(created.status).toBe(200);
 
     // The detached run owns the turn, and its own teardown is what flushes.
-    for (let attempt = 0; attempt < 200 && flusher.mock.calls.length === 0; attempt += 1) {
-      await new Promise((resolve) => setTimeout(resolve, 5));
-    }
+    await vi.waitUntil(() => flusher.mock.calls.length > 0, { timeout: 1_000, interval: 5 });
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(flusher).toHaveBeenCalledTimes(1);
   });
@@ -893,7 +890,8 @@ describe('server-stamped baggage', () => {
 
     // The lift in the enrichment processor is what the portal actually reads, and it is dead code
     // until the entry exists.
-    const start = must(exporter.getFinishedSpans().find((span) => span.name === 'start-span'));
+    const start = exporter.getFinishedSpans().find((span) => span.name === 'start-span');
+    assert.exists(start);
     expect(start.attributes[FOUNDRY_ATTR.conversationId]).toBe('conv_7');
   });
 
@@ -936,7 +934,8 @@ describe('server-stamped baggage', () => {
     expect(captured.conversationId).toBe('');
     // …and its enrichment processor tests the value for truth, so an empty one stamps nothing.
     expect(captured.requestId).toBeUndefined();
-    const start = must(exporter.getFinishedSpans().find((span) => span.name === 'start-span'));
+    const start = exporter.getFinishedSpans().find((span) => span.name === 'start-span');
+    assert.exists(start);
     expect(start.attributes[FOUNDRY_ATTR.conversationId]).toBeUndefined();
   });
 
@@ -960,7 +959,8 @@ describe('server-stamped baggage', () => {
 
     expect(response.status).toBe(200);
     expect(captured.conversationId).toBe('conv_9');
-    const start = must(exporter.getFinishedSpans().find((span) => span.name === 'start-span'));
+    const start = exporter.getFinishedSpans().find((span) => span.name === 'start-span');
+    assert.exists(start);
     expect(start.attributes[FOUNDRY_ATTR.sessionId]).toBe('sess-1');
     expect(start.attributes[FOUNDRY_ATTR.conversationId]).toBe('conv_9');
   });

--- a/packages/agentserver/src/observability.test.ts
+++ b/packages/agentserver/src/observability.test.ts
@@ -17,11 +17,12 @@ import { GenAIMainAgentSpanProcessor } from './observability/main-agent.js';
 // `vi.resetModules()`, so importing it here would pin the very instance those tests replace.
 import type * as HostObservabilitySetup from './observability/setup.js';
 import { RESPONSE_BAGGAGE } from './observability/trace-context.js';
-import type { HandlerContext, ResponseHandler } from './server.js';
+import type { ResponseHandler } from './server.js';
 import { ResponsesServer } from './server.js';
 import { InMemoryResponseProvider } from './store/memory.js';
 import type { ResponseProvider } from './store/provider.js';
-import type { CreateResponseRequest, ResponseObject } from './wire.js';
+import { lifecycleHandler, must, post } from './test-helpers.js';
+import type { ResponseObject } from './wire.js';
 
 /** Resets every piece of global OTel state a test may have registered. */
 function disableGlobalOtel(): void {
@@ -32,33 +33,9 @@ function disableGlobalOtel(): void {
   setTelemetryFlusher(undefined);
 }
 
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}
-
-function post(body: unknown, headers: Record<string, string> = {}): Request {
-  return new Request('http://localhost:8088/responses', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', ...headers },
-    body: JSON.stringify(body),
-  });
-}
-
 /** The smallest event sequence the lifecycle contract accepts, with room for span-making work. */
 function minimalHandler(work?: (stage: 'start' | 'late') => void): ResponseHandler {
-  return async function* (_request: CreateResponseRequest, context: HandlerContext) {
-    const response = (status: ResponseObject['status']): ResponseObject => ({
-      ...context.response,
-      status,
-    });
-    work?.('start');
-    yield { type: 'response.created', response: response('queued') };
-    yield { type: 'response.in_progress', response: response('in_progress') };
-    work?.('late');
-    yield { type: 'response.completed', response: response('completed') };
-  };
+  return lifecycleHandler({ work });
 }
 
 describe('otlpProtocol', () => {

--- a/packages/agentserver/src/observability/main-agent.ts
+++ b/packages/agentserver/src/observability/main-agent.ts
@@ -112,8 +112,8 @@ export class GenAIMainAgentSpanProcessor implements SpanProcessor {
       }
     }
 
-    // The SDK refuses setAttribute on an ended span, so this writes the attribute record
-    // directly — the same workaround the enrichment processor uses.
+    // Written into the attribute record directly — `FoundryEnrichmentSpanProcessor.onEnd`
+    // explains the workaround (the SDK refuses setAttribute on an ended span).
     try {
       for (const [key, value] of Object.entries(updates)) {
         attributes[key] = value;

--- a/packages/agentserver/src/resource-routes.ts
+++ b/packages/agentserver/src/resource-routes.ts
@@ -1,10 +1,9 @@
 import type { BackgroundRun, IdClaim } from './background-run.js';
 import { sequenceOf } from './background-run.js';
-import { cancelGraceMs, sseKeepAliveSeconds } from './config.js';
+import { cancelGraceMs, sseKeepAliveMs } from './config.js';
 import { badRequest, notFound, notImplemented, ProtocolError } from './errors.js';
-import { jsonResponse } from './http.js';
+import { jsonResponse, sseResponse } from './http.js';
 import { applyCancelledTerminal } from './lifecycle.js';
-import { SSE_HEADERS, toSseStream } from './sse.js';
 import type { ResponseOwner, ResponseProvider } from './store/provider.js';
 import { sameOwner } from './store/provider.js';
 import { parseLimit, parseOrder, parseStartingAfter } from './validation.js';
@@ -45,6 +44,11 @@ const REPLAY_UNAVAILABLE =
 /** A 400 with `code: "invalid_mode"` on `param: "stream"`, Python's `_invalid_mode` shape. */
 function invalidMode(message: string): ProtocolError {
   return badRequest(message, { code: 'invalid_mode', param: 'stream' });
+}
+
+/** A 400 refusal on `param: "response_id"` — the shape every delete/cancel refusal here shares. */
+function refuse(message: string): ProtocolError {
+  return new ProtocolError(400, message, { code: 'invalid_request_error', param: 'response_id' });
 }
 
 /** The states a response never leaves (Python `_RuntimeState._TERMINAL_STATUSES`). */
@@ -106,15 +110,13 @@ export async function getResponse(
   if (run !== undefined) {
     if (!streamReplay) {
       // A cancel that is still inside its winddown grace has already promised `cancelled`, and
-      // the reference refreshes the record's status from the cancel signal before answering any
-      // GET (`_refresh_background_status`). Only the status is refreshed — the rest of the
-      // snapshot, accumulated output included, stays the handler's until the cancel route
-      // applies the actual cancelled terminal.
+      // `runStatus` refreshes a registered run's status from the cancel signal exactly the way
+      // the reference does before answering any GET (`_refresh_background_status`). Only the
+      // status is refreshed — the rest of the snapshot, accumulated output included, stays the
+      // handler's until the cancel route applies the actual cancelled terminal.
       const snapshot = run.tracker.response;
-      if (run.cancelRequested && !TERMINAL_STATUSES.has(String(snapshot.status))) {
-        return jsonResponse({ ...snapshot, status: 'cancelled' }, 200);
-      }
-      return jsonResponse(snapshot, 200);
+      const status = runStatus(run);
+      return jsonResponse(status === String(snapshot.status) ? snapshot : { ...snapshot, status }, 200);
     }
     if (!run.streamed) {
       throw invalidMode('This response cannot be streamed because it was not created with stream=true.');
@@ -124,11 +126,7 @@ export async function getResponse(
     }
     // Replay the retained prefix, then follow live to the terminal (the resilience contract's
     // reconnect clause: events strictly after the cursor, then live-tail).
-    const keepAliveMs = sseKeepAliveSeconds() * 1000;
-    return new Response(toSseStream(run.follow(startingAfter), { keepAliveMs }), {
-      status: 200,
-      headers: SSE_HEADERS,
-    });
+    return sseResponse(run.follow(startingAfter), { keepAliveMs: sseKeepAliveMs() });
   }
 
   const stored = await state.store.get(id, owner);
@@ -176,7 +174,7 @@ export async function getResponse(
   const replayable = events.filter((event) => sequenceOf(event) > startingAfter);
   // A finished stream replays as-is and closes; no keep-alive timer for a body that is already
   // complete (Python's fallback replay does not wrap `with_keep_alive` either).
-  return new Response(toSseStream(replayEvents(replayable)), { status: 200, headers: SSE_HEADERS });
+  return sseResponse(replayEvents(replayable));
 }
 
 /** `DELETE /responses/{id}`. */
@@ -192,10 +190,7 @@ export async function deleteResponse(
     // the record's mere presence, and the difference is a real window here: the registration
     // outlives the terminal state by however long the replay log takes to store, and during it
     // the finished turn is already in the store and perfectly deletable.
-    throw new ProtocolError(400, 'Cannot delete an in-flight response.', {
-      code: 'invalid_request_error',
-      param: 'response_id',
-    });
+    throw refuse('Cannot delete an in-flight response.');
   }
   const deleted = await state.store.delete(id, owner);
   if (!deleted) {
@@ -228,7 +223,7 @@ export async function cancelResponse(
     const status = runStatus(run);
     const refusal = CANCEL_TERMINAL_ERRORS[status];
     if (refusal !== undefined) {
-      throw new ProtocolError(400, refusal, { code: 'invalid_request_error', param: 'response_id' });
+      throw refuse(refusal);
     }
     if (status === 'cancelled') {
       // Repeats the cancelled snapshot instead of opening a second winddown — the case where a
@@ -267,14 +262,11 @@ export async function cancelResponse(
     throw notFound(id);
   }
   if (stored.response.background !== true) {
-    throw new ProtocolError(400, 'Cannot cancel a synchronous response.', {
-      code: 'invalid_request_error',
-      param: 'response_id',
-    });
+    throw refuse('Cannot cancel a synchronous response.');
   }
   const message = CANCEL_TERMINAL_ERRORS[String(stored.response.status)];
   if (message !== undefined) {
-    throw new ProtocolError(400, message, { code: 'invalid_request_error', param: 'response_id' });
+    throw refuse(message);
   }
   if (stored.response.status === 'cancelled') {
     // Idempotent: cancelling a cancelled response repeats the snapshot (Python's sentinel path).

--- a/packages/agentserver/src/server.test.ts
+++ b/packages/agentserver/src/server.test.ts
@@ -1,5 +1,5 @@
 import { getEventListeners } from 'node:events';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HEADERS } from './context.js';
 import { ProtocolError } from './errors.js';
 import { partitionKeyOf } from './ids.js';
@@ -7,7 +7,7 @@ import type { HandlerContext, ResponseHandler } from './server.js';
 import { ResponsesServer } from './server.js';
 import { encodeEvent } from './sse.js';
 import { InMemoryResponseProvider } from './store/memory.js';
-import { lifecycleHandler, makeServer, must, post, readSse } from './test-helpers.js';
+import { lifecycleHandler, makeServer, post, readSse } from './test-helpers.js';
 import type { CreateResponseRequest, ResponseObject } from './wire.js';
 
 describe('routes', () => {
@@ -21,18 +21,9 @@ describe('routes', () => {
   it('stays non-hosted even when FOUNDRY_HOSTING_ENVIRONMENT is set in the test environment', async () => {
     // The helper always passes an explicit `hosted`; without it, a stray platform variable in the
     // runner's environment would flip every test into hosted mode and its strict header checks.
-    const previous = process.env.FOUNDRY_HOSTING_ENVIRONMENT;
-    process.env.FOUNDRY_HOSTING_ENVIRONMENT = '1';
-    try {
-      const response = await makeServer().handle(post({ input: 'Hi' }));
-      expect(response.status).toBe(200);
-    } finally {
-      if (previous === undefined) {
-        delete process.env.FOUNDRY_HOSTING_ENVIRONMENT;
-      } else {
-        process.env.FOUNDRY_HOSTING_ENVIRONMENT = previous;
-      }
-    }
+    vi.stubEnv('FOUNDRY_HOSTING_ENVIRONMENT', '1');
+    const response = await makeServer().handle(post({ input: 'Hi' }));
+    expect(response.status).toBe(200);
   });
 
   it('creates a response and returns the finished resource', async () => {
@@ -65,54 +56,46 @@ describe('routes', () => {
     // A service-side store validates that every persisted response names its agent — without the
     // stamp, the write dies as an opaque 500. Resolved once at resource construction so every
     // store sees it: the request's own reference first, else the environment, else the default.
-    const saved = { name: process.env.FOUNDRY_AGENT_NAME, version: process.env.FOUNDRY_AGENT_VERSION };
-    try {
-      process.env.FOUNDRY_AGENT_NAME = 'weather-agent';
-      process.env.FOUNDRY_AGENT_VERSION = '2';
-      const server = makeServer();
+    vi.stubEnv('FOUNDRY_AGENT_NAME', 'weather-agent');
+    vi.stubEnv('FOUNDRY_AGENT_VERSION', '2');
+    const server = makeServer();
 
-      const fromEnv = (await (await server.handle(post({ input: 'Hi' }))).json()) as ResponseObject;
-      expect(fromEnv.agent_reference).toEqual({
-        type: 'agent_reference',
-        name: 'weather-agent',
-        version: '2',
-      });
+    const fromEnv = (await (await server.handle(post({ input: 'Hi' }))).json()) as ResponseObject;
+    expect(fromEnv.agent_reference).toEqual({
+      type: 'agent_reference',
+      name: 'weather-agent',
+      version: '2',
+    });
 
-      const requested = (await (
-        await server.handle(
-          post({ input: 'Hi', agent_reference: { type: 'agent_reference', name: 'router', version: '9' } }),
-        )
-      ).json()) as ResponseObject;
-      expect(requested.agent_reference).toEqual({
-        type: 'agent_reference',
-        name: 'router',
-        version: '9',
-      });
+    const requested = (await (
+      await server.handle(
+        post({ input: 'Hi', agent_reference: { type: 'agent_reference', name: 'router', version: '9' } }),
+      )
+    ).json()) as ResponseObject;
+    expect(requested.agent_reference).toEqual({
+      type: 'agent_reference',
+      name: 'router',
+      version: '9',
+    });
 
-      delete process.env.FOUNDRY_AGENT_NAME;
-      delete process.env.FOUNDRY_AGENT_VERSION;
-      const fallback = (await (await server.handle(post({ input: 'Hi' }))).json()) as ResponseObject;
-      expect(fallback.agent_reference).toEqual({ type: 'agent_reference', name: 'server-default-agent' });
+    vi.stubEnv('FOUNDRY_AGENT_NAME', undefined);
+    vi.stubEnv('FOUNDRY_AGENT_VERSION', undefined);
+    const fallback = (await (await server.handle(post({ input: 'Hi' }))).json()) as ResponseObject;
+    expect(fallback.agent_reference).toEqual({ type: 'agent_reference', name: 'server-default-agent' });
 
-      // Validation only checks name and version, so a caller can omit the discriminator or send
-      // a wrong one — the resolved reference normalizes it to the literal the wire type declares.
-      const untyped = (await (
-        await server.handle(post({ input: 'Hi', agent_reference: { name: 'router' } }))
-      ).json()) as ResponseObject;
-      expect(untyped.agent_reference).toEqual({ type: 'agent_reference', name: 'router' });
+    // Validation only checks name and version, so a caller can omit the discriminator or send
+    // a wrong one — the resolved reference normalizes it to the literal the wire type declares.
+    const untyped = (await (
+      await server.handle(post({ input: 'Hi', agent_reference: { name: 'router' } }))
+    ).json()) as ResponseObject;
+    expect(untyped.agent_reference).toEqual({ type: 'agent_reference', name: 'router' });
 
-      const mistyped = (await (
-        await server.handle(
-          post({ input: 'Hi', agent_reference: { type: 'other', name: 'router', version: '3' } }),
-        )
-      ).json()) as ResponseObject;
-      expect(mistyped.agent_reference).toEqual({ type: 'agent_reference', name: 'router', version: '3' });
-    } finally {
-      if (saved.name !== undefined) process.env.FOUNDRY_AGENT_NAME = saved.name;
-      else delete process.env.FOUNDRY_AGENT_NAME;
-      if (saved.version !== undefined) process.env.FOUNDRY_AGENT_VERSION = saved.version;
-      else delete process.env.FOUNDRY_AGENT_VERSION;
-    }
+    const mistyped = (await (
+      await server.handle(
+        post({ input: 'Hi', agent_reference: { type: 'other', name: 'router', version: '3' } }),
+      )
+    ).json()) as ResponseObject;
+    expect(mistyped.agent_reference).toEqual({ type: 'agent_reference', name: 'router', version: '3' });
   });
 
   it('gets, lists input items for, and deletes a response', async () => {
@@ -837,7 +820,8 @@ describe('lifecycle enforcement', () => {
     });
 
     const events = await readSse(await server.handle(post({ input: 'x', stream: true })));
-    const terminal = must(events.at(-1));
+    const terminal = events.at(-1);
+    assert.exists(terminal);
 
     // The caller already holds a 200 by now, so the terminal event is the only place it can learn
     // why the turn failed. Both hosting references surface the exception's own message there
@@ -861,7 +845,8 @@ describe('lifecycle enforcement', () => {
     });
 
     const events = await readSse(await server.handle(post({ input: 'x', stream: true })));
-    const terminal = must(events.at(-1));
+    const terminal = events.at(-1);
+    assert.exists(terminal);
 
     // Python's fallback: `str(ex) or type(ex).__name__`.
     expect((terminal.data.response as ResponseObject).error?.message).toBe('RangeError');
@@ -883,7 +868,8 @@ describe('lifecycle enforcement', () => {
     });
 
     const events = await readSse(await server.handle(post({ input: 'x', stream: true })));
-    const terminal = must(events.at(-1));
+    const terminal = events.at(-1);
+    assert.exists(terminal);
 
     // `failed` would tell the platform the agent broke, and invite a retry against a container
     // that is going away. The turn is unfinished, and resumable with previous_response_id.
@@ -921,7 +907,8 @@ describe('header contract', () => {
     const server = makeServer();
 
     const first = await server.handle(post({ input: 'x' }));
-    const firstId = must(first.headers.get(HEADERS.sessionId));
+    const firstId = first.headers.get(HEADERS.sessionId);
+    assert.exists(firstId);
     // A session id names the sandbox the turn runs in, so it must not be the response id — that
     // would send every turn of one conversation to a different filesystem.
     expect(firstId).toMatch(/^[0-9a-f]{63}$/);
@@ -939,16 +926,12 @@ describe('header contract', () => {
   });
 
   it('follows the platform-assigned session id when there is one', async () => {
-    process.env.FOUNDRY_AGENT_SESSION_ID = 'platform-session';
-    try {
-      const created = await makeServer().handle(post({ input: 'x' }));
-      expect(created.headers.get(HEADERS.sessionId)).toBe('platform-session');
-      // Routes with no request body to derive from report the container's own session.
-      const probe = await makeServer().handle(new Request('http://localhost:8088/readiness'));
-      expect(probe.headers.get(HEADERS.sessionId)).toBe('platform-session');
-    } finally {
-      delete process.env.FOUNDRY_AGENT_SESSION_ID;
-    }
+    vi.stubEnv('FOUNDRY_AGENT_SESSION_ID', 'platform-session');
+    const created = await makeServer().handle(post({ input: 'x' }));
+    expect(created.headers.get(HEADERS.sessionId)).toBe('platform-session');
+    // Routes with no request body to derive from report the container's own session.
+    const probe = await makeServer().handle(new Request('http://localhost:8088/readiness'));
+    expect(probe.headers.get(HEADERS.sessionId)).toBe('platform-session');
   });
 
   it('lets the platform choose the response id', async () => {
@@ -1166,7 +1149,8 @@ describe('persistence failure', () => {
     });
 
     const events = await readSse(await server.handle(post({ input: 'x', stream: true })));
-    const terminal = must(events.at(-1));
+    const terminal = events.at(-1);
+    assert.exists(terminal);
 
     // Persist happens *before* the terminal goes out; a client that reads `response.completed`
     // must be able to come back with `previous_response_id`, and this one could not.
@@ -1454,12 +1438,15 @@ describe('handler context identity', () => {
     const response = await server.handle(post({ input: 'hi' }));
     expect(response.status).toBe(200);
 
-    const context = must(seen);
+    const context = seen;
+    assert.exists(context);
     // The same resolution the response resource and the `x-agent-session-id` header carry — the
     // handler no longer has to re-derive either.
     expect(context.agentReference).toEqual(((await response.json()) as ResponseObject).agent_reference);
     expect(context.agentReference.name).not.toBe('');
-    expect(context.agentSessionId).toBe(must(response.headers.get(HEADERS.sessionId)));
+    const sessionId = response.headers.get(HEADERS.sessionId);
+    assert.exists(sessionId);
+    expect(context.agentSessionId).toBe(sessionId);
   });
 
   it('resolves the agent reference the request named', async () => {
@@ -1475,7 +1462,8 @@ describe('handler context identity', () => {
       post({ input: 'hi', agent_reference: { type: 'agent_reference', name: 'triage', version: '3' } }),
     );
 
-    expect(must(seen).agentReference).toMatchObject({ name: 'triage', version: '3' });
+    assert.exists(seen);
+    expect(seen.agentReference).toMatchObject({ name: 'triage', version: '3' });
   });
 });
 
@@ -1520,7 +1508,8 @@ describe('draining', () => {
 
     // Pull one chunk so the generator is genuinely parked at a `yield` past the committed 200,
     // then walk away from the body: no further reads, and — the crux — no cancel.
-    const reader = must(response.body).getReader();
+    assert.exists(response.body);
+    const reader = response.body.getReader();
     await reader.read();
     reader.releaseLock();
 

--- a/packages/agentserver/src/server.test.ts
+++ b/packages/agentserver/src/server.test.ts
@@ -7,79 +7,8 @@ import type { HandlerContext, ResponseHandler } from './server.js';
 import { ResponsesServer } from './server.js';
 import { encodeEvent } from './sse.js';
 import { InMemoryResponseProvider } from './store/memory.js';
+import { lifecycleHandler, makeServer, must, post, readSse } from './test-helpers.js';
 import type { CreateResponseRequest, ResponseObject } from './wire.js';
-
-/** The echo handler from the reference samples: one message item, streamed as one delta. */
-function echoHandler(): ResponseHandler {
-  return async function* (request: CreateResponseRequest, context: HandlerContext) {
-    const text = `Echo: ${typeof request.input === 'string' ? request.input : JSON.stringify(request.input)}`;
-    const response = (status: ResponseObject['status']): ResponseObject => ({
-      ...context.response,
-      status,
-    });
-
-    yield { type: 'response.created', response: response('queued') };
-    yield { type: 'response.in_progress', response: response('in_progress') };
-    yield {
-      type: 'response.output_item.added',
-      output_index: 0,
-      item: { type: 'message', id: 'msg_1', role: 'assistant', status: 'in_progress', content: [] },
-    };
-    yield {
-      type: 'response.output_text.delta',
-      item_id: 'msg_1',
-      output_index: 0,
-      content_index: 0,
-      delta: text,
-    };
-    yield {
-      type: 'response.output_item.done',
-      output_index: 0,
-      item: {
-        type: 'message',
-        id: 'msg_1',
-        role: 'assistant',
-        status: 'completed',
-        content: [{ type: 'output_text', text, annotations: [] }],
-      },
-    };
-    yield { type: 'response.completed', response: response('completed') };
-  };
-}
-
-function makeServer(handler: ResponseHandler = echoHandler(), hosted = false): ResponsesServer {
-  return new ResponsesServer({ handler, store: new InMemoryResponseProvider(), hosted });
-}
-
-function post(body: unknown, headers: Record<string, string> = {}): Request {
-  return new Request('http://localhost:8088/responses', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', ...headers },
-    body: JSON.stringify(body),
-  });
-}
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}
-
-/** Parses an SSE body into `{ event, data }` pairs. */
-async function readSse(response: Response): Promise<Array<{ event: string; data: Record<string, unknown> }>> {
-  const text = await response.text();
-  return text
-    .split('\n\n')
-    .filter((block) => block.trim() !== '' && !block.startsWith(':'))
-    .map((block) => {
-      const eventLine = must(block.split('\n').find((line) => line.startsWith('event: ')));
-      const dataLine = must(block.split('\n').find((line) => line.startsWith('data: ')));
-      return {
-        event: eventLine.slice('event: '.length),
-        data: JSON.parse(dataLine.slice('data: '.length)) as Record<string, unknown>,
-      };
-    });
-}
 
 describe('routes', () => {
   it('answers the readiness probe', async () => {
@@ -87,6 +16,23 @@ describe('routes', () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ status: 'healthy' });
+  });
+
+  it('stays non-hosted even when FOUNDRY_HOSTING_ENVIRONMENT is set in the test environment', async () => {
+    // The helper always passes an explicit `hosted`; without it, a stray platform variable in the
+    // runner's environment would flip every test into hosted mode and its strict header checks.
+    const previous = process.env.FOUNDRY_HOSTING_ENVIRONMENT;
+    process.env.FOUNDRY_HOSTING_ENVIRONMENT = '1';
+    try {
+      const response = await makeServer().handle(post({ input: 'Hi' }));
+      expect(response.status).toBe(200);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.FOUNDRY_HOSTING_ENVIRONMENT;
+      } else {
+        process.env.FOUNDRY_HOSTING_ENVIRONMENT = previous;
+      }
+    }
   });
 
   it('creates a response and returns the finished resource', async () => {
@@ -103,7 +49,7 @@ describe('routes', () => {
 
   it('keeps the response addressable when a conversation alias is stored at capacity one', async () => {
     const store = new InMemoryResponseProvider({ maxResponses: 1 });
-    const server = new ResponsesServer({ handler: echoHandler(), store, hosted: false });
+    const server = new ResponsesServer({ handler: lifecycleHandler({ echo: true }), store, hosted: false });
     const conversationId = `caresp_${'c'.repeat(18)}${'d'.repeat(32)}`;
 
     const created = (await (
@@ -555,7 +501,7 @@ describe('route-level errors', () => {
   });
 
   it('does not claim a path that merely starts with the prefix', async () => {
-    const server = new ResponsesServer({ handler: echoHandler(), prefix: '/api' });
+    const server = new ResponsesServer({ handler: lifecycleHandler({ echo: true }), prefix: '/api' });
 
     expect((await server.handle(post({ input: 'x' }))).status).toBe(404);
     expect(
@@ -747,7 +693,7 @@ describe('request limits', () => {
     expect(
       () =>
         new ResponsesServer({
-          handler: echoHandler(),
+          handler: lifecycleHandler({ echo: true }),
           limits: { [name]: value },
         }),
     ).toThrow(`${name} must be a safe integer of at least 1`);
@@ -771,7 +717,10 @@ describe('request limits', () => {
   });
 
   it('bounds the number of input items', async () => {
-    const server = new ResponsesServer({ handler: echoHandler(), limits: { maxInputItems: 2 } });
+    const server = new ResponsesServer({
+      handler: lifecycleHandler({ echo: true }),
+      limits: { maxInputItems: 2 },
+    });
     const items = Array.from({ length: 3 }, (_, i) => ({ type: 'message', id: `in_${i}` }));
 
     const response = await server.handle(post({ input: items }));
@@ -1103,7 +1052,7 @@ describe('header contract', () => {
 
 describe('protocol version fail-close', () => {
   it('refuses a hosted request with no call id', async () => {
-    const response = await makeServer(echoHandler(), true).handle(
+    const response = await makeServer(lifecycleHandler({ echo: true }), { hosted: true }).handle(
       post({ input: 'x' }, { [HEADERS.userId]: 'user-1' }),
     );
     const body = (await response.json()) as { error: { code: string } };
@@ -1114,14 +1063,16 @@ describe('protocol version fail-close', () => {
   });
 
   it('serves a hosted request that carries a call id', async () => {
-    const response = await makeServer(echoHandler(), true).handle(
+    const response = await makeServer(lifecycleHandler({ echo: true }), { hosted: true }).handle(
       post({ input: 'x' }, { [HEADERS.foundryCallId]: 'call-1' }),
     );
     expect(response.status).toBe(200);
   });
 
   it('does not require a call id outside a hosted environment', async () => {
-    const response = await makeServer(echoHandler(), false).handle(post({ input: 'x' }));
+    const response = await makeServer(lifecycleHandler({ echo: true }), { hosted: false }).handle(
+      post({ input: 'x' }),
+    );
     expect(response.status).toBe(200);
   });
 });
@@ -1191,7 +1142,10 @@ describe('persistence failure', () => {
   }
 
   it('answers a non-streaming turn as failed with storage_error, not an opaque 500', async () => {
-    const server = new ResponsesServer({ handler: echoHandler(), store: new FailingPutProvider() });
+    const server = new ResponsesServer({
+      handler: lifecycleHandler({ echo: true }),
+      store: new FailingPutProvider(),
+    });
 
     const response = await server.handle(post({ input: 'x' }));
     const body = (await response.json()) as ResponseObject;
@@ -1206,7 +1160,10 @@ describe('persistence failure', () => {
   });
 
   it('replaces the streamed terminal event instead of delivering a completed that was never stored', async () => {
-    const server = new ResponsesServer({ handler: echoHandler(), store: new FailingPutProvider() });
+    const server = new ResponsesServer({
+      handler: lifecycleHandler({ echo: true }),
+      store: new FailingPutProvider(),
+    });
 
     const events = await readSse(await server.handle(post({ input: 'x', stream: true })));
     const terminal = must(events.at(-1));
@@ -1221,7 +1178,10 @@ describe('persistence failure', () => {
   });
 
   it('does not report storage_error when the caller opted out of storage', async () => {
-    const server = new ResponsesServer({ handler: echoHandler(), store: new FailingPutProvider() });
+    const server = new ResponsesServer({
+      handler: lifecycleHandler({ echo: true }),
+      store: new FailingPutProvider(),
+    });
 
     const response = await server.handle(post({ input: 'x', store: false }));
     const body = (await response.json()) as ResponseObject;

--- a/packages/agentserver/src/server.ts
+++ b/packages/agentserver/src/server.ts
@@ -21,6 +21,7 @@ import {
   decodeSegment,
   errorResponse,
   jsonResponse,
+  linkedAbort,
   stripPrefix,
   trimTrailingSlashes,
   withStandardHeaders,
@@ -246,11 +247,11 @@ export class ResponsesServer {
       return await otelContext.with(extractTraceContext(request.headers), () =>
         runWithRequestContext(context, async () => {
           const response = await this.#route(request, context, telemetry);
-          return this.#withStandardHeaders(response, context);
+          return withStandardHeaders(response, context, serverIdentity());
         }),
       );
     } catch (error) {
-      return this.#errorResponse(toProtocolError(error), context);
+      return errorResponse(toProtocolError(error), context, serverIdentity());
     } finally {
       // Unconditional, as the reference's is (Python `handle_create` flushes in a `finally`): the
       // failing turns are the ones whose spans are worth the most, and a hosted sandbox may be
@@ -527,37 +528,26 @@ export class ResponsesServer {
       ...(conversationId === undefined ? {} : { conversation: { id: conversationId } }),
     };
 
-    const abort = new AbortController();
-    const onShutdown = (): void => abort.abort();
-    this.#shutdown.signal.addEventListener('abort', onShutdown, { once: true });
-    if (!background) {
-      // A background run is decoupled from the connection that started it: the caller hanging up
-      // must not cancel work it was explicitly told would outlive the request — as in the Python
-      // reference, "a consumer disconnect must NOT cancel it". Only the container's own shutdown reaches it.
-      request.signal.addEventListener('abort', onShutdown, { once: true });
-    }
-    // `#shutdown.signal` lives as long as the server; a listener left on it after the turn ends
-    // is a leak that grows with every request served. Every exit path below releases both. The
-    // paths that share this teardown can each reach it, so every step is idempotent: removing a
-    // removed listener is a no-op, `#releaseClaim` only drops the claim it is given, and a
-    // settled claim stays settled.
+    // A background run is decoupled from the connection that started it: the caller hanging up
+    // must not cancel work it was explicitly told would outlive the request — as in the Python
+    // reference, "a consumer disconnect must NOT cancel it". Only the container's own shutdown
+    // reaches it. `linkedAbort` re-reads the sources after registering, so an abort that landed
+    // before this turn was routed is not missed.
+    const { controller: abort, release } = linkedAbort(
+      this.#shutdown.signal,
+      background ? undefined : request.signal,
+    );
+    // Every exit path below releases the listeners and — for a turn that lives inside its
+    // request — the claim. The paths that share this teardown can each reach it, so every step
+    // is idempotent: removing a removed listener is a no-op, `#releaseClaim` only drops the
+    // claim it is given, and a settled claim stays settled.
     const releaseSignals = (): void => {
-      this.#shutdown.signal.removeEventListener('abort', onShutdown);
-      request.signal.removeEventListener('abort', onShutdown);
+      release();
       if (!background) {
         this.#releaseClaim(responseId, claim);
         claim.settle();
       }
     };
-    // `addEventListener` is not a subscription to *state*: an `AbortSignal` that was already
-    // aborted never fires again, so a request whose client hung up before this turn was routed —
-    // or a `drain()` that landed between the `#draining` check in `#route` and the registration
-    // just above — would hand the handler a signal that reads as live, and the turn would report
-    // `completed` for work nobody is waiting for. Re-read here, after the
-    // listeners are in place, so neither the edge nor the state can be missed.
-    if (this.#shutdown.signal.aborted || (!background && request.signal.aborted)) {
-      onShutdown();
-    }
 
     const tracker = new ResponseTracker(initial);
     const handlerContext: HandlerContext = {
@@ -745,15 +735,5 @@ export class ResponsesServer {
         releaseSignals();
       }
     });
-  }
-
-  /** Adds the headers the platform expects on every response. */
-  #withStandardHeaders(response: Response, context: RequestContext): Response {
-    return withStandardHeaders(response, context, serverIdentity());
-  }
-
-  /** Renders a {@link ProtocolError} as the wire envelope, with diagnostics kept out of the body. */
-  #errorResponse(error: ProtocolError, context: RequestContext): Response {
-    return errorResponse(error, context, serverIdentity());
   }
 }

--- a/packages/agentserver/src/store/file.ts
+++ b/packages/agentserver/src/store/file.ts
@@ -4,22 +4,22 @@ import { notFound } from '../errors.js';
 import { resolveUnder } from '../paths.js';
 import type { OutputItem, ResponseEvent } from '../wire.js';
 import { readJsonFile, writeJsonFile } from './json-file.js';
-import type { ResponseGeneration, ResponseOwner, ResponseProvider, StoredResponse } from './provider.js';
+import type {
+  ResponseGeneration,
+  ResponseOwner,
+  ResponseProvider,
+  StoredEventLog,
+  StoredResponse,
+} from './provider.js';
 import {
   assertOwnerCanWrite,
   assertWritable,
-  historyOf,
+  fencedEvents,
+  historyVia,
   isCurrentGeneration,
   ownedOrUndefined,
   sameOwner,
 } from './provider.js';
-
-/** The on-disk shape of a persisted event stream: the events plus who they belong to. */
-interface StoredEventsFile {
-  userId?: string;
-  generation?: ResponseGeneration;
-  events: ResponseEvent[];
-}
 
 /**
  * Persists responses as JSON files under a root directory.
@@ -120,8 +120,9 @@ export class FileResponseProvider implements ResponseProvider {
     assertOwnerCanWrite(await this.#read(id), id, owner);
   }
 
-  async #readEvents(id: string): Promise<StoredEventsFile | undefined> {
-    return readJsonFile<StoredEventsFile>(this.#eventsPathFor(id));
+  /** Reads one on-disk event stream, with the same unchecked-assertion caveat as `#read`. */
+  async #readEvents(id: string): Promise<StoredEventLog | undefined> {
+    return readJsonFile<StoredEventLog>(this.#eventsPathFor(id));
   }
 
   async putEvents(
@@ -145,7 +146,7 @@ export class FileResponseProvider implements ResponseProvider {
       if (existing !== undefined && !sameOwner(existing.userId, owner)) {
         throw notFound(id);
       }
-      const payload: StoredEventsFile = {
+      const payload: StoredEventLog = {
         ...(owner === undefined || owner === '' ? {} : { userId: owner }),
         generation,
         events: [...events],
@@ -159,10 +160,7 @@ export class FileResponseProvider implements ResponseProvider {
     owner: ResponseOwner,
     generation: ResponseGeneration,
   ): Promise<ResponseEvent[] | undefined> {
-    const record = await this.#readEvents(id);
-    return record !== undefined && record.generation === generation && sameOwner(record.userId, owner)
-      ? record.events
-      : undefined;
+    return fencedEvents(await this.#readEvents(id), owner, generation);
   }
 
   async delete(id: string, owner: ResponseOwner): Promise<boolean> {
@@ -185,7 +183,6 @@ export class FileResponseProvider implements ResponseProvider {
   }
 
   async history(id: string, owner: ResponseOwner): Promise<OutputItem[] | undefined> {
-    const stored = await this.get(id, owner);
-    return stored === undefined ? undefined : historyOf(stored);
+    return historyVia(this, id, owner);
   }
 }

--- a/packages/agentserver/src/store/memory.ts
+++ b/packages/agentserver/src/store/memory.ts
@@ -1,11 +1,18 @@
 import { notFound } from '../errors.js';
 import { positiveLimit } from '../validation.js';
 import type { OutputItem, ResponseEvent } from '../wire.js';
-import type { ResponseGeneration, ResponseOwner, ResponseProvider, StoredResponse } from './provider.js';
+import type {
+  ResponseGeneration,
+  ResponseOwner,
+  ResponseProvider,
+  StoredEventLog,
+  StoredResponse,
+} from './provider.js';
 import {
   assertOwnerCanWrite,
   assertWritable,
-  historyOf,
+  fencedEvents,
+  historyVia,
   isCurrentGeneration,
   ownedOrUndefined,
   sameOwner,
@@ -22,13 +29,6 @@ export interface InMemoryResponseProviderConfig {
    * that needs no timers. An evicted response reads as absent, exactly like an expired one.
    */
   maxResponses?: number;
-}
-
-/** An event stream held for replay, together with who it belongs to. */
-interface StoredEvents {
-  owner: ResponseOwner;
-  generation: ResponseGeneration;
-  events: ResponseEvent[];
 }
 
 /**
@@ -52,7 +52,7 @@ export class InMemoryResponseProvider implements ResponseProvider {
    */
   readonly #aliasIdsFor = new Map<string, Set<string>>();
   /** Replayable background streams, keyed by response id. Bounded by the same cap as responses. */
-  readonly #events = new Map<string, StoredEvents>();
+  readonly #events = new Map<string, StoredEventLog>();
   readonly #maxResponses: number;
 
   constructor(options: InMemoryResponseProviderConfig = {}) {
@@ -153,24 +153,24 @@ export class InMemoryResponseProvider implements ResponseProvider {
     events: readonly ResponseEvent[],
     generation: ResponseGeneration,
   ): Promise<void> {
-    // The same two refusals a `put` gives: neither someone else's response record nor someone
-    // else's event stream may be replaced under a reused id.
+    // The same two refusals a `put` gives — `FileResponseProvider.putEvents` spells out the
+    // rationale. Here the whole check-and-write is one synchronous step, so nothing can slip
+    // between them.
     const record = this.#responses.get(id);
     assertOwnerCanWrite(record, id, owner);
     if (!isCurrentGeneration(record, generation)) {
       // The id was deleted, or has moved on to another turn, since these events were produced.
       // Discarded rather than reported: nothing about the *current* occupant of the id is wrong.
-      // The whole check-and-write is one synchronous step here, so nothing can slip between them.
       return;
     }
     const existing = this.#events.get(id);
-    if (existing !== undefined && !sameOwner(existing.owner, owner)) {
+    if (existing !== undefined && !sameOwner(existing.userId, owner)) {
       throw notFound(id);
     }
     if (!this.#events.has(id)) {
       this.#evictOldest(this.#events);
     }
-    this.#events.set(id, { owner, generation, events: [...events] });
+    this.#events.set(id, { userId: owner, generation, events: [...events] });
   }
 
   async getEvents(
@@ -178,10 +178,9 @@ export class InMemoryResponseProvider implements ResponseProvider {
     owner: ResponseOwner,
     generation: ResponseGeneration,
   ): Promise<ResponseEvent[] | undefined> {
-    const entry = this.#events.get(id);
-    return entry !== undefined && entry.generation === generation && sameOwner(entry.owner, owner)
-      ? [...entry.events]
-      : undefined;
+    const events = fencedEvents(this.#events.get(id), owner, generation);
+    // Copied, so a caller cannot mutate the retained log.
+    return events === undefined ? undefined : [...events];
   }
 
   async delete(id: string, owner: ResponseOwner): Promise<boolean> {
@@ -204,8 +203,7 @@ export class InMemoryResponseProvider implements ResponseProvider {
   }
 
   async history(id: string, owner: ResponseOwner): Promise<OutputItem[] | undefined> {
-    const stored = await this.get(id, owner);
-    return stored === undefined ? undefined : historyOf(stored);
+    return historyVia(this, id, owner);
   }
 
   /** How many responses are held. Exposed for tests and diagnostics. */

--- a/packages/agentserver/src/store/provider.ts
+++ b/packages/agentserver/src/store/provider.ts
@@ -165,6 +165,41 @@ export function historyOf(stored: StoredResponse): OutputItem[] {
   return [...(stored.inputItems ?? []), ...stored.response.output];
 }
 
+/**
+ * The {@link ResponseProvider.history} implementation every local store shares: resolve the
+ * record for `owner`, then flatten it. `undefined` when the id is unknown to that owner.
+ */
+export async function historyVia(
+  store: Pick<ResponseProvider, 'get'>,
+  id: string,
+  owner: ResponseOwner,
+): Promise<OutputItem[] | undefined> {
+  const stored = await store.get(id, owner);
+  return stored === undefined ? undefined : historyOf(stored);
+}
+
+/** A stored replay log: the events plus the fence fields {@link fencedEvents} checks. */
+export interface StoredEventLog {
+  userId?: string | undefined;
+  generation?: ResponseGeneration | undefined;
+  events: ResponseEvent[];
+}
+
+/**
+ * The read fence every {@link ResponseProvider.getEvents} implementation applies: a stored log is
+ * visible only when it carries this exact turn's `generation` and belongs to `owner` — anything
+ * else (a missing log, another generation's, someone else's) reads as absent.
+ */
+export function fencedEvents(
+  record: StoredEventLog | undefined,
+  owner: ResponseOwner,
+  generation: ResponseGeneration,
+): ResponseEvent[] | undefined {
+  return record !== undefined && record.generation === generation && sameOwner(record.userId, owner)
+    ? record.events
+    : undefined;
+}
+
 /** Whether two owners are the same partition. Both halves normalize `''` to "no user". */
 export function sameOwner(a: ResponseOwner, b: ResponseOwner): boolean {
   return (a === '' ? undefined : a) === (b === '' ? undefined : b);

--- a/packages/agentserver/src/store/store.test.ts
+++ b/packages/agentserver/src/store/store.test.ts
@@ -1,9 +1,8 @@
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, assert, describe, expect, it } from 'vitest';
 import { ProtocolError } from '../errors.js';
-import { must } from '../test-helpers.js';
 import type { ResponseEvent, ResponseObject } from '../wire.js';
 import { FileResponseProvider } from './file.js';
 import { InMemoryResponseProvider } from './memory.js';
@@ -268,7 +267,8 @@ describe('FileResponseProvider', () => {
     expect(reason.status).toBe(404);
 
     // The record on disk belongs to whoever won; it was never replaced.
-    const raw = JSON.parse(await readFile(join(must(root), 'caresp_raced.json'), 'utf8')) as StoredResponse;
+    assert.exists(root);
+    const raw = JSON.parse(await readFile(join(root, 'caresp_raced.json'), 'utf8')) as StoredResponse;
     expect(raw.userId).toBe('alice');
     expect(await provider.get('caresp_raced', 'mallory')).toBeUndefined();
   });

--- a/packages/agentserver/src/store/store.test.ts
+++ b/packages/agentserver/src/store/store.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { ProtocolError } from '../errors.js';
+import { must } from '../test-helpers.js';
 import type { ResponseEvent, ResponseObject } from '../wire.js';
 import { FileResponseProvider } from './file.js';
 import { InMemoryResponseProvider } from './memory.js';
@@ -15,12 +16,6 @@ const EVENTS: ResponseEvent[] = [
 
 /** The generation every fixture below is written under, unless a test is about the fence itself. */
 const GENERATION = 'generation-default';
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}
 
 function stored(id: string, userId?: string, generation: ResponseGeneration = GENERATION): StoredResponse {
   const response: ResponseObject = {

--- a/packages/agentserver/src/terminal.ts
+++ b/packages/agentserver/src/terminal.ts
@@ -1,5 +1,5 @@
 import type { ResponseTracker } from './lifecycle.js';
-import type { ApiError, ResponseEvent, ResponseObject } from './wire.js';
+import type { ApiError, ResponseEvent, ResponseLifecycleEvent, ResponseObject } from './wire.js';
 
 /**
  * What the caller is told when a finished response could not be stored (.NET
@@ -44,7 +44,11 @@ export class TerminalPersister {
       await this.#persist();
       return event;
     } catch {
-      return { type: 'response.failed', response: storageFailed(this.#tracker.response) };
+      const failed: ResponseLifecycleEvent = {
+        type: 'response.failed',
+        response: storageFailed(this.#tracker.response),
+      };
+      return failed;
     }
   }
 

--- a/packages/agentserver/src/test-helpers.ts
+++ b/packages/agentserver/src/test-helpers.ts
@@ -4,17 +4,12 @@
  * artifact.
  */
 
+import { assert } from 'vitest';
 import type { HandlerContext, ResponseHandler } from './server.js';
 import { ResponsesServer } from './server.js';
 import { InMemoryResponseProvider } from './store/memory.js';
 import type { ResponseProvider } from './store/provider.js';
 import type { CreateResponseRequest, ResponseObject } from './wire.js';
-
-/** Narrows away null/undefined; a missing value fails the test with a clear error. */
-export function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}
 
 /** A `POST /responses` request with a JSON body. */
 export function post(body: unknown, headers: Record<string, string> = {}): Request {
@@ -34,8 +29,10 @@ export async function readSse(
     .split('\n\n')
     .filter((block) => block.trim() !== '' && !block.startsWith(':'))
     .map((block) => {
-      const eventLine = must(block.split('\n').find((line) => line.startsWith('event: ')));
-      const dataLine = must(block.split('\n').find((line) => line.startsWith('data: ')));
+      const eventLine = block.split('\n').find((line) => line.startsWith('event: '));
+      const dataLine = block.split('\n').find((line) => line.startsWith('data: '));
+      assert.exists(eventLine);
+      assert.exists(dataLine);
       return {
         event: eventLine.slice('event: '.length),
         data: JSON.parse(dataLine.slice('data: '.length)) as Record<string, unknown>,

--- a/packages/agentserver/src/test-helpers.ts
+++ b/packages/agentserver/src/test-helpers.ts
@@ -1,0 +1,176 @@
+/**
+ * Helpers shared by this package's test suites. Not a test file itself (vitest collects only
+ * `*.test.ts`), and not reachable from any build entry, so it never lands in the published
+ * artifact.
+ */
+
+import type { HandlerContext, ResponseHandler } from './server.js';
+import { ResponsesServer } from './server.js';
+import { InMemoryResponseProvider } from './store/memory.js';
+import type { ResponseProvider } from './store/provider.js';
+import type { CreateResponseRequest, ResponseObject } from './wire.js';
+
+/** Narrows away null/undefined; a missing value fails the test with a clear error. */
+export function must<T>(value: T | null | undefined): T {
+  if (value == null) throw new Error('expected a value');
+  return value;
+}
+
+/** A `POST /responses` request with a JSON body. */
+export function post(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost:8088/responses', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Parses an SSE body into `{ event, data }` pairs. */
+export async function readSse(
+  response: Response,
+): Promise<Array<{ event: string; data: Record<string, unknown> }>> {
+  const text = await response.text();
+  return text
+    .split('\n\n')
+    .filter((block) => block.trim() !== '' && !block.startsWith(':'))
+    .map((block) => {
+      const eventLine = must(block.split('\n').find((line) => line.startsWith('event: ')));
+      const dataLine = must(block.split('\n').find((line) => line.startsWith('data: ')));
+      return {
+        event: eventLine.slice('event: '.length),
+        data: JSON.parse(dataLine.slice('data: '.length)) as Record<string, unknown>,
+      };
+    });
+}
+
+/** Resolves when `signal` fires — or immediately, when it already has. */
+function onAbort(signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+}
+
+/** The knobs on {@link lifecycleHandler}. */
+export interface LifecycleHandlerOptions {
+  /**
+   * Stream the reference samples' echo shape between `in_progress` and the terminal: an
+   * `output_item.added`, one `output_text.delta` carrying `Echo: <input>`, then the completed
+   * item.
+   */
+  echo?: boolean | undefined;
+  /**
+   * Emit one completed message item, `msg_<label>` carrying `label` as its text. The tag is what
+   * lets tests that put two turns under one id tell their event logs apart — untagged, two runs
+   * produce byte-identical streams, and "the stale log replaced the fresh one" would be
+   * indistinguishable from success. Ignored when `echo` is set.
+   */
+  label?: string | undefined;
+  /** Holds the handler open between `in_progress` and its output until this promise resolves. */
+  gate?: Promise<void> | undefined;
+  /**
+   * Ignore cancellation completely: produce the output first, then await `gate` without racing
+   * the abort signal, and complete anyway once it opens — the misbehaving half of the
+   * cancellation contract. By default the handler instead waits on `gate` *before* its output,
+   * racing the abort signal and rethrowing its reason, the way a well-behaved handler is
+   * documented to. The rethrown value is the real shape, not a hand-named `Error`: the
+   * `DOMException` the platform puts on `signal.reason`, and the same value the framework's
+   * providers propagate for an interrupted model call.
+   */
+  ignoreAbort?: boolean | undefined;
+  /**
+   * Extra fields merged into the `in_progress` event's response snapshot — fields only a handler
+   * can put on the resource.
+   */
+  inProgressResponse?: Partial<ResponseObject> | undefined;
+  /** Called as the handler starts and again just before the terminal event. */
+  work?: ((stage: 'start' | 'late') => void) | undefined;
+}
+
+/**
+ * The one parameterized builder for the lifecycle shape every suite drives the server with:
+ * `response.created`, `response.in_progress`, optional output, then `response.completed`.
+ */
+export function lifecycleHandler(options: LifecycleHandlerOptions = {}): ResponseHandler {
+  const { echo = false, label, gate, ignoreAbort = false, inProgressResponse, work } = options;
+  return async function* (request: CreateResponseRequest, context: HandlerContext) {
+    const response = (status: ResponseObject['status']): ResponseObject => ({
+      ...context.response,
+      status,
+    });
+    work?.('start');
+    yield { type: 'response.created', response: response('queued') };
+    yield {
+      type: 'response.in_progress',
+      response:
+        inProgressResponse === undefined
+          ? response('in_progress')
+          : { ...response('in_progress'), ...inProgressResponse },
+    };
+    if (gate !== undefined && !ignoreAbort) {
+      await Promise.race([gate, onAbort(context.signal)]);
+      context.signal.throwIfAborted();
+    }
+    if (echo) {
+      const text = `Echo: ${typeof request.input === 'string' ? request.input : JSON.stringify(request.input)}`;
+      yield {
+        type: 'response.output_item.added',
+        output_index: 0,
+        item: { type: 'message', id: 'msg_1', role: 'assistant', status: 'in_progress', content: [] },
+      };
+      yield {
+        type: 'response.output_text.delta',
+        item_id: 'msg_1',
+        output_index: 0,
+        content_index: 0,
+        delta: text,
+      };
+      yield {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          type: 'message',
+          id: 'msg_1',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text, annotations: [] }],
+        },
+      };
+    } else if (label !== undefined) {
+      yield {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          type: 'message',
+          id: `msg_${label}`,
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: label, annotations: [] }],
+        },
+      };
+    }
+    if (gate !== undefined && ignoreAbort) {
+      // Deliberately *not* racing `context.signal`: this handler does not honour cancellation.
+      await gate;
+    }
+    work?.('late');
+    yield { type: 'response.completed', response: response('completed') };
+  };
+}
+
+/** A server over an in-memory store; the default handler is the reference echo shape. */
+export function makeServer(
+  handler: ResponseHandler = lifecycleHandler({ echo: true }),
+  options: { store?: ResponseProvider; hosted?: boolean } = {},
+): ResponsesServer {
+  return new ResponsesServer({
+    handler,
+    store: options.store ?? new InMemoryResponseProvider(),
+    // Always explicit: leaving it unset would let FOUNDRY_HOSTING_ENVIRONMENT in the test
+    // runner's environment flip every test into hosted mode.
+    hosted: options.hosted ?? false,
+  });
+}

--- a/packages/agentserver/src/test-setup.ts
+++ b/packages/agentserver/src/test-setup.ts
@@ -1,0 +1,15 @@
+/**
+ * Clears the deployment environment before each test file runs.
+ *
+ * The server reads its hosted mode, request limits and telemetry wiring from process env, so a
+ * variable leaking in from the machine running the tests would silently change what the suite
+ * asserts. A test that exercises an environment-driven path sets — and restores — the variable
+ * itself.
+ */
+const PLATFORM_ENV_PREFIXES = ['FOUNDRY_', 'AGENTSERVER_', 'OTEL_EXPORTER_', 'APPLICATIONINSIGHTS_'];
+
+for (const name of Object.keys(process.env)) {
+  if (PLATFORM_ENV_PREFIXES.some((prefix) => name.startsWith(prefix))) {
+    delete process.env[name];
+  }
+}

--- a/packages/agentserver/src/validation.ts
+++ b/packages/agentserver/src/validation.ts
@@ -78,7 +78,7 @@ export function validateStoreId(id: string, param: string): void {
 /** Rejects a response id that is not both canonical and safe as a storage key. */
 export function validateResponseId(id: string, param = 'response_id'): void {
   if (!isValidId(id, [ID_PREFIX.response])) {
-    // The message stays generic on purpose: echoing the id back would reflect caller input.
+    // The same deliberately generic message as `validateStoreId`.
     throw badRequest('Malformed identifier.', { code: 'invalid_parameters', param });
   }
   validateStoreId(id, param);

--- a/packages/agentserver/vitest.config.ts
+++ b/packages/agentserver/vitest.config.ts
@@ -1,3 +1,6 @@
 import { definePackageTests } from '../../scripts/vitest-config.ts';
 
-export default definePackageTests();
+const config = definePackageTests();
+// The suite must not inherit the machine's deployment environment; see src/test-setup.ts.
+config.test = { ...config.test, setupFiles: ['./src/test-setup.ts'] };
+export default config;

--- a/packages/anthropic/src/chat-client.test.ts
+++ b/packages/anthropic/src/chat-client.test.ts
@@ -2,6 +2,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import type { Content, Message } from '@polymind-inc/agent-framework-core';
 import {
   Agent,
+  arrayToStream,
   ChatClientError,
   ConfigurationError,
   deserializeMessage,
@@ -34,12 +35,7 @@ class MockMessages {
     this.requests.push(body);
     const turn = this.#turns[Math.min(this.requests.length - 1, this.#turns.length - 1)];
     if (body.stream === true) {
-      const events = Array.isArray(turn) ? turn : [];
-      return (async function* () {
-        for (const event of events) {
-          yield event;
-        }
-      })();
+      return arrayToStream(Array.isArray(turn) ? turn : []);
     }
     return Promise.resolve(turn);
   }
@@ -201,7 +197,7 @@ describe('request mapping', () => {
   it('replaces spaces in the server label, as Python does', () => {
     // Messages API rejects a `mcp_servers[].name` containing spaces. Python's
     // `AnthropicClient.get_mcp_tool` normalises with `name.replace(" ", "_")`
-    // (`_chat_client.py:520`), and the openai package already does the same.
+    // (`_chat_client.py`), and the openai package already does the same.
     const { client } = clientWith([message('hi')]);
     const request = client.buildRequest([{ role: 'user', contents: [textContent('hi')] }], {
       tools: [client.getMcpTool({ serverLabel: 'my docs', serverUrl: 'https://mcp.example/sse' })],
@@ -334,6 +330,28 @@ describe('beta namespace routing', () => {
 });
 
 describe('message conversion', () => {
+  it('coerces non-object tool arguments to an empty input object', () => {
+    // `tool_use.input` must be a JSON object on the wire; a replayed transcript can carry a
+    // stringified array or scalar, and neither may pass through as `input`.
+    const calls: Message = {
+      role: 'assistant',
+      contents: [
+        { type: 'function_call', callId: 'c1', name: 'search', arguments: '[]' },
+        { type: 'function_call', callId: 'c2', name: 'search', arguments: '"text"' },
+      ],
+    };
+
+    expect(toAnthropicMessages([calls])).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'c1', name: 'search', input: {} },
+          { type: 'tool_use', id: 'c2', name: 'search', input: {} },
+        ],
+      },
+    ]);
+  });
+
   it('splits a mixed message into the roles the API requires', () => {
     const exchange: Message = {
       role: 'assistant',

--- a/packages/anthropic/src/chat-client.ts
+++ b/packages/anthropic/src/chat-client.ts
@@ -120,11 +120,12 @@ export class AnthropicChatClient
   readonly #model: string;
   readonly #defaultMaxTokens: number;
   /**
-   * A cancellation is not a provider failure and must not be laundered into one: hosting maps
-   * `AbortError` to `response.incomplete`/`interrupted` and everything else to `response.failed`.
-   * The SDK's own abort error is *not* named `AbortError` — `APIUserAbortError` never sets
-   * `this.name`, so it arrives as a plain `"Error"` (@anthropic-ai/sdk `core/error.mjs`) and is
-   * recognized by type instead.
+   * Normalizes anything thrown around an SDK call into the value this client throws, following
+   * the `createClientErrorNormalizer` contract: a cancellation passes through as the
+   * standards-shaped abort value rather than being laundered into a provider failure.
+   *
+   * This SDK's specifics: `APIUserAbortError` never sets `this.name`, so it arrives as a plain
+   * `"Error"` (@anthropic-ai/sdk `core/error.mjs`) and is recognized by type instead.
    */
   readonly #toClientError: ClientErrorNormalizer = createClientErrorNormalizer({
     abortErrorClass: Anthropic.APIUserAbortError,

--- a/packages/anthropic/src/from-anthropic.ts
+++ b/packages/anthropic/src/from-anthropic.ts
@@ -346,15 +346,29 @@ export function parseContentBlocks(blocks: readonly unknown[], state?: StreamPar
   return contents;
 }
 
+/**
+ * The `responseId` / `model` / `finishReason` init entries `fields` carries, each omitted rather
+ * than set to `undefined` when the wire did not report it.
+ */
+function envelopeInit(fields: ParsedMessageFields): {
+  responseId?: string;
+  model?: string;
+  finishReason?: FinishReason;
+} {
+  return {
+    ...(fields.responseId === undefined ? {} : { responseId: fields.responseId }),
+    ...(fields.model === undefined ? {} : { model: fields.model }),
+    ...(fields.finishReason === undefined ? {} : { finishReason: fields.finishReason }),
+  };
+}
+
 /** Converts a complete Messages API response. */
 export function parseMessage(message: unknown): ChatResponse<undefined> {
   const fields = parseMessageFields(message);
   const usage = parseUsage(fields.raw.usage);
   return chatResponse<undefined>({
     messages: [{ role: 'assistant', contents: fields.contents, rawRepresentation: message }],
-    ...(fields.responseId === undefined ? {} : { responseId: fields.responseId }),
-    ...(fields.model === undefined ? {} : { model: fields.model }),
-    ...(fields.finishReason === undefined ? {} : { finishReason: fields.finishReason }),
+    ...envelopeInit(fields),
     ...(usage === undefined ? {} : { usageDetails: usage }),
     rawRepresentation: message,
   });
@@ -378,9 +392,7 @@ export function parseStreamEvent(event: unknown, state: StreamParseState): ChatR
       return chatResponseUpdate({
         role: 'assistant',
         contents: [...fields.contents, ...(usage === undefined ? [] : [usage])],
-        ...(fields.responseId === undefined ? {} : { responseId: fields.responseId }),
-        ...(fields.model === undefined ? {} : { model: fields.model }),
-        ...(fields.finishReason === undefined ? {} : { finishReason: fields.finishReason }),
+        ...envelopeInit(fields),
         rawRepresentation: event,
       });
     }

--- a/packages/anthropic/src/hosted-tools.ts
+++ b/packages/anthropic/src/hosted-tools.ts
@@ -1,5 +1,6 @@
 import type { HostedTool, McpToolOptions, WebSearchToolOptions } from '@polymind-inc/agent-framework-core';
-import { ConfigurationError, hostedTool, withoutUndefined } from '@polymind-inc/agent-framework-core';
+import { hostedTool, withoutUndefined } from '@polymind-inc/agent-framework-core';
+import { normalizeServerLabel } from '@polymind-inc/agent-framework-core/internal';
 
 /**
  * Declares the provider-hosted web search tool.
@@ -47,14 +48,9 @@ export const MCP_SERVER_SPEC_TYPE = 'anthropic.mcp_server';
  * disclosed to that server on every call.
  */
 export function mcpTool(options: McpToolOptions): HostedTool {
-  if (options.serverLabel.trim() === '') {
-    throw new ConfigurationError('mcpTool requires a non-empty serverLabel.');
-  }
-  // The API rejects an `mcp_servers[].name` containing spaces; Python's `get_mcp_tool` applies the
-  // same substitution (`_chat_client.py`: `"server_label": name.replace(" ", "_")`), as does the
-  // openai package. Only spaces are replaced — matching the reference implementation exactly rather
-  // than sanitising every character the API might dislike.
-  const serverLabel = options.serverLabel.replaceAll(' ', '_');
+  // Here the normalized label lands on the wire as `mcp_servers[].name`, which is the field the
+  // Messages API rejects when it contains spaces.
+  const serverLabel = normalizeServerLabel(options.serverLabel);
   const authorizationEntry = Object.entries(options.headers ?? {}).find(
     ([name]) => name.toLowerCase() === 'authorization',
   );

--- a/packages/anthropic/src/integration.test.ts
+++ b/packages/anthropic/src/integration.test.ts
@@ -25,8 +25,7 @@ import {
   textContent,
   tool,
 } from '@polymind-inc/agent-framework-core';
-import { must } from '@polymind-inc/agent-framework-core/internal';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import { AnthropicChatClient } from './chat-client.js';
 
 const apiKey = process.env.ANTHROPIC_API_KEY;
@@ -34,8 +33,10 @@ const model = process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001';
 const thinkingModel = process.env.ANTHROPIC_THINKING_MODEL ?? model;
 const TIMEOUT = 120_000;
 
-const client = (override?: string): AnthropicChatClient =>
-  new AnthropicChatClient({ model: override ?? model, apiKey: must(apiKey) });
+function client(override?: string): AnthropicChatClient {
+  assert.exists(apiKey);
+  return new AnthropicChatClient({ model: override ?? model, apiKey });
+}
 
 const contentsOf = (response: { messages: Array<{ contents: Content[] }> }): Content[] =>
   response.messages.flatMap((message) => message.contents);

--- a/packages/anthropic/src/integration.test.ts
+++ b/packages/anthropic/src/integration.test.ts
@@ -25,6 +25,7 @@ import {
   textContent,
   tool,
 } from '@polymind-inc/agent-framework-core';
+import { must } from '@polymind-inc/agent-framework-core/internal';
 import { describe, expect, it } from 'vitest';
 import { AnthropicChatClient } from './chat-client.js';
 
@@ -32,12 +33,6 @@ const apiKey = process.env.ANTHROPIC_API_KEY;
 const model = process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001';
 const thinkingModel = process.env.ANTHROPIC_THINKING_MODEL ?? model;
 const TIMEOUT = 120_000;
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}
 
 const client = (override?: string): AnthropicChatClient =>
   new AnthropicChatClient({ model: override ?? model, apiKey: must(apiKey) });

--- a/packages/anthropic/src/to-anthropic.ts
+++ b/packages/anthropic/src/to-anthropic.ts
@@ -11,8 +11,10 @@ import {
   isFunctionTool,
   resolveResponseFormat,
   serializeContent,
+  textOfContents,
   topLevelMediaType,
 } from '@polymind-inc/agent-framework-core';
+import { isRecord, safeStringify } from '@polymind-inc/agent-framework-core/internal';
 import { MCP_SERVER_SPEC_TYPE } from './hosted-tools.js';
 
 /** A Messages API content block, kept loose so unmodelled block types pass through. */
@@ -53,7 +55,8 @@ function toolInput(args: Record<string, unknown> | string): Record<string, unkno
   }
   try {
     const parsed: unknown = JSON.parse(trimmed);
-    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : {};
+    // Arrays and scalars are valid JSON but not a valid `input`; they degrade the same way.
+    return isRecord(parsed) ? parsed : {};
   } catch {
     // A half-streamed fragment can reach here after a fold; an empty object is closer to the
     // model's intent than a 400 from the API.
@@ -110,20 +113,8 @@ function toolResultContent(result: unknown): AnthropicBlock[] | string {
   }
   // Caller-built or replayed transcripts can carry results JSON cannot encode (circular
   // references, bigints, symbols); degrade to the value's string form rather than failing the
-  // whole request, as Python does with json.dumps falling back to str(). Same contract as
-  // stringifyResult in the OpenAI package, which this package cannot depend on.
-  const fallback = (): string => {
-    try {
-      return String(result);
-    } catch {
-      return '[unserializable]';
-    }
-  };
-  try {
-    return JSON.stringify(result) ?? fallback();
-  } catch {
-    return fallback();
-  }
+  // whole request, as Python does with json.dumps falling back to str().
+  return safeStringify(result);
 }
 
 /**
@@ -327,16 +318,9 @@ export function toAnthropicSystem(
   messages: readonly Message[],
   instructions: string | undefined,
 ): string | undefined {
-  const leading = messages[0]?.role === 'system' ? textOfMessage(messages[0]) : undefined;
+  const leading = messages[0]?.role === 'system' ? textOfContents(messages[0].contents) : undefined;
   const parts = [instructions, leading].filter((part): part is string => part !== undefined && part !== '');
   return parts.length === 0 ? undefined : parts.join('\n\n');
-}
-
-function textOfMessage(msg: Message): string {
-  return msg.contents
-    .filter((content): content is Extract<Content, { type: 'text' }> => content.type === 'text')
-    .map((content) => content.text)
-    .join('');
 }
 
 /** The `tools` and `mcp_servers` halves of the request. */

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/testing.d.ts",
       "default": "./dist/testing.js"
     },
+    "./internal": {
+      "types": "./dist/internal.d.ts",
+      "default": "./dist/internal.js"
+    },
     "./node": {
       "types": "./dist/node.d.ts",
       "default": "./dist/node.js"

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
 import type { ChatClient, ChatOptions } from '../client/chat-client.js';
-import { MockChatClient, must } from '../client/test-support.js';
+import { MockChatClient } from '../client/test-support.js';
 import type { ContextProvider, HistoryProvider } from '../context/context-provider.js';
 import { InMemoryHistoryProvider } from '../context/in-memory-history-provider.js';
 import { ConfigurationError, StreamConsumedError, UserInputRequiredError } from '../errors.js';
@@ -55,10 +55,13 @@ describe('Agent.run', () => {
     await agent.run('two', { session });
 
     // Turn two sees: user(one), assistant(first), user(two).
-    const secondCall = must(mock.calls[1]);
+    const secondCall = mock.calls[1];
+    assert.exists(secondCall);
     expect(secondCall.messages.map((m) => m.role)).toEqual(['user', 'assistant', 'user']);
     expect(secondCall.messages[0]?.contents).toEqual([{ type: 'text', text: 'one' }]);
-    expect(getMessageSource(must(secondCall.messages[0]))?.sourceType).toBe('ChatHistory');
+    const firstMessage = secondCall.messages[0];
+    assert.exists(firstMessage);
+    expect(getMessageSource(firstMessage)?.sourceType).toBe('ChatHistory');
   });
 
   it('does not grow history geometrically across turns', async () => {
@@ -184,7 +187,8 @@ describe('Agent.run', () => {
     const options = mock.calls[0]?.options as ChatOptions;
     expect(options.instructions).toBe('Base.\nRemember: the user likes tea.');
     expect(options.tools?.map((t) => t.name)).toEqual(['recall']);
-    const injected = must(mock.calls[0]?.messages[0]);
+    const injected = mock.calls[0]?.messages[0];
+    assert.exists(injected);
     expect(getMessageSource(injected)).toEqual({ sourceType: 'AIContextProvider', sourceId: 'memories' });
   });
 
@@ -305,7 +309,9 @@ describe('Agent.run', () => {
 
     const response = await new Agent({ client: mock }).run('Taro is 30', { responseFormat: schema as never });
     expect(response.value).toEqual({ name: 'Taro', age: 30 });
-    expect(must(mock.calls[0]?.options).responseFormat).toBe(schema);
+    const options = mock.calls[0]?.options;
+    assert.exists(options);
+    expect(options.responseFormat).toBe(schema);
   });
 
   it('fills value for every responseFormat path', async () => {
@@ -355,7 +361,9 @@ describe('Agent.run', () => {
     }).run('x', { responseFormat: explicit as never });
 
     expect(response.value).toEqual({ a: 1 });
-    expect(must(mock.calls[0]?.options).responseFormat).toBe(explicit);
+    const options = mock.calls[0]?.options;
+    assert.exists(options);
+    expect(options.responseFormat).toBe(explicit);
   });
 
   it('fills value when the run is streamed', async () => {
@@ -665,7 +673,9 @@ describe('service-managed sessions', () => {
 
     await agent.run('hi', { session });
 
-    expect(must(mock.calls[0]?.options).conversationId).toBe('conv_1');
+    const options = mock.calls[0]?.options;
+    assert.exists(options);
+    expect(options.conversationId).toBe('conv_1');
     expect(session.state).toEqual({});
   });
 });

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ChatClient, ChatOptions } from '../client/chat-client.js';
-import { MockChatClient } from '../client/test-support.js';
+import { MockChatClient, must } from '../client/test-support.js';
 import type { ContextProvider, HistoryProvider } from '../context/context-provider.js';
 import { InMemoryHistoryProvider } from '../context/in-memory-history-provider.js';
 import { ConfigurationError, StreamConsumedError, UserInputRequiredError } from '../errors.js';
@@ -17,12 +17,6 @@ import { AgentSession } from './session.js';
 
 function client(...texts: string[]): MockChatClient {
   return new MockChatClient(texts.map((text) => ({ contents: [textContent(text)], finishReason: 'stop' })));
-}
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
 }
 
 describe('Agent.run', () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1,4 +1,3 @@
-import type { Span } from '@opentelemetry/api';
 import type { ChatClient, ChatOptions, ChatResponseStream, ResponseFormat } from '../client/chat-client.js';
 import type { FunctionInvocationConfig } from '../client/function-invocation.js';
 import { createFunctionInvocationClientFactory } from '../client/function-invocation.js';
@@ -23,17 +22,8 @@ import type {
   Middleware,
 } from '../middleware/middleware.js';
 import { categorizeMiddleware } from '../middleware/middleware.js';
-import { GEN_AI, GEN_AI_OPERATION } from '../observability/attributes.js';
-import {
-  agentSpanAttributes,
-  inActiveSpan,
-  recordSpanError,
-  setMessageContent,
-  setResponseAttributes,
-  spanName,
-  startSpan,
-  withActiveSpan,
-} from '../observability/tracing.js';
+import type { AgentRunSpan } from '../observability/tracing.js';
+import { startAgentRunSpan } from '../observability/tracing.js';
 import type { ResponseStream } from '../streaming/response-stream.js';
 import { createResponseStream } from '../streaming/response-stream.js';
 import type { StandardSchemaV1 } from '../tools/standard-schema.js';
@@ -417,7 +407,7 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
         const session = options?.session ?? this.createSession();
         pipeline = await runAgentPipeline<Final>({
           middleware: chain,
-          agent: { id: this.id, ...(this.name === undefined ? {} : { name: this.name }) },
+          agent: this.#agentInfo(),
           session,
           messages: [...callerMessages],
           tools: [...(options?.tools ?? [])],
@@ -477,7 +467,7 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
     let streamedRun = false;
     // The `invoke_agent` span covers the whole run, including the tool loop and history
     // persistence, so it is started in `start` and closed by hand rather than around a call.
-    let runSpan: Span | undefined;
+    let runSpan: AgentRunSpan | undefined;
     let runFailure: unknown;
 
     /** Ends the run span once, on whichever path gets there first. */
@@ -486,7 +476,7 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
         return;
       }
       if (runFailure !== undefined) {
-        recordSpanError(runSpan, runFailure);
+        runSpan.setError(runFailure);
       }
       runSpan.end();
       runSpan = undefined;
@@ -531,11 +521,10 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
       const chatOptions = this.#mergeOptions(options, prepared.accumulator, session, continuation.innerToken);
       const client = this.#approvalClient(session, functionMiddleware);
 
-      const span = this.#startRunSpan(session, chatOptions.model);
+      // Capturing the input messages serializes caller-supplied content and can throw;
+      // `startAgentRunSpan` ends the span itself in that case, so nothing leaks here.
+      const span = this.#startRunSpan(session, chatOptions.model, messages);
       runSpan = span;
-      // Capturing the input messages serializes caller-supplied content and can throw; it runs
-      // only after the span is assigned above, so the teardown can end what was started.
-      setMessageContent(span, GEN_AI.inputMessages, messages);
       const inner = client.getResponse(messages, chatOptions);
       // Everything the caller will have seen by the time a token is issued, so a resumed run can
       // persist the whole exchange rather than just its tail (Go `continuationUpdates`).
@@ -574,10 +563,7 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
             if (activeSession !== undefined) {
               this.#rejectHistoryConflict(activeSession);
             }
-            if (runSpan !== undefined) {
-              setResponseAttributes(runSpan, response);
-              setMessageContent(runSpan, GEN_AI.outputMessages, response.messages);
-            }
+            runSpan?.setResponse(response);
             // Persist first, parse second. The model answered:
             // whether the answer happens to satisfy the caller's schema does not change what was
             // said, and parsing before persisting loses the whole exchange — the next turn then
@@ -680,7 +666,7 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
     const providerContexts = providers.map((provider) => ({
       provider,
       ctx: createProviderRunContext(provider, {
-        agent: { id: this.id, ...(this.name === undefined ? {} : { name: this.name }) },
+        agent: this.#agentInfo(),
         session,
         inputMessages,
         accumulator,
@@ -746,18 +732,27 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
     );
   }
 
-  /** Opens the `invoke_agent` span and records the request-side attributes on it. */
-  #startRunSpan(session: AgentSession, model: string | undefined): Span {
-    return startSpan(
-      spanName(GEN_AI_OPERATION.invokeAgent, this.name ?? this.id),
-      agentSpanAttributes({
+  /** This agent's identity as handed to middleware and context providers. */
+  #agentInfo(): { id: string; name?: string } {
+    return { id: this.id, ...(this.name === undefined ? {} : { name: this.name }) };
+  }
+
+  /** Opens the `invoke_agent` span and records the request-side attributes and input on it. */
+  #startRunSpan(
+    session: AgentSession,
+    model: string | undefined,
+    inputMessages: readonly Message[],
+  ): AgentRunSpan {
+    return startAgentRunSpan(
+      {
         id: this.id,
         ...(this.name === undefined ? {} : { name: this.name }),
         ...(this.description === undefined ? {} : { description: this.description }),
         providerName: this.#client.metadata.providerName,
         ...(model === undefined ? {} : { model }),
         ...(session.serviceSessionId === undefined ? {} : { conversationId: session.serviceSessionId }),
-      }),
+      },
+      inputMessages,
     );
   }
 
@@ -845,7 +840,7 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
    */
   async *#pipeUpdates(run: {
     stream: boolean;
-    span: Span;
+    span: AgentRunSpan;
     inner: ChatResponseStream<unknown>;
     carried: readonly AgentResponseUpdate[];
     mapUpdate: (update: ChatResponseUpdate) => AgentResponseUpdate;
@@ -858,11 +853,11 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
       if (run.stream) {
         // Driven inside the run span so the tool loop's `chat` and `execute_tool` spans become
         // its children — the generator body would otherwise run outside any span context.
-        for await (const update of withActiveSpan(run.span, run.inner)) {
+        for await (const update of run.span.active(run.inner)) {
           yield run.mapUpdate(update);
         }
       } else {
-        const response = await inActiveSpan(run.span, () => run.inner);
+        const response = await run.span.awaited(() => run.inner);
         for (const update of chatResponseToUpdates(response)) {
           yield run.mapUpdate(update);
         }

--- a/packages/core/src/agent/continuation.test.ts
+++ b/packages/core/src/agent/continuation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ChatClient, ChatOptions, ChatResponseStream } from '../client/chat-client.js';
+import { must } from '../client/test-support.js';
 import type { ContextProvider } from '../context/context-provider.js';
 import { InMemoryHistoryProvider } from '../context/in-memory-history-provider.js';
 import { ConfigurationError } from '../errors.js';
@@ -15,12 +16,6 @@ import {
 } from '../types/response.js';
 import { Agent } from './agent.js';
 import { isAgentContinuationToken, parseContinuationToken, wrapContinuationToken } from './continuation.js';
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}
 
 /** One scripted turn: some text, and optionally a token meaning "not finished yet". */
 interface Turn {

--- a/packages/core/src/agent/continuation.test.ts
+++ b/packages/core/src/agent/continuation.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import type { ChatClient, ChatOptions, ChatResponseStream } from '../client/chat-client.js';
-import { must } from '../client/test-support.js';
 import type { ContextProvider } from '../context/context-provider.js';
 import { InMemoryHistoryProvider } from '../context/in-memory-history-provider.js';
 import { ConfigurationError } from '../errors.js';
@@ -35,7 +34,8 @@ class BackgroundClient implements ChatClient<ChatOptions> {
   }
 
   getResponse(messages: Message[], options?: ChatOptions & { signal?: AbortSignal }): ChatResponseStream {
-    const turn = must(this.#turns[Math.min(this.#index, this.#turns.length - 1)]);
+    const turn = this.#turns[Math.min(this.#index, this.#turns.length - 1)];
+    assert.exists(turn);
     this.#index++;
     this.seen.push({ messages, token: options?.continuationToken });
 
@@ -94,7 +94,8 @@ describe('token payload round trip', () => {
     expect(state.inputMessages).toEqual([
       expect.objectContaining({ role: 'user', contents: [expect.objectContaining({ text: 'question' })] }),
     ]);
-    const restored = must(state.updates[0]);
+    const restored = state.updates[0];
+    assert.exists(restored);
     expect(restored.text).toBe('partial');
     expect(restored.role).toBe('assistant');
     expect(restored.authorName).toBe('writer');
@@ -114,7 +115,8 @@ describe('token payload round trip', () => {
     );
     expect(token.inputMessages).toBeUndefined();
 
-    const restored = must(parseContinuationToken(token).updates[0]);
+    const restored = parseContinuationToken(token).updates[0];
+    assert.exists(restored);
     expect(restored.contents).toEqual([]);
     expect(restored.authorName).toBeUndefined();
     expect(restored.responseId).toBeUndefined();
@@ -174,9 +176,11 @@ describe('continuation tokens', () => {
     const session = agent.createSession();
 
     const suspended = await agent.run('long job', { session, allowBackgroundResponses: true });
+    const continuationToken = suspended.continuationToken;
+    assert.exists(continuationToken);
     const resumed = await agent.run(undefined, {
       session,
-      continuationToken: must(suspended.continuationToken),
+      continuationToken,
     });
 
     expect(client.seen[1]?.token).toEqual({ responseId: 'resp_1' });
@@ -198,7 +202,9 @@ describe('continuation tokens', () => {
     }
     const suspended = await first.finalResponse();
 
-    const resumed = agent.run(undefined, { session, continuationToken: must(suspended.continuationToken) });
+    const continuationToken = suspended.continuationToken;
+    assert.exists(continuationToken);
+    const resumed = agent.run(undefined, { session, continuationToken });
     const texts: string[] = [];
     for await (const update of resumed) {
       texts.push(update.text);
@@ -219,9 +225,11 @@ describe('continuation tokens', () => {
     const suspended = await agent.run('long job', { session, allowBackgroundResponses: true });
     expect(suspended.continuationToken?.responseUpdates).toBeUndefined();
 
+    const continuationToken = suspended.continuationToken;
+    assert.exists(continuationToken);
     const resumed = await agent.run(undefined, {
       session,
-      continuationToken: must(suspended.continuationToken),
+      continuationToken,
     });
     expect(resumed.text).toBe('part two');
   });
@@ -264,9 +272,11 @@ describe('continuation tokens', () => {
     expect(suspended.continuationToken).toBeDefined();
     expect(suspended.value).toBeUndefined();
 
+    const continuationToken = suspended.continuationToken;
+    assert.exists(continuationToken);
     const resumed = await agent.run(undefined, {
       session,
-      continuationToken: must(suspended.continuationToken),
+      continuationToken,
       responseFormat: format as never,
     });
     expect(resumed.value).toEqual({ ok: true });
@@ -285,7 +295,8 @@ describe('continuation tokens', () => {
     for await (const update of agent.run('long job', { session, allowBackgroundResponses: true })) {
       token = update.continuationToken ?? token;
     }
-    const resumed = await agent.run(undefined, { session, continuationToken: must(token) });
+    assert.exists(token);
+    const resumed = await agent.run(undefined, { session, continuationToken: token });
     expect(resumed.continuationToken).toBeUndefined();
     expect(resumed.text).toContain('part one');
     expect(resumed.text).toContain('part two');
@@ -294,7 +305,9 @@ describe('continuation tokens', () => {
     // run stores the whole exchange; the suspended run storing its half too would make the next
     // turn replay the question and the partial answer twice.
     await agent.run('and now?', { session });
-    const replayed = must(client.seen[2]).messages.flatMap((msg) =>
+    const thirdCall = client.seen[2];
+    assert.exists(thirdCall);
+    const replayed = thirdCall.messages.flatMap((msg) =>
       msg.contents.flatMap((c) => (c.type === 'text' ? [c.text] : [])),
     );
     expect(replayed.filter((text) => text === 'long job')).toHaveLength(1);
@@ -319,14 +332,18 @@ describe('continuation tokens', () => {
     // The second run resumes as a stream and suspends again; its token carries the whole
     // exchange so far, so only the run that finally completes appends to history.
     let token2: ContinuationToken | undefined;
-    for await (const update of agent.run(undefined, { session, continuationToken: must(token1) })) {
+    assert.exists(token1);
+    for await (const update of agent.run(undefined, { session, continuationToken: token1 })) {
       token2 = update.continuationToken ?? token2;
     }
-    const resumed = await agent.run(undefined, { session, continuationToken: must(token2) });
+    assert.exists(token2);
+    const resumed = await agent.run(undefined, { session, continuationToken: token2 });
     expect(resumed.continuationToken).toBeUndefined();
 
     await agent.run('and now?', { session });
-    const replayed = must(client.seen[3]).messages.flatMap((msg) =>
+    const fourthCall = client.seen[3];
+    assert.exists(fourthCall);
+    const replayed = fourthCall.messages.flatMap((msg) =>
       msg.contents.flatMap((c) => (c.type === 'text' ? [c.text] : [])),
     );
     expect(replayed.filter((text) => text === 'long job')).toHaveLength(1);
@@ -364,12 +381,15 @@ describe('continuation tokens', () => {
     for await (const update of agent.run('long job', { session, allowBackgroundResponses: true })) {
       token = update.continuationToken ?? token;
     }
-    await agent.run(undefined, { session, continuationToken: must(token) });
+    assert.exists(token);
+    await agent.run(undefined, { session, continuationToken: token });
 
     // The suspended run defers persistence to the completing run, so the injected context has to
     // ride the continuation token alongside the input — otherwise it would never be stored.
     await agent.run('and now?', { session });
-    const replayed = must(client.seen[2]).messages.flatMap((msg) =>
+    const thirdCall = client.seen[2];
+    assert.exists(thirdCall);
+    const replayed = thirdCall.messages.flatMap((msg) =>
       msg.contents.flatMap((c) => (c.type === 'text' ? [c.text] : [])),
     );
     expect(replayed.filter((text) => text === 'retrieved doc')).toHaveLength(1);
@@ -386,14 +406,18 @@ describe('continuation tokens', () => {
     const session = agent.createSession();
 
     const suspended = await agent.run('long job', { session, allowBackgroundResponses: true });
-    await agent.run(undefined, { session, continuationToken: must(suspended.continuationToken) });
+    const continuationToken = suspended.continuationToken;
+    assert.exists(continuationToken);
+    await agent.run(undefined, { session, continuationToken });
 
     // The resumed call sends nothing: the operation is already running service-side.
     expect(client.seen[1]?.messages).toEqual([]);
 
     // History still records the original input and the completed answer, so the next turn has it.
     await agent.run('and now?', { session });
-    const replayed = must(client.seen[2]).messages.flatMap((msg) =>
+    const thirdCall = client.seen[2];
+    assert.exists(thirdCall);
+    const replayed = thirdCall.messages.flatMap((msg) =>
       msg.contents.flatMap((c) => (c.type === 'text' ? [c.text] : [])),
     );
     expect(replayed).toContain('long job');

--- a/packages/core/src/agent/continuation.ts
+++ b/packages/core/src/agent/continuation.ts
@@ -1,7 +1,7 @@
 import { ConfigurationError } from '../errors.js';
 import type { Message } from '../types/message.js';
-import type { AgentResponseUpdate, ContinuationToken } from '../types/response.js';
-import { agentResponseUpdate } from '../types/response.js';
+import type { AgentResponseUpdate, AgentResponseUpdateInit, ContinuationToken } from '../types/response.js';
+import { agentResponseUpdate, copyDefined } from '../types/response.js';
 import type { SerializedMessage } from '../types/serialization.js';
 import { deserializeMessages, serializeMessages } from '../types/serialization.js';
 
@@ -54,37 +54,58 @@ export function isAgentContinuationToken(
   return token?.type === AGENT_TOKEN_TYPE && token.innerToken !== undefined;
 }
 
+/**
+ * The update fields a token carries, keyed exhaustively so the compiler rejects both a stray entry
+ * and a missing one whenever {@link AgentResponseUpdate} changes.
+ *
+ * Three fields are deliberately excluded rather than listed. `contents` is the payload, serialized
+ * separately through the message serializer so nested unknown content round-trips.
+ * `rawRepresentation` is the provider's own object, which is never serialized anywhere in the
+ * framework and can be circular. `continuationToken` is the token this update is being packed
+ * *into*: carrying it would nest a token inside itself and grow the payload on every resume.
+ * (`text` never appears here at all — the init type already omits it, and it is recomputed from
+ * the contents on the way back.)
+ *
+ * **Adding a field to `ResponseUpdateBase`? It has to be listed here, or added to the key list's
+ * `Exclude` with the reason why.** Otherwise a resumed run replays its updates with the new field
+ * silently dropped — a data loss no test of the field itself would catch.
+ */
+const CARRIED_UPDATE_KEYS = {
+  role: true,
+  authorName: true,
+  responseId: true,
+  messageId: true,
+  createdAt: true,
+  finishReason: true,
+  agentId: true,
+  additionalProperties: true,
+} as const satisfies Record<
+  Exclude<keyof AgentResponseUpdateInit, 'contents' | 'continuationToken' | 'rawRepresentation'>,
+  true
+>;
+
+/**
+ * The same keys as a list, in declaration order.
+ *
+ * One list drives both directions, so the two halves of the round trip cannot disagree about
+ * which fields survive it.
+ */
+const CARRIED_UPDATE_KEY_LIST = Object.keys(CARRIED_UPDATE_KEYS) as ReadonlyArray<
+  keyof typeof CARRIED_UPDATE_KEYS
+>;
+
 function serializeUpdate(update: AgentResponseUpdate): SerializedUpdate {
   const [serialized] = serializeMessages([{ role: update.role ?? 'assistant', contents: update.contents }]);
   const out: SerializedUpdate = { contents: serialized?.contents ?? [] };
-  if (update.role !== undefined) out.role = update.role;
-  if (update.authorName !== undefined) out.authorName = update.authorName;
-  if (update.responseId !== undefined) out.responseId = update.responseId;
-  if (update.messageId !== undefined) out.messageId = update.messageId;
-  if (update.createdAt !== undefined) out.createdAt = update.createdAt;
-  if (update.finishReason !== undefined) out.finishReason = update.finishReason;
-  if (update.agentId !== undefined) out.agentId = update.agentId;
-  if (update.additionalProperties !== undefined) out.additionalProperties = update.additionalProperties;
-  return out;
+  return copyDefined(out, update, CARRIED_UPDATE_KEY_LIST);
 }
 
 function deserializeUpdate(serialized: SerializedUpdate): AgentResponseUpdate {
   const [message] = deserializeMessages([
     { role: serialized.role ?? 'assistant', contents: serialized.contents },
   ]);
-  return agentResponseUpdate({
-    contents: message?.contents ?? [],
-    ...(serialized.role === undefined ? {} : { role: serialized.role }),
-    ...(serialized.authorName === undefined ? {} : { authorName: serialized.authorName }),
-    ...(serialized.responseId === undefined ? {} : { responseId: serialized.responseId }),
-    ...(serialized.messageId === undefined ? {} : { messageId: serialized.messageId }),
-    ...(serialized.createdAt === undefined ? {} : { createdAt: serialized.createdAt }),
-    ...(serialized.finishReason === undefined ? {} : { finishReason: serialized.finishReason }),
-    ...(serialized.agentId === undefined ? {} : { agentId: serialized.agentId }),
-    ...(serialized.additionalProperties === undefined
-      ? {}
-      : { additionalProperties: serialized.additionalProperties }),
-  });
+  const init: AgentResponseUpdateInit = { contents: message?.contents ?? [] };
+  return agentResponseUpdate(copyDefined(init, serialized, CARRIED_UPDATE_KEY_LIST));
 }
 
 /**

--- a/packages/core/src/agent/service-history.test.ts
+++ b/packages/core/src/agent/service-history.test.ts
@@ -5,6 +5,7 @@ import type {
   ChatOptions,
   ChatResponseStream,
 } from '../client/chat-client.js';
+import { must } from '../client/test-support.js';
 import { InMemoryHistoryProvider } from '../context/in-memory-history-provider.js';
 import { ConfigurationError } from '../errors.js';
 import { createResponseStream } from '../streaming/response-stream.js';
@@ -13,12 +14,6 @@ import type { Message } from '../types/message.js';
 import type { ChatResponse, ChatResponseUpdate } from '../types/response.js';
 import { chatResponseUpdate, mergeChatUpdates } from '../types/response.js';
 import { Agent } from './agent.js';
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}
 
 /** A client that answers with text and reports a service-side conversation id, like Responses. */
 class StoringClient implements ChatClient<ChatOptions> {

--- a/packages/core/src/agent/service-history.test.ts
+++ b/packages/core/src/agent/service-history.test.ts
@@ -1,11 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import type {
   ChatClient,
   ChatClientMetadata,
   ChatOptions,
   ChatResponseStream,
 } from '../client/chat-client.js';
-import { must } from '../client/test-support.js';
 import { InMemoryHistoryProvider } from '../context/in-memory-history-provider.js';
 import { ConfigurationError } from '../errors.js';
 import { createResponseStream } from '../streaming/response-stream.js';
@@ -29,9 +28,8 @@ class StoringClient implements ChatClient<ChatOptions> {
 
   getResponse(messages: Message[], options?: ChatOptions): ChatResponseStream {
     this.calls.push({ messages, conversationId: options?.conversationId });
-    const conversationId = must(
-      this.#conversationIds[Math.min(this.#turn, this.#conversationIds.length - 1)],
-    );
+    const conversationId = this.#conversationIds[Math.min(this.#turn, this.#conversationIds.length - 1)];
+    assert.exists(conversationId);
     this.#turn++;
     const update = chatResponseUpdate({
       contents: [textContent(`answer ${this.calls.length}`)],

--- a/packages/core/src/client/function-execution.ts
+++ b/packages/core/src/client/function-execution.ts
@@ -421,10 +421,11 @@ async function runTool(
  * The metadata a generated `function_result` inherits from the call it answers.
  *
  * Python passes `additional_properties=function_call_content.additional_properties` at every site
- * that builds a result for a call it executed — success (`_tools.py:1553`), tool not found
- * (`:1475`), argument parsing failure (`:1527`), a thrown tool body
- * (`_function_execution_error_result`, `:1422`) and a middleware-terminated result (`:1616`) — plus
- * the rejected-approval result (`:2439`). Provider-specific routing lives there: a hosted MCP call
+ * in `_tools.py` that builds a result for a call it executed — success, tool not found, argument
+ * parsing failure, a thrown tool body (`_function_execution_error_result`) and a
+ * middleware-terminated result — plus the rejected-approval result. There is no site that omits
+ * it, which is what makes it an invariant rather than a convention. Provider-specific routing
+ * rides on it: a hosted MCP call
  * carries its `serverLabel`, and Python's own approval bookkeeping reads it back off the call
  * (`_sessions.py` `_approval_controls_to_keep`). Dropping it means the result can no longer be
  * attributed to the server that produced the call.

--- a/packages/core/src/client/function-invocation.test.ts
+++ b/packages/core/src/client/function-invocation.test.ts
@@ -13,8 +13,9 @@ import type {
 import { textContent } from '../types/content.js';
 import { chatResponseUpdate, mergeChatUpdates } from '../types/response.js';
 import type { ChatClient, ChatClientMetadata, ChatOptions } from './chat-client.js';
+import { FunctionInvocationLimitError } from './function-execution.js';
 import { withFunctionInvocation } from './function-invocation.js';
-import { MockChatClient } from './test-support.js';
+import { MockChatClient, must } from './test-support.js';
 
 function call(
   callId: string,
@@ -26,12 +27,6 @@ function call(
 
 function resultsOf(contents: readonly Content[]): FunctionResultContent[] {
   return contents.filter((c): c is FunctionResultContent => c.type === 'function_result');
-}
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
 }
 
 const echoSchema = {
@@ -241,6 +236,31 @@ describe('withFunctionInvocation', () => {
     ).rejects.toThrow(/2 times in a row|kaboom/);
     // 2 tolerated rounds, then the third failure is fatal.
     expect(inner.callCount).toBe(3);
+  });
+
+  it('throws FunctionInvocationLimitError once a concurrent round exhausts the budget', async () => {
+    // The serial path rethrows the raw tool error on the fatal round; the concurrent path is the
+    // one that aggregates the round's failures into the limit error. The thrown type is public
+    // API — callers catch it with `instanceof` — so this test pins the class, not just a message.
+    const failing = tool({
+      name: 'boom',
+      description: 'd',
+      parameters: echoSchema,
+      execute: async () => {
+        throw new Error('kaboom');
+      },
+    });
+    const inner = new MockChatClient([
+      { contents: [call('c1', 'boom'), call('c2', 'boom')], finishReason: 'tool_calls' },
+      { contents: [call('c3', 'boom'), call('c4', 'boom')], finishReason: 'tool_calls' },
+    ]);
+
+    await expect(
+      withFunctionInvocation(inner, {
+        maxConsecutiveErrors: 1,
+        allowConcurrentInvocations: true,
+      }).getResponse([], { tools: [failing] } as ChatOptions),
+    ).rejects.toThrow(FunctionInvocationLimitError);
   });
 
   it('does not count unknown-tool rounds toward the consecutive-error budget', async () => {
@@ -751,7 +771,8 @@ describe('generated function_result metadata (Python parity)', () => {
 
   it('carries the call additionalProperties onto success, not_found and failure results', async () => {
     // Python passes `additional_properties=function_call_content.additional_properties` at every
-    // site that answers a call it executed (`_tools.py:1422 / :1475 / :1527 / :1553 / :1616`).
+    // site in `_tools.py` that answers a call it executed — success, tool not found, argument
+    // parsing failure, thrown tool body and middleware termination.
     // Losing it detaches the result from the server that asked for the call.
     const ok = tool({
       name: 'ok',
@@ -809,7 +830,7 @@ describe('generated function_result metadata (Python parity)', () => {
   });
 
   it('carries them onto a rejected approval result too', async () => {
-    // Python's rejection path does the same (`_tools.py:2439`).
+    // Python's rejection path in `_tools.py` does the same.
     const gated = tool({
       name: 'gated',
       description: 'Needs a human',
@@ -903,8 +924,8 @@ describe('toolChoice across the approval boundary (Go parity)', () => {
   }
 
   it('keeps required when the turn carried only a rejection', async () => {
-    // Go relaxes `required` only when `invokeApprovedToolApprovalResponses` produced a message,
-    // i.e. only when an approved call actually ran (`autocall.go:196`, `:629-644`). A turn that
+    // Go relaxes `required` only when `invokeApprovedToolApprovalResponses` produced a message
+    // (`autocall.go`), i.e. only when an approved call actually ran. A turn that
     // answered nothing has not satisfied the `required` demand yet.
     const mock = new MockChatClient([{ contents: [textContent('done')], finishReason: 'stop' }]);
     const client = withFunctionInvocation(mock);

--- a/packages/core/src/client/function-invocation.test.ts
+++ b/packages/core/src/client/function-invocation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { assert, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { ConfigurationError, SchemaResolutionError, UserInputRequiredError } from '../errors.js';
 import { functionMiddleware } from '../middleware/middleware.js';
 import { createResponseStream } from '../streaming/response-stream.js';
@@ -15,7 +15,7 @@ import { chatResponseUpdate, mergeChatUpdates } from '../types/response.js';
 import type { ChatClient, ChatClientMetadata, ChatOptions } from './chat-client.js';
 import { FunctionInvocationLimitError } from './function-execution.js';
 import { withFunctionInvocation } from './function-invocation.js';
-import { MockChatClient, must } from './test-support.js';
+import { MockChatClient } from './test-support.js';
 
 function call(
   callId: string,
@@ -63,7 +63,8 @@ describe('withFunctionInvocation', () => {
     expect(resultsOf(allContents).map((r) => r.result)).toEqual(['Tokyo is sunny']);
 
     // The second model call sees user -> assistant(tool_call) -> tool(result).
-    const secondCall = must(inner.calls[1]);
+    const secondCall = inner.calls[1];
+    assert.exists(secondCall);
     expect(secondCall.messages.map((m) => m.role)).toEqual(['user', 'assistant', 'tool']);
   });
 
@@ -826,7 +827,8 @@ describe('generated function_result metadata (Python parity)', () => {
 
     const [result] = resultsOf(response.messages.flatMap((msg) => msg.contents));
     expect(result).toBeDefined();
-    expect('additionalProperties' in must(result)).toBe(false);
+    assert.exists(result);
+    expect('additionalProperties' in result).toBe(false);
   });
 
   it('carries them onto a rejected approval result too', async () => {
@@ -1428,7 +1430,9 @@ describe('conversation chaining between rounds', () => {
     } as ChatOptions);
 
     expect(requests).toHaveLength(2);
-    expect(must(requests[1]).conversationId).toBe('stable_1');
+    const secondRequest = requests[1];
+    assert.exists(secondRequest);
+    expect(secondRequest.conversationId).toBe('stable_1');
   });
 
   it('advances to the reported id when the provider declares no stable ids', async () => {
@@ -1441,7 +1445,9 @@ describe('conversation chaining between rounds', () => {
     } as ChatOptions);
 
     expect(requests).toHaveLength(2);
-    expect(must(requests[1]).conversationId).toBe('resp_r1');
+    const secondRequest = requests[1];
+    assert.exists(secondRequest);
+    expect(secondRequest.conversationId).toBe('resp_r1');
   });
 
   it('advances a non-stable id even when the provider declares a stable spelling', async () => {
@@ -1455,6 +1461,8 @@ describe('conversation chaining between rounds', () => {
     } as ChatOptions);
 
     expect(requests).toHaveLength(2);
-    expect(must(requests[1]).conversationId).toBe('resp_r1');
+    const secondRequest = requests[1];
+    assert.exists(secondRequest);
+    expect(secondRequest.conversationId).toBe('resp_r1');
   });
 });

--- a/packages/core/src/client/function-invocation.ts
+++ b/packages/core/src/client/function-invocation.ts
@@ -1,5 +1,5 @@
 import type { AgentSession } from '../agent/session.js';
-import { throwIfAborted, validateSafeInteger } from '../errors.js';
+import { validateSafeInteger } from '../errors.js';
 import type { FunctionMiddleware } from '../middleware/middleware.js';
 import { createResponseStream } from '../streaming/response-stream.js';
 import {
@@ -66,8 +66,21 @@ const DEFAULT_MAX_ITERATIONS = 40;
 const DEFAULT_MAX_CONSECUTIVE_ERRORS = 3;
 
 /** A `function_call` this layer is expected to act on, rather than one the provider already ran. */
-function isPendingCall(content: Content): content is FunctionCallContent {
+export function isPendingCall(content: Content): content is FunctionCallContent {
   return content.type === 'function_call' && content.informationalOnly !== true;
+}
+
+/** Collects the `callId`s answered by a `function_result` anywhere in the transcript. */
+export function answeredCallIds(messages: readonly Message[]): Set<string> {
+  const answered = new Set<string>();
+  for (const msg of messages) {
+    for (const content of msg.contents) {
+      if (content.type === 'function_result') {
+        answered.add(content.callId);
+      }
+    }
+  }
+  return answered;
 }
 
 function buildToolMap(
@@ -163,19 +176,12 @@ function optionsForNextIteration<TOptions extends ChatOptions>(
  * mutated: the caller's messages and any previously returned response stay immutable.
  */
 function collectExecutableCalls(messages: Message[]): FunctionCallContent[] {
-  const answered = new Set<string>();
-  for (const msg of messages) {
-    for (const content of msg.contents) {
-      if (content.type === 'function_result') {
-        answered.add(content.callId);
-      }
-    }
-  }
+  const answered = answeredCallIds(messages);
   const calls: FunctionCallContent[] = [];
   const seen = new Set<string>();
   for (const msg of messages) {
     for (const content of msg.contents) {
-      if (content.type !== 'function_call' || content.informationalOnly === true) {
+      if (!isPendingCall(content)) {
         continue;
       }
       if (answered.has(content.callId)) {
@@ -592,7 +598,7 @@ export function createFunctionInvocationClientFactory<TOptions extends ChatOptio
     }
     // Only a round that actually *ran* something advances the options. Go gates the same call on
     // `newMsg != nil` — the message `invokeApprovedToolApprovalResponses` produces, which is `nil`
-    // when there are no approved calls (`autocall.go:196` and `:629-644`). A turn that carried only
+    // when there are no approved calls (Go `autocall.go`). A turn that carried only
     // rejections, or only stale approval requests, has not answered the model yet, so relaxing
     // `toolChoice: 'required'` to `'auto'` there lets the model reply with prose to a request that
     // demanded a tool call. The loop below still relaxes after the first real round, which is what
@@ -602,7 +608,7 @@ export function createFunctionInvocationClientFactory<TOptions extends ChatOptio
     }
 
     for (let iteration = 0; ; iteration++) {
-      throwIfAborted(signal);
+      signal?.throwIfAborted();
       const isFinalIteration = iteration >= maxIterations;
       const roundOptions = isFinalIteration ? withoutFunctionTools(current) : current;
       const tools = buildToolMap(roundOptions.tools, additionalTools);
@@ -627,9 +633,7 @@ export function createFunctionInvocationClientFactory<TOptions extends ChatOptio
           }
         }
       } else {
-        for (const update of chatResponseToUpdates(await inner)) {
-          updates.push(update);
-        }
+        updates.push(...chatResponseToUpdates(await inner));
         if (!mayRequireApproval) {
           for (const update of updates) {
             flushed++;

--- a/packages/core/src/client/provider-utils.ts
+++ b/packages/core/src/client/provider-utils.ts
@@ -4,6 +4,11 @@
  * streaming interface.
  */
 
+import { ConfigurationError } from '../errors.js';
+import type { ChatResponseUpdate } from '../types/response.js';
+import { chatResponseToUpdates } from '../types/response.js';
+import type { ChatResponseStream } from './chat-client.js';
+
 /**
  * Assigns `value` to `target[key]` unless the value is `undefined`.
  *
@@ -27,6 +32,44 @@ export function withoutUndefined(spec: Record<string, unknown>): Record<string, 
 }
 
 /**
+ * JSON-encodes `value`, degrading to `String(value)` and then `'[unserializable]'`.
+ *
+ * `JSON.stringify` throws on a cycle or a `BigInt`, and answers `undefined` for a symbol or a
+ * function. A wire mapper renders a transcript that already exists, so failing the whole request
+ * over one unencodable value is not an option — and the value's string form still says
+ * *something* about what it was, mirroring Python's `json.dumps` falling back to `str()`.
+ */
+export function safeStringify(value: unknown): string {
+  const fallback = (): string => {
+    try {
+      return String(value);
+    } catch {
+      return '[unserializable]';
+    }
+  };
+  try {
+    return JSON.stringify(value) ?? fallback();
+  } catch {
+    return fallback();
+  }
+}
+
+/**
+ * Validates and normalizes a hosted MCP tool's server label.
+ *
+ * A blank label is a configuration mistake and is refused. Spaces become underscores: the
+ * provider APIs reject labels containing spaces, and Python's `get_mcp_tool` applies the same
+ * substitution. Only spaces are replaced — matching the reference implementation exactly rather
+ * than sanitising every character an API might dislike.
+ */
+export function normalizeServerLabel(serverLabel: string): string {
+  if (serverLabel.trim() === '') {
+    throw new ConfigurationError('mcpTool requires a non-empty serverLabel.');
+  }
+  return serverLabel.replaceAll(' ', '_');
+}
+
+/**
  * Returns the lowercased top-level type of an IANA media type (`'image/PNG'` → `'image'`), or an
  * empty string when `mediaType` is `undefined`.
  *
@@ -47,5 +90,30 @@ export function topLevelMediaType(mediaType: string | undefined): string {
 export async function* arrayToStream<T>(items: readonly T[]): AsyncGenerator<T> {
   for (const item of items) {
     yield item;
+  }
+}
+
+/**
+ * The updates of an inner {@link ChatResponseStream}, consumed the way the outer caller consumes
+ * the wrapping layer.
+ *
+ * This is the relay every chat-client layer needs: iterating the inner stream propagates the
+ * streaming transport choice inward, while a caller that awaited must make the inner call await
+ * too — iterating it instead would silently switch the provider to a streaming transport. The
+ * awaited response is exploded back into updates so the layer's own per-update handling runs
+ * identically in both modes, which is what keeps a streamed run and an awaited run producing the
+ * same transcript through any stack of layers.
+ *
+ * Consumes `inner` either way, so the caller must not also await or iterate it — read the folded
+ * result from `inner.finalResponse()` afterwards instead.
+ */
+export async function* updatesOf(
+  inner: ChatResponseStream<unknown>,
+  streaming: boolean,
+): AsyncGenerator<ChatResponseUpdate> {
+  if (streaming) {
+    yield* inner;
+  } else {
+    yield* chatResponseToUpdates(await inner);
   }
 }

--- a/packages/core/src/client/structured-output.ts
+++ b/packages/core/src/client/structured-output.ts
@@ -5,8 +5,7 @@ import { resolveJsonSchema } from '../tools/json-schema.js';
 import type { StandardSchemaV1 } from '../tools/standard-schema.js';
 import { formatSchemaIssues, isStandardSchema } from '../tools/standard-schema.js';
 import { isUserInputRequest } from '../types/content.js';
-import type { ChatResponseUpdate, ResponseBase } from '../types/response.js';
-import { chatResponseToUpdates } from '../types/response.js';
+import type { ResponseBase } from '../types/response.js';
 import type {
   ChatClient,
   ChatOptions,
@@ -14,6 +13,8 @@ import type {
   JsonSchemaResponseFormat,
   ResponseFormat,
 } from './chat-client.js';
+import { answeredCallIds, isPendingCall } from './function-invocation.js';
+import { updatesOf } from './provider-utils.js';
 
 /** A {@link ResponseFormat} reduced to what a provider request needs. */
 export interface ResolvedResponseFormat {
@@ -76,21 +77,11 @@ function isSuspended(response: ResponseBase<unknown>): boolean {
   if (response.continuationToken !== undefined) {
     return true;
   }
-  const resultCallIds = new Set<string>();
-  for (const msg of response.messages) {
-    for (const content of msg.contents) {
-      if (content.type === 'function_result') {
-        resultCallIds.add(content.callId);
-      }
-    }
-  }
+  const resultCallIds = answeredCallIds(response.messages);
   return response.messages.some((msg) =>
     msg.contents.some(
       (content) =>
-        isUserInputRequest(content) ||
-        (content.type === 'function_call' &&
-          content.informationalOnly !== true &&
-          !resultCallIds.has(content.callId)),
+        isUserInputRequest(content) || (isPendingCall(content) && !resultCallIds.has(content.callId)),
     ),
   );
 }
@@ -176,24 +167,23 @@ export async function applyStructuredOutput<TResponse extends ResponseBase<unkno
     throw new ChatClientError('Structured output was requested but the model returned no text.');
   }
 
+  const invalidJson = (cause: unknown): ChatClientError =>
+    new ChatClientError(
+      `Structured output was requested but the model returned text that is not valid JSON: ${text.slice(0, 200)}`,
+      { cause },
+    );
   let parsed: unknown;
   try {
     parsed = JSON.parse(text) as unknown;
   } catch (error) {
     const first = sliceFirstTopLevelValue(text);
     if (first === undefined) {
-      throw new ChatClientError(
-        `Structured output was requested but the model returned text that is not valid JSON: ${text.slice(0, 200)}`,
-        { cause: error },
-      );
+      throw invalidJson(error);
     }
     try {
       parsed = JSON.parse(first) as unknown;
     } catch (innerError) {
-      throw new ChatClientError(
-        `Structured output was requested but the model returned text that is not valid JSON: ${text.slice(0, 200)}`,
-        { cause: innerError },
-      );
+      throw invalidJson(innerError);
     }
   }
 
@@ -228,15 +218,8 @@ export function withStructuredOutput<TOptions extends ChatOptions>(
       if (format === undefined) {
         return inner;
       }
-      const relay = async function* (stream: boolean): AsyncGenerator<ChatResponseUpdate> {
-        if (stream) {
-          yield* inner;
-        } else {
-          yield* chatResponseToUpdates(await inner);
-        }
-      };
       return createResponseStream({
-        start: (ctx) => relay(ctx.stream),
+        start: (ctx) => updatesOf(inner, ctx.stream),
         finalize: async () => inner.finalResponse(),
         // Parsing is a result hook rather than part of `finalize` so it can see whether the caller
         // abandoned the stream: a `break` leaves a truncated answer that was never meant to be a

--- a/packages/core/src/client/telemetry.ts
+++ b/packages/core/src/client/telemetry.ts
@@ -1,4 +1,5 @@
 import type { Attributes, Span } from '@opentelemetry/api';
+import { errorTypeOf } from '../errors.js';
 import { GEN_AI, GEN_AI_OPERATION } from '../observability/attributes.js';
 import { recordChatMetrics } from '../observability/metrics.js';
 import {
@@ -100,9 +101,7 @@ export function withChatTelemetry<TOptions extends ChatOptions>(
           attributes: metricAttributes,
           usage: folded?.usageDetails,
           ...(startedAt === undefined ? {} : { durationSeconds: (performance.now() - startedAt) / 1000 }),
-          ...(failure === undefined
-            ? {}
-            : { errorType: failure instanceof Error ? failure.name : typeof failure }),
+          ...(failure === undefined ? {} : { errorType: errorTypeOf(failure) }),
         });
       };
 

--- a/packages/core/src/client/test-support.ts
+++ b/packages/core/src/client/test-support.ts
@@ -111,5 +111,3 @@ export class MockChatClient implements ChatClient<ChatOptions> {
     });
   }
 }
-
-export { must } from '../must.js';

--- a/packages/core/src/client/test-support.ts
+++ b/packages/core/src/client/test-support.ts
@@ -111,3 +111,5 @@ export class MockChatClient implements ChatClient<ChatOptions> {
     });
   }
 }
+
+export { must } from '../must.js';

--- a/packages/core/src/client/tool-approval.test.ts
+++ b/packages/core/src/client/tool-approval.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import { Agent } from '../agent/agent.js';
 import { AgentSession } from '../agent/session.js';
 import {
@@ -16,7 +16,7 @@ import type {
 } from '../types/content.js';
 import { textContent } from '../types/content.js';
 import type { Message } from '../types/message.js';
-import { MockChatClient, must } from './test-support.js';
+import { MockChatClient } from './test-support.js';
 
 const deleteAll = tool({
   name: 'delete_all',
@@ -78,7 +78,9 @@ describe('tool approval', () => {
     const session = agent.createSession();
 
     const first = await agent.run('delete everything', { session });
-    const resumed = await agent.run(approvalResponse(must(approvals(first)[0]), true), { session });
+    const request = approvals(first)[0];
+    assert.exists(request);
+    const resumed = await agent.run(approvalResponse(request, true), { session });
 
     expect(results(resumed.messages)).toEqual([['c1', 'deleted']]);
     expect(resumed.text).toBe('all gone');
@@ -99,12 +101,11 @@ describe('tool approval', () => {
     const session = agent.createSession();
 
     const first = await agent.run('delete everything', { session });
-    const resumed = await agent.run(
-      approvalResponse(must(approvals(first)[0]), false, { reason: 'too risky' }),
-      {
-        session,
-      },
-    );
+    const request = approvals(first)[0];
+    assert.exists(request);
+    const resumed = await agent.run(approvalResponse(request, false, { reason: 'too risky' }), {
+      session,
+    });
 
     expect(results(resumed.messages)).toEqual([
       ['c1', 'Error: Tool call invocation was rejected by user. too risky'],
@@ -140,13 +141,15 @@ describe('tool approval', () => {
 
     const first = await agent.run('do both', { session });
     const [firstRequest, secondRequest] = approvals(first);
-    const partial = await agent.run(approvalResponse(must(firstRequest), true), { session });
+    assert.exists(firstRequest);
+    const partial = await agent.run(approvalResponse(firstRequest, true), { session });
 
     expect(executed).toEqual(['first']);
     expect(mock.callCount).toBe(1);
     expect(approvals(partial).map((request) => request.functionCall.callId)).toEqual(['c2']);
 
-    const resumed = await agent.run(approvalResponse(must(secondRequest), true), { session });
+    assert.exists(secondRequest);
+    const resumed = await agent.run(approvalResponse(secondRequest, true), { session });
     expect(executed).toEqual(['first', 'second']);
     expect(resumed.text).toBe('done');
     expect(session.state._toolApproval).toBeUndefined();
@@ -213,7 +216,9 @@ describe('tool approval', () => {
     const session = agent.createSession();
 
     const first = await agent.run('delete', { session });
-    const decision = approvalResponse(must(approvals(first)[0]), true);
+    const request = approvals(first)[0];
+    assert.exists(request);
+    const decision = approvalResponse(request, true);
     // The caller escalates the approved call before sending it back.
     const tampered: FunctionApprovalResponseContent = {
       ...decision,
@@ -256,7 +261,8 @@ describe('tool approval', () => {
     const session = agent.createSession();
 
     const first = await agent.run('delete', { session });
-    const request = must(approvals(first)[0]);
+    const request = approvals(first)[0];
+    assert.exists(request);
     const decision = approvalResponse(structuredClone(request), true);
     const args = request.functionCall.arguments as { scope: { target: string } };
     args.scope.target = 'everything';
@@ -378,7 +384,8 @@ describe('tool approval', () => {
     const session = agent.createSession();
 
     const first = await agent.run('delete', { session });
-    const request = must(approvals(first)[0]);
+    const request = approvals(first)[0];
+    assert.exists(request);
     // A caller that replays the whole transcript can send the request back too — with different
     // arguments. The session's own record of what the human saw has to outrank it.
     const replayed: Content = {
@@ -399,7 +406,8 @@ describe('tool approval', () => {
     const agent = new Agent({ client: mock, tools: [deleteAll] });
 
     const session = agent.createSession();
-    const request = must(approvals(await agent.run('delete', { session }))[0]);
+    const request = approvals(await agent.run('delete', { session }))[0];
+    assert.exists(request);
     // The human answers in another process, so only the serialized session bridges the turns.
     const roundTripped = AgentSession.fromJSON(JSON.parse(JSON.stringify(session)) as unknown);
 
@@ -423,7 +431,9 @@ describe('tool approval', () => {
     // Only the approval-required call reaches the caller.
     expect(approvals(first).map((r) => r.functionCall.name)).toEqual(['delete_all']);
 
-    const resumed = await agent.run(approvalResponse(must(approvals(first)[0]), true), { session });
+    const request = approvals(first)[0];
+    assert.exists(request);
+    const resumed = await agent.run(approvalResponse(request, true), { session });
 
     // Both calls run once the human answers: the model needs a result for every call it made.
     expect(results(resumed.messages).sort()).toEqual([
@@ -458,13 +468,17 @@ describe('tool approval', () => {
     expect(first.userInputRequests).toHaveLength(1);
     expect(approvals(first)[0]?.id).toBe('mcpr_1');
 
-    const resumed = await agent.run(approvalResponse(must(approvals(first)[0]), true), { session });
+    const request = approvals(first)[0];
+    assert.exists(request);
+    const resumed = await agent.run(approvalResponse(request, true), { session });
 
     // No local execution, and above all no fabricated "not found" result: the tool is not ours.
     expect(results(resumed.messages)).toEqual([]);
     // The decision reaches the provider as approval content, which is what becomes the wire
     // `mcp_approval_response`. Stripping it here is what left the approval pending forever.
-    const sent = must(mock.calls[1]).messages.flatMap((msg) => msg.contents);
+    const secondCall = mock.calls[1];
+    assert.exists(secondCall);
+    const sent = secondCall.messages.flatMap((msg) => msg.contents);
     const decision = sent.find((content) => content.type === 'function_approval_response');
     expect(decision).toMatchObject({ id: 'mcpr_1', approved: true });
     expect(resumed.text).toBe('found three');
@@ -508,7 +522,9 @@ describe('tool approval', () => {
     expect(first.userInputRequests).toHaveLength(1);
     expect(approvals(first)[0]?.functionCall.arguments).toBe('{"scope":"all"}');
 
-    const resumed = await agent.run(approvalResponse(must(approvals(first)[0]), true), { session });
+    const request = approvals(first)[0];
+    assert.exists(request);
+    const resumed = await agent.run(approvalResponse(request, true), { session });
     expect(executed).toEqual([{ scope: 'all' }]);
     expect(resumed.text).toBe('all gone');
   });
@@ -566,7 +582,9 @@ describe('tool approval', () => {
     const first = await stream.finalResponse();
     expect(first.userInputRequests).toHaveLength(1);
 
-    const resumeStream = agent.run(approvalResponse(must(approvals(first)[0]), true), { session });
+    const request = approvals(first)[0];
+    assert.exists(request);
+    const resumeStream = agent.run(approvalResponse(request, true), { session });
     for await (const _ of resumeStream) {
       // drain
     }
@@ -612,9 +630,9 @@ describe('tool approval', () => {
     const first = await agent.run('go', { session });
     expect(approvals(first)).toHaveLength(1);
 
-    await expect(agent.run(approvalResponse(must(approvals(first)[0]), true), { session })).rejects.toThrow(
-      'kaboom2',
-    );
+    const request = approvals(first)[0];
+    assert.exists(request);
+    await expect(agent.run(approvalResponse(request, true), { session })).rejects.toThrow('kaboom2');
   });
 
   it('reads a legacy additionalProperties reason when no first-class reason is present', async () => {
@@ -628,7 +646,8 @@ describe('tool approval', () => {
     const session = agent.createSession();
 
     const first = await agent.run('delete everything', { session });
-    const request = must(approvals(first)[0]);
+    const request = approvals(first)[0];
+    assert.exists(request);
     const legacy: FunctionApprovalResponseContent = {
       type: 'function_approval_response',
       id: request.id,

--- a/packages/core/src/client/tool-approval.test.ts
+++ b/packages/core/src/client/tool-approval.test.ts
@@ -16,7 +16,7 @@ import type {
 } from '../types/content.js';
 import { textContent } from '../types/content.js';
 import type { Message } from '../types/message.js';
-import { MockChatClient } from './test-support.js';
+import { MockChatClient, must } from './test-support.js';
 
 const deleteAll = tool({
   name: 'delete_all',
@@ -35,12 +35,6 @@ const readOnly = tool({
 
 function call(callId: string, name: string): FunctionCallContent {
   return { type: 'function_call', callId, name, arguments: '{}' };
-}
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
 }
 
 /** Every `function_result` in a transcript, as `[callId, result]`. */

--- a/packages/core/src/client/tool-approval.ts
+++ b/packages/core/src/client/tool-approval.ts
@@ -10,10 +10,12 @@ import {
 import type { AnyFunctionTool, Tool } from '../tools/tool.js';
 import { isFunctionTool } from '../tools/tool.js';
 import type { Content, FunctionApprovalRequestContent, FunctionCallContent } from '../types/content.js';
+import { isRecord } from '../types/content.js';
 import type { Message } from '../types/message.js';
 import type { ChatResponseUpdate } from '../types/response.js';
-import { chatResponseToUpdates, chatResponseUpdate, mergeChatUpdates } from '../types/response.js';
+import { chatResponseUpdate, mergeChatUpdates } from '../types/response.js';
 import type { ChatClient, ChatOptions, ChatResponseStream } from './chat-client.js';
+import { updatesOf } from './provider-utils.js';
 
 /** The {@link AgentSession.state} slot this layer owns. */
 export const APPROVAL_STATE_KEY = '_toolApproval';
@@ -79,9 +81,7 @@ function readSlot(state: Record<string, unknown>, key: string): FunctionApproval
 export function sessionApprovalStore(session: AgentSession): ApprovalStateStore {
   const peek = (): Record<string, unknown> => {
     const existing = session.state[APPROVAL_STATE_KEY];
-    return typeof existing === 'object' && existing !== null && !Array.isArray(existing)
-      ? (existing as Record<string, unknown>)
-      : {};
+    return isRecord(existing) ? existing : {};
   };
   const take = (slot: string): FunctionApprovalRequestContent[] => {
     const state = peek();
@@ -342,14 +342,8 @@ export function withToolApproval<TOptions extends ChatOptions>(
         };
 
         try {
-          if (stream) {
-            for await (const update of inner) {
-              yield* handle(update);
-            }
-          } else {
-            for (const update of chatResponseToUpdates(await inner)) {
-              yield* handle(update);
-            }
+          for await (const update of updatesOf(inner, stream)) {
+            yield* handle(update);
           }
         } finally {
           // `finally` so an abandoned stream still records what it surfaced; otherwise the caller

--- a/packages/core/src/context/context-provider.ts
+++ b/packages/core/src/context/context-provider.ts
@@ -80,7 +80,7 @@ export interface ContextProvider {
 }
 
 /** The provenance stamped on messages a provider injects. */
-export function sourceTypeOf(provider: ContextProvider): MessageSourceType {
+function sourceTypeOf(provider: ContextProvider): MessageSourceType {
   return isHistoryProvider(provider) ? 'ChatHistory' : 'AIContextProvider';
 }
 

--- a/packages/core/src/context/history-store.ts
+++ b/packages/core/src/context/history-store.ts
@@ -1,6 +1,11 @@
 import type { Message, MessageFilter } from '../types/message.js';
 import { notSourceTypes, passThrough } from '../types/message.js';
-import type { HistoryStoreOptions, ProviderAfterRunContext } from './context-provider.js';
+import type {
+  HistoryProvider,
+  HistoryStoreOptions,
+  ProviderAfterRunContext,
+  ProviderRunContext,
+} from './context-provider.js';
 import { selectContextMessages } from './context-provider.js';
 
 /** {@link HistoryStoreOptions} with the defaults filled in. */
@@ -30,10 +35,7 @@ export function resolveHistoryStoreOptions(options?: HistoryStoreOptions): Resol
  * Empty for a run that failed: it produced no exchange, and storing the input on its own would
  * leave an unanswered question for the next run to replay.
  */
-export function messagesToStore(
-  ctx: ProviderAfterRunContext,
-  options: ResolvedHistoryStoreOptions,
-): Message[] {
+function messagesToStore(ctx: ProviderAfterRunContext, options: ResolvedHistoryStoreOptions): Message[] {
   if (ctx.response === undefined) {
     return [];
   }
@@ -42,4 +44,41 @@ export function messagesToStore(
     ...ctx.inputMessages,
     ...ctx.response.messages,
   ]);
+}
+
+/**
+ * The `beforeRun` every bundled history provider performs: replay the stored transcript.
+ *
+ * A provider differs from its siblings only in where the messages live, which is
+ * {@link HistoryProvider.getMessages}. What happens around that call — which messages the filter
+ * lets through, and that an empty transcript contributes nothing rather than an empty message —
+ * is the same for all of them, so it is written here instead of being copied into each one.
+ */
+export async function replayStoredHistory(
+  provider: HistoryProvider,
+  ctx: ProviderRunContext,
+  options: ResolvedHistoryStoreOptions,
+): Promise<void> {
+  const history = options.provideFilter(await provider.getMessages(ctx.session, ctx.state));
+  if (history.length > 0) {
+    ctx.extendMessages(history);
+  }
+}
+
+/**
+ * The `afterRun` every bundled history provider performs: append what the run produced.
+ *
+ * The counterpart of {@link replayStoredHistory}, over {@link HistoryProvider.saveMessages}. A run
+ * with nothing to append does not reach the store at all, so a provider never has to treat an
+ * empty write as a special case.
+ */
+export async function persistRunHistory(
+  provider: HistoryProvider,
+  ctx: ProviderAfterRunContext,
+  options: ResolvedHistoryStoreOptions,
+): Promise<void> {
+  const toSave = messagesToStore(ctx, options);
+  if (toSave.length > 0) {
+    await provider.saveMessages(ctx.session, toSave, ctx.state);
+  }
 }

--- a/packages/core/src/context/in-memory-history-provider.ts
+++ b/packages/core/src/context/in-memory-history-provider.ts
@@ -9,7 +9,7 @@ import type {
   ProviderRunContext,
 } from './context-provider.js';
 import type { ResolvedHistoryStoreOptions } from './history-store.js';
-import { messagesToStore, resolveHistoryStoreOptions } from './history-store.js';
+import { persistRunHistory, replayStoredHistory, resolveHistoryStoreOptions } from './history-store.js';
 
 const MESSAGES_KEY = 'messages';
 
@@ -66,16 +66,10 @@ export class InMemoryHistoryProvider implements HistoryProvider {
   }
 
   async beforeRun(ctx: ProviderRunContext): Promise<void> {
-    const history = this.#options.provideFilter(await this.getMessages(ctx.session, ctx.state));
-    if (history.length > 0) {
-      ctx.extendMessages(history);
-    }
+    await replayStoredHistory(this, ctx, this.#options);
   }
 
   async afterRun(ctx: ProviderAfterRunContext): Promise<void> {
-    const toSave = messagesToStore(ctx, this.#options);
-    if (toSave.length > 0) {
-      await this.saveMessages(ctx.session, toSave, ctx.state);
-    }
+    await persistRunHistory(this, ctx, this.#options);
   }
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -138,17 +138,12 @@ export function validateSafeInteger(name: string, value: number, minimum: number
   return value;
 }
 
-/**
- * Throws the abort reason when `signal` is already aborted.
- *
- * The thrown value is whatever the caller's {@link AbortController} carries — by default a
- * `DOMException` named `AbortError`, per the web standard.
- */
-export function throwIfAborted(signal?: AbortSignal): void {
-  signal?.throwIfAborted();
-}
-
 /** The human-readable summary of a thrown value: `error.message` for an `Error`, `String(error)` otherwise. */
 export function errorMessageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/** The classification of a thrown value for telemetry: `error.name` for an `Error`, `typeof` otherwise. */
+export function errorTypeOf(error: unknown): string {
+  return error instanceof Error ? error.name : typeof error;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,7 +77,6 @@ export type {
   FunctionMiddlewareContext,
   Middleware,
   MiddlewareHandler,
-  MiddlewareKind,
 } from './middleware/middleware.js';
 export {
   agentMiddleware,
@@ -231,7 +230,13 @@ export type {
   UsageContent,
   UserInputRequestContent,
 } from './types/content.js';
-export { dataContent, textContent, textOfContents, unknownContent, uriContent } from './types/content.js';
+export {
+  dataContent,
+  textContent,
+  textOfContents,
+  unknownContent,
+  uriContent,
+} from './types/content.js';
 // messages
 export type {
   AgentRunInput,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -12,6 +12,4 @@
 export { answeredCallIds } from './client/function-invocation.js';
 export { normalizeServerLabel, safeStringify } from './client/provider-utils.js';
 export { errorMessageOf, validateSafeInteger } from './errors.js';
-// Test-only internal helper; not part of the supported `/testing` API.
-export { must } from './must.js';
 export { isRecord } from './types/content.js';

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal contract between the framework's own packages — not part of the documented surface.
+ *
+ * These are the utilities the provider packages share so that one rule (error rendering, integer
+ * validation, record narrowing, wire-string degradation, MCP label normalization, answered-call
+ * bookkeeping) has exactly one implementation. None of them has a public counterpart in the
+ * reference implementations, so none of them belongs on the package's supported surface.
+ * Everything exported here may change or disappear in any release; import from
+ * `@polymind-inc/agent-framework-core` instead for the supported surface.
+ */
+
+export { answeredCallIds } from './client/function-invocation.js';
+export { normalizeServerLabel, safeStringify } from './client/provider-utils.js';
+export { errorMessageOf, validateSafeInteger } from './errors.js';
+// Test-only internal helper; not part of the supported `/testing` API.
+export { must } from './must.js';
+export { isRecord } from './types/content.js';

--- a/packages/core/src/middleware/agent-pipeline.ts
+++ b/packages/core/src/middleware/agent-pipeline.ts
@@ -1,6 +1,7 @@
 import type { AgentSession } from '../agent/session.js';
 import { MiddlewareTerminated } from '../errors.js';
 import type { ResponseStream } from '../streaming/response-stream.js';
+import { applyHooks } from '../streaming/response-stream.js';
 import type { Tool } from '../tools/tool.js';
 import type { Message } from '../types/message.js';
 import type { AgentResponse, AgentResponseUpdate } from '../types/response.js';
@@ -105,16 +106,8 @@ export async function runAgentPipeline<TFinal extends AgentResponse<unknown>>(
     }
   }
 
-  const applyResultHooks = async (response: AgentResponse<unknown>): Promise<TFinal> => {
-    let current = response;
-    for (const hook of resultHooks) {
-      const hooked = await hook(current);
-      if (hooked !== undefined && hooked !== null) {
-        current = hooked;
-      }
-    }
-    return current as TFinal;
-  };
+  const applyResultHooks = async (response: AgentResponse<unknown>): Promise<TFinal> =>
+    (await applyHooks(response, resultHooks)) as TFinal;
 
   if (ctx.response !== undefined) {
     const response = ctx.response;
@@ -172,12 +165,7 @@ async function* transform(
 
       let current = result.value;
       try {
-        for (const hook of hooks) {
-          const hooked = await hook(current);
-          if (hooked !== undefined && hooked !== null) {
-            current = hooked;
-          }
-        }
+        current = await applyHooks(current, hooks);
       } catch (error) {
         // A hook failure is a failure of the run, not an early consumer `break`. Forward it into
         // the ResponseStream so its cleanup observes the error and history does not persist a

--- a/packages/core/src/middleware/middleware.ts
+++ b/packages/core/src/middleware/middleware.ts
@@ -6,17 +6,6 @@ import type { AnyFunctionTool, Tool } from '../tools/tool.js';
 import type { Message } from '../types/message.js';
 import type { AgentResponse, AgentResponseUpdate } from '../types/response.js';
 
-/**
- * What a middleware intercepts.
- *
- * Two kinds are public in v1: `agent` wraps a whole `run()`, `function` wraps
- * a single tool invocation. Interception of individual model calls stays an internal concern —
- * telemetry, the function-calling loop and the approval layer are implemented as chat-client
- * layers (`withChatTelemetry`, `withFunctionInvocation`, `withToolApproval`), and a public chat
- * middleware would be a second way to do the same thing.
- */
-export type MiddlewareKind = 'agent' | 'function';
-
 /** The `(ctx, next)` signature every middleware handler follows. */
 export type MiddlewareHandler<TContext> = (ctx: TContext, next: () => Promise<void>) => Promise<void> | void;
 
@@ -36,7 +25,15 @@ export interface FunctionMiddleware {
   readonly name?: string;
 }
 
-/** Anything accepted where middleware is collected. */
+/**
+ * Anything accepted where middleware is collected.
+ *
+ * Two kinds exist, and the `kind` discriminant says which layer a middleware wraps: `agent` wraps
+ * a whole `run()`, `function` wraps a single tool invocation. Interception of individual model
+ * calls stays an internal concern — telemetry, the function-calling loop and the approval layer
+ * are implemented as chat-client layers (`withChatTelemetry`, `withFunctionInvocation`,
+ * `withToolApproval`), and a public chat middleware would be a second way to do the same thing.
+ */
 export type Middleware = AgentMiddleware | FunctionMiddleware;
 
 /**
@@ -161,8 +158,13 @@ export function agentMiddleware(
   handler: MiddlewareHandler<AgentMiddlewareContext>,
   options?: { name?: string },
 ): AgentMiddleware {
+  return { kind: 'agent', handler, ...middlewareName(handler, options) };
+}
+
+/** The shared name resolution: an explicit option wins, then the handler's own function name. */
+function middlewareName(handler: MiddlewareHandler<never>, options?: { name?: string }): { name?: string } {
   const name = options?.name ?? (handler.name === '' ? undefined : handler.name);
-  return { kind: 'agent', handler, ...(name === undefined ? {} : { name }) };
+  return name === undefined ? {} : { name };
 }
 
 /**
@@ -180,8 +182,7 @@ export function functionMiddleware(
   handler: MiddlewareHandler<FunctionMiddlewareContext>,
   options?: { name?: string },
 ): FunctionMiddleware {
-  const name = options?.name ?? (handler.name === '' ? undefined : handler.name);
-  return { kind: 'function', handler, ...(name === undefined ? {} : { name }) };
+  return { kind: 'function', handler, ...middlewareName(handler, options) };
 }
 
 /** Middleware split by kind. */

--- a/packages/core/src/must.ts
+++ b/packages/core/src/must.ts
@@ -1,0 +1,5 @@
+/** Narrows a nullable value in a test, throwing when it is absent. */
+export function must<T>(value: T | null | undefined): T {
+  if (value == null) throw new Error('expected a value');
+  return value;
+}

--- a/packages/core/src/must.ts
+++ b/packages/core/src/must.ts
@@ -1,5 +1,0 @@
-/** Narrows a nullable value in a test, throwing when it is absent. */
-export function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}

--- a/packages/core/src/node/file-history-provider.ts
+++ b/packages/core/src/node/file-history-provider.ts
@@ -8,7 +8,11 @@ import type {
   ProviderRunContext,
 } from '../context/context-provider.js';
 import type { ResolvedHistoryStoreOptions } from '../context/history-store.js';
-import { messagesToStore, resolveHistoryStoreOptions } from '../context/history-store.js';
+import {
+  persistRunHistory,
+  replayStoredHistory,
+  resolveHistoryStoreOptions,
+} from '../context/history-store.js';
 import { ConfigurationError } from '../errors.js';
 import type { Message } from '../types/message.js';
 import type { SerializedMessage } from '../types/serialization.js';
@@ -230,17 +234,11 @@ export class FileHistoryProvider implements HistoryProvider {
   }
 
   async beforeRun(ctx: ProviderRunContext): Promise<void> {
-    const history = this.#options.provideFilter(await this.getMessages(ctx.session, ctx.state));
-    if (history.length > 0) {
-      ctx.extendMessages(history);
-    }
+    await replayStoredHistory(this, ctx, this.#options);
   }
 
   async afterRun(ctx: ProviderAfterRunContext): Promise<void> {
-    const toSave = messagesToStore(ctx, this.#options);
-    if (toSave.length > 0) {
-      await this.saveMessages(ctx.session, toSave, ctx.state);
-    }
+    await persistRunHistory(this, ctx, this.#options);
   }
 
   async #sessionFile(session: AgentSession): Promise<string> {

--- a/packages/core/src/observability/metrics.ts
+++ b/packages/core/src/observability/metrics.ts
@@ -29,7 +29,7 @@ export const OPERATION_DURATION_BUCKET_BOUNDARIES: readonly number[] = [
  * With no SDK registered this is the API's no-op meter, so instrumentation costs a few property
  * reads and nothing is exported — the same contract as {@link getTracer}.
  */
-export function getMeter(): Meter {
+function getMeter(): Meter {
   return metrics.getMeter(METER_NAME, METER_VERSION);
 }
 
@@ -69,7 +69,7 @@ export const GEN_AI_METRICS = {
 } as const;
 
 /** The `gen_ai.token.type` dimension of the token-usage histogram. */
-export const TOKEN_TYPE = { input: 'input', output: 'output' } as const;
+const TOKEN_TYPE = { input: 'input', output: 'output' } as const;
 
 /**
  * The span attributes that also become metric dimensions.

--- a/packages/core/src/observability/settings.test.ts
+++ b/packages/core/src/observability/settings.test.ts
@@ -15,7 +15,6 @@ describe('captureMessageContent', () => {
   });
 
   afterEach(() => {
-    vi.unstubAllEnvs();
     configureObservability({});
   });
 

--- a/packages/core/src/observability/tracing.test.ts
+++ b/packages/core/src/observability/tracing.test.ts
@@ -6,10 +6,10 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, assert, beforeAll, describe, expect, it } from 'vitest';
 import { Agent } from '../agent/agent.js';
 import { withChatTelemetry } from '../client/telemetry.js';
-import { MockChatClient, must } from '../client/test-support.js';
+import { MockChatClient } from '../client/test-support.js';
 import { tool } from '../tools/tool.js';
 import { textContent } from '../types/content.js';
 import { message } from '../types/message.js';
@@ -88,11 +88,13 @@ describe('GenAI tracing', () => {
 
     await agent.run('weather?');
 
-    const invoke = must(byName('invoke_agent weather-bot'));
-    expect(invoke).toBeDefined();
+    const invoke = byName('invoke_agent weather-bot');
+    assert.exists(invoke);
     // Two model rounds, one tool execution, all under the agent span.
     expect(spans().filter((s) => s.name === 'chat mock-model')).toHaveLength(2);
-    expect(parentOf(must(byName('execute_tool get_weather')))).toBe('invoke_agent weather-bot');
+    const execute = byName('execute_tool get_weather');
+    assert.exists(execute);
+    expect(parentOf(execute)).toBe('invoke_agent weather-bot');
     expect(
       spans()
         .filter((s) => s.name === 'chat mock-model')
@@ -112,7 +114,9 @@ describe('GenAI tracing', () => {
     await expect(agent.run(poisoned)).rejects.toThrow(/BigInt/);
 
     expect(startedSpanNames).toContain('invoke_agent leaky-bot');
-    expect(must(byName('invoke_agent leaky-bot')).status.code).toBe(SpanStatusCode.ERROR);
+    const invoke = byName('invoke_agent leaky-bot');
+    assert.exists(invoke);
+    expect(invoke.status.code).toBe(SpanStatusCode.ERROR);
   });
 
   it('nests the same way when the caller streams', async () => {
@@ -128,7 +132,9 @@ describe('GenAI tracing', () => {
       // drain
     }
 
-    expect(parentOf(must(byName('execute_tool get_weather')))).toBe('invoke_agent weather-bot');
+    const execute = byName('execute_tool get_weather');
+    assert.exists(execute);
+    expect(parentOf(execute)).toBe('invoke_agent weather-bot');
     expect(
       spans()
         .filter((s) => s.name === 'chat mock-model')
@@ -168,7 +174,8 @@ describe('GenAI tracing', () => {
 
     await agent.run('hello');
 
-    const invoke = must(byName('invoke_agent bot'));
+    const invoke = byName('invoke_agent bot');
+    assert.exists(invoke);
     expect(invoke.attributes[GEN_AI.operation]).toBe('invoke_agent');
     expect(invoke.attributes[GEN_AI.agentName]).toBe('bot');
     expect(invoke.attributes[GEN_AI.agentDescription]).toBe('a bot');
@@ -176,7 +183,8 @@ describe('GenAI tracing', () => {
     expect(invoke.attributes[GEN_AI.providerName]).toBe('mock');
     expect(invoke.attributes[GEN_AI.finishReasons]).toEqual(['stop']);
 
-    const chat = must(byName('chat mock-model'));
+    const chat = byName('chat mock-model');
+    assert.exists(chat);
     expect(chat.attributes[GEN_AI.operation]).toBe('chat');
     expect(chat.attributes[GEN_AI.providerName]).toBe('mock');
     expect(chat.attributes[GEN_AI.requestModel]).toBe('mock-model');
@@ -196,7 +204,8 @@ describe('GenAI tracing', () => {
 
     await new Agent({ client: mock, tools: [getWeather] }).run('weather?');
 
-    const execute = must(byName('execute_tool get_weather'));
+    const execute = byName('execute_tool get_weather');
+    assert.exists(execute);
     expect(execute.attributes[GEN_AI.toolName]).toBe('get_weather');
     expect(execute.attributes[GEN_AI.toolCallId]).toBe('call_42');
     expect(execute.attributes[GEN_AI.toolType]).toBe('function');
@@ -222,7 +231,8 @@ describe('GenAI tracing', () => {
     const mock = new MockChatClient([{ contents: [textContent('secret answer')], finishReason: 'stop' }]);
     await new Agent({ client: mock, name: 'bot' }).run('secret question');
 
-    const invoke = must(byName('invoke_agent bot'));
+    const invoke = byName('invoke_agent bot');
+    assert.exists(invoke);
     expect(invoke.attributes[GEN_AI.inputMessages]).toBeUndefined();
     expect(invoke.attributes[GEN_AI.outputMessages]).toBeUndefined();
   });
@@ -234,7 +244,8 @@ describe('GenAI tracing', () => {
     const mock = new MockChatClient([{ contents: [textContent('x')], finishReason: 'stop' }]);
     await new Agent({ client: mock, name: 'bot', instructions: 'You are terse.' }).run('q');
 
-    const chat = must(byName('chat mock-model'));
+    const chat = byName('chat mock-model');
+    assert.exists(chat);
     expect(chat.attributes[GEN_AI.systemInstructions]).toBeUndefined();
   });
 
@@ -243,7 +254,8 @@ describe('GenAI tracing', () => {
     const mock = new MockChatClient([{ contents: [textContent('x')], finishReason: 'stop' }]);
     await new Agent({ client: mock, name: 'bot', instructions: 'You are terse.' }).run('q');
 
-    const chat = must(byName('chat mock-model'));
+    const chat = byName('chat mock-model');
+    assert.exists(chat);
     expect(chat.attributes[GEN_AI.systemInstructions]).toBe(
       JSON.stringify([{ type: 'text', content: 'You are terse.' }]),
     );
@@ -255,7 +267,8 @@ describe('GenAI tracing', () => {
 
     await new Agent({ client: mock, name: 'bot' }).run('the question');
 
-    const invoke = must(byName('invoke_agent bot'));
+    const invoke = byName('invoke_agent bot');
+    assert.exists(invoke);
     expect(String(invoke.attributes[GEN_AI.inputMessages])).toContain('the question');
     expect(String(invoke.attributes[GEN_AI.outputMessages])).toContain('the answer');
   });
@@ -283,7 +296,8 @@ describe('GenAI tracing', () => {
     configureObservability({ captureMessageContent: true });
     await new Agent({ client: new MockChatClient(turns), tools: [getWeather] }).run('x');
 
-    const execute = must(byName('execute_tool get_weather'));
+    const execute = byName('execute_tool get_weather');
+    assert.exists(execute);
     expect(execute.attributes[GEN_AI.toolArguments]).toBe('{"city":"Tokyo"}');
     expect(execute.attributes[GEN_AI.toolResult]).toBe('sunny');
   });
@@ -298,7 +312,8 @@ describe('GenAI tracing', () => {
 
     await expect(new Agent({ client: failing as never, name: 'bot' }).run('x')).rejects.toThrow('boom');
 
-    const invoke = must(byName('invoke_agent bot'));
+    const invoke = byName('invoke_agent bot');
+    assert.exists(invoke);
     expect(invoke.attributes[GEN_AI.errorType]).toBe('Error');
     expect(invoke.status.code).toBe(2);
   });
@@ -330,7 +345,8 @@ describe('GenAI tracing', () => {
     controller.abort(new Error('stop now'));
     await expect(iterator.next()).rejects.toThrow('stop now');
 
-    const invoke = must(byName('invoke_agent bot'));
+    const invoke = byName('invoke_agent bot');
+    assert.exists(invoke);
     expect(invoke.status.code).toBe(2);
     expect(byName('chat mock-model')).toBeDefined();
   });
@@ -345,7 +361,8 @@ describe('GenAI tracing', () => {
     await iterator.next();
     await expect(iterator.throw?.(new Error('consumer bailed'))).rejects.toThrow('consumer bailed');
 
-    const chat = must(byName('chat mock-model'));
+    const chat = byName('chat mock-model');
+    assert.exists(chat);
     expect(chat.status.code).toBe(2);
   });
 });
@@ -383,7 +400,8 @@ describe('startAgentRunSpan', () => {
     );
     span.end();
 
-    const run = must(byName('invoke_agent remote-bot'));
+    const run = byName('invoke_agent remote-bot');
+    assert.exists(run);
     expect(run.attributes[GEN_AI.operation]).toBe('invoke_agent');
     expect(run.attributes[GEN_AI.agentId]).toBe('a1');
     expect(run.attributes[GEN_AI.agentName]).toBe('remote-bot');
@@ -391,7 +409,9 @@ describe('startAgentRunSpan', () => {
     expect(run.attributes[GEN_AI.conversationId]).toBe('ctx-1');
     expect(run.attributes[GEN_AI.responseId]).toBe('resp-1');
     expect(run.attributes[GEN_AI.finishReasons]).toEqual(['stop']);
-    expect(parentOf(must(byName('http POST')))).toBe('invoke_agent remote-bot');
+    const http = byName('http POST');
+    assert.exists(http);
+    expect(parentOf(http)).toBe('invoke_agent remote-bot');
   });
 
   it('records a failure and ends only once', () => {
@@ -401,7 +421,8 @@ describe('startAgentRunSpan', () => {
     span.end();
     span.end();
 
-    const run = must(byName('invoke_agent a1'));
+    const run = byName('invoke_agent a1');
+    assert.exists(run);
     expect(run.status.code).toBe(2);
     expect(run.attributes[GEN_AI.errorType]).toBe('TypeError');
     expect(spans().filter((candidate) => candidate.name === 'invoke_agent a1')).toHaveLength(1);
@@ -412,13 +433,17 @@ describe('startAgentRunSpan', () => {
     const span = startAgentRunSpan({ id: 'a1' }, [{ role: 'user', contents: [textContent('secret')] }]);
     span.end();
 
-    expect(must(byName('invoke_agent a1')).attributes[GEN_AI.inputMessages]).toContain('secret');
+    const captured = byName('invoke_agent a1');
+    assert.exists(captured);
+    expect(captured.attributes[GEN_AI.inputMessages]).toContain('secret');
 
     configureObservability({ captureMessageContent: false });
     const quiet = startAgentRunSpan({ id: 'a2' }, [{ role: 'user', contents: [textContent('secret')] }]);
     quiet.end();
 
-    expect(must(byName('invoke_agent a2')).attributes[GEN_AI.inputMessages]).toBeUndefined();
+    const quietSpan = byName('invoke_agent a2');
+    assert.exists(quietSpan);
+    expect(quietSpan.attributes[GEN_AI.inputMessages]).toBeUndefined();
   });
 
   it('ends the span itself when recording the input messages throws', () => {
@@ -431,7 +456,8 @@ describe('startAgentRunSpan', () => {
 
     // The factory never handed the span out, so nobody else could have closed it: an unclosed
     // span here is a leak that outlives the failed run.
-    const run = must(byName('invoke_agent a1'));
+    const run = byName('invoke_agent a1');
+    assert.exists(run);
     expect(run.status.code).toBe(2);
     expect(startedSpanNames).toContain('invoke_agent a1');
   });
@@ -444,7 +470,9 @@ describe('startAgentRunSpan', () => {
     });
     span.end();
 
-    expect(parentOf(must(byName('http POST')))).toBe('invoke_agent a1');
+    const http = byName('http POST');
+    assert.exists(http);
+    expect(parentOf(http)).toBe('invoke_agent a1');
   });
 });
 
@@ -479,7 +507,8 @@ describe('v1.36.0 message events', () => {
       'weather?',
     );
 
-    const invoke = must(byName('invoke_agent bot'));
+    const invoke = byName('invoke_agent bot');
+    assert.exists(invoke);
     // The reference implementations emit message events only for the model invocation; the agent
     // span reports content as span attributes alone.
     expect(invoke.events).toEqual([]);
@@ -498,9 +527,12 @@ describe('v1.36.0 message events', () => {
 
     const chats = spans().filter((span) => span.name === 'chat mock-model');
     expect(chats).toHaveLength(2);
+    const [firstChat, secondChat] = chats;
+    assert.exists(firstChat);
+    assert.exists(secondChat);
 
     // First round: instructions, the user turn, then the model's tool-calling choice.
-    expect(eventBodies(must(chats[0]))).toEqual([
+    expect(eventBodies(firstChat)).toEqual([
       { name: 'gen_ai.system.message', body: { content: 'Be terse.' } },
       { name: 'gen_ai.user.message', body: { content: 'weather?' } },
       {
@@ -522,7 +554,7 @@ describe('v1.36.0 message events', () => {
     ]);
 
     // Second round replays the whole exchange: the assistant's call, the tool result, the answer.
-    expect(eventBodies(must(chats[1]))).toEqual([
+    expect(eventBodies(secondChat)).toEqual([
       { name: 'gen_ai.system.message', body: { content: 'Be terse.' } },
       { name: 'gen_ai.user.message', body: { content: 'weather?' } },
       {
@@ -551,7 +583,8 @@ describe('v1.36.0 message events', () => {
       'weather?',
     );
 
-    const chat = must(spans().find((span) => span.name === 'chat mock-model'));
+    const chat = spans().find((span) => span.name === 'chat mock-model');
+    assert.exists(chat);
     expect(chat.events.length).toBeGreaterThan(1);
     for (const event of chat.events) {
       expect(event.attributes?.['gen_ai.system']).toBe('mock');
@@ -560,8 +593,12 @@ describe('v1.36.0 message events', () => {
     // Compared as [seconds, nanos] tuples: collapsing an epoch hrtime into one number exceeds
     // float64 integer precision and would erase the 1μs steps this asserts.
     for (let i = 1; i < chat.events.length; i++) {
-      const [prevSec, prevNs] = must(chat.events[i - 1]).time;
-      const [sec, ns] = must(chat.events[i]).time;
+      const previousEvent: ReadableSpan['events'][number] | undefined = chat.events[i - 1];
+      const event: ReadableSpan['events'][number] | undefined = chat.events[i];
+      assert.exists(previousEvent);
+      assert.exists(event);
+      const [prevSec, prevNs] = previousEvent.time;
+      const [sec, ns] = event.time;
       expect(sec > prevSec || (sec === prevSec && ns > prevNs)).toBe(true);
     }
   });
@@ -587,7 +624,9 @@ describe('v1.36.0 message events', () => {
 
     // A bigint or a cycle inside caller-built arguments must not cost the event its text and
     // call name; only the offending values degrade.
-    const body = JSON.parse(String(must(byName('chat test')).events[0]?.attributes?.body));
+    const chat = byName('chat test');
+    assert.exists(chat);
+    const body = JSON.parse(String(chat.events[0]?.attributes?.body));
     expect(body.content).toBe('calling');
     expect(body.tool_calls[0].id).toBe('c1');
     expect(body.tool_calls[0].function.name).toBe('f');
@@ -613,7 +652,8 @@ describe('v1.36.0 message events', () => {
     const mock = new MockChatClient([{ contents: [textContent('hi')] }]);
     await new Agent({ client: mock, name: 'bot' }).run('hello');
 
-    const chat = must(spans().find((span) => span.name === 'chat mock-model'));
+    const chat = spans().find((span) => span.name === 'chat mock-model');
+    assert.exists(chat);
     expect(chat.events.map((event) => event.name)).toEqual(['gen_ai.user.message']);
   });
 });

--- a/packages/core/src/observability/tracing.test.ts
+++ b/packages/core/src/observability/tracing.test.ts
@@ -9,7 +9,7 @@ import {
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { Agent } from '../agent/agent.js';
 import { withChatTelemetry } from '../client/telemetry.js';
-import { MockChatClient } from '../client/test-support.js';
+import { MockChatClient, must } from '../client/test-support.js';
 import { tool } from '../tools/tool.js';
 import { textContent } from '../types/content.js';
 import { message } from '../types/message.js';
@@ -60,12 +60,6 @@ function spans(): ReadableSpan[] {
 
 function byName(name: string): ReadableSpan | undefined {
   return spans().find((span) => span.name === name);
-}
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
 }
 
 /** The name of `span`'s parent, or undefined at the root. */
@@ -425,6 +419,21 @@ describe('startAgentRunSpan', () => {
     quiet.end();
 
     expect(must(byName('invoke_agent a2')).attributes[GEN_AI.inputMessages]).toBeUndefined();
+  });
+
+  it('ends the span itself when recording the input messages throws', () => {
+    configureObservability({ captureMessageContent: true });
+    // `JSON.stringify` throws on a BigInt, standing in for any caller-supplied content the
+    // serializer cannot encode.
+    const poisoned = [{ role: 'user', contents: [{ type: 'text', text: 1n as unknown as string }] }];
+
+    expect(() => startAgentRunSpan({ id: 'a1' }, poisoned as never)).toThrow(TypeError);
+
+    // The factory never handed the span out, so nobody else could have closed it: an unclosed
+    // span here is a leak that outlives the failed run.
+    const run = must(byName('invoke_agent a1'));
+    expect(run.status.code).toBe(2);
+    expect(startedSpanNames).toContain('invoke_agent a1');
   });
 
   it('awaits a non-streaming call inside the span', async () => {

--- a/packages/core/src/observability/tracing.ts
+++ b/packages/core/src/observability/tracing.ts
@@ -1,5 +1,7 @@
 import type { Attributes, AttributeValue, Span } from '@opentelemetry/api';
 import { context, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
+import { setIfDefined } from '../client/provider-utils.js';
+import { errorTypeOf } from '../errors.js';
 import type { Content } from '../types/content.js';
 import { textContent, textOfContents } from '../types/content.js';
 import type { Message } from '../types/message.js';
@@ -16,7 +18,7 @@ export function setAttr(span: Span, key: string, value: unknown): void {
 }
 
 /** Records token counts under the GenAI usage attribute names. */
-export function setUsageAttributes(span: Span, usage: UsageDetails | undefined): void {
+function setUsageAttributes(span: Span, usage: UsageDetails | undefined): void {
   if (usage === undefined) {
     return;
   }
@@ -40,12 +42,6 @@ export function setResponseAttributes(
   setUsageAttributes(span, response.usageDetails);
 }
 
-/**
- * Serializes messages for the sensitive-data attributes.
- *
- * Only the fields the convention asks for, so a span does not carry provider objects or base64
- * payloads: those belong in the transcript, not in a trace.
- */
 /** One part of the sensitive-data serialization: only the field the convention asks for. */
 function spanPart(content: Content): { type: string; content?: string } {
   return content.type === 'text' ? { type: 'text', content: content.text } : { type: content.type };
@@ -56,7 +52,13 @@ function serializeMessageForSpan(msg: Message): string {
   return JSON.stringify({ role: msg.role, parts: msg.contents.map(spanPart) });
 }
 
-export function serializeMessagesForSpan(messages: readonly Message[]): string {
+/**
+ * Serializes messages for the sensitive-data attributes.
+ *
+ * Only the fields the convention asks for, so a span does not carry provider objects or base64
+ * payloads: those belong in the transcript, not in a trace.
+ */
+function serializeMessagesForSpan(messages: readonly Message[]): string {
   return `[${messages.map(serializeMessageForSpan).join(',')}]`;
 }
 
@@ -301,8 +303,7 @@ export function responseFinishReason(response: ResponseBase<unknown>): string | 
 
 /** Marks a span failed and records the error type, matching the GenAI conventions. */
 export function recordSpanError(span: Span, error: unknown): void {
-  const type = error instanceof Error ? error.name : typeof error;
-  span.setAttribute(GEN_AI.errorType, type);
+  span.setAttribute(GEN_AI.errorType, errorTypeOf(error));
   span.setStatus(
     error instanceof Error
       ? { code: SpanStatusCode.ERROR, message: error.message }
@@ -438,23 +439,16 @@ export function inActiveSpan<T>(span: Span, value: () => PromiseLike<T>): Promis
 }
 
 /** Attributes for the `invoke_agent` span. */
-export function agentSpanAttributes(agent: {
-  id: string;
-  name?: string;
-  description?: string;
-  providerName?: string;
-  model?: string;
-  conversationId?: string;
-}): Attributes {
+export function agentSpanAttributes(agent: AgentRunSpanInfo): Attributes {
   const attributes: Attributes = {
     [GEN_AI.operation]: GEN_AI_OPERATION.invokeAgent,
     [GEN_AI.agentId]: agent.id,
   };
-  if (agent.name !== undefined) attributes[GEN_AI.agentName] = agent.name;
-  if (agent.description !== undefined) attributes[GEN_AI.agentDescription] = agent.description;
-  if (agent.providerName !== undefined) attributes[GEN_AI.providerName] = agent.providerName;
-  if (agent.model !== undefined) attributes[GEN_AI.requestModel] = agent.model;
-  if (agent.conversationId !== undefined) attributes[GEN_AI.conversationId] = agent.conversationId;
+  setIfDefined(attributes, GEN_AI.agentName, agent.name);
+  setIfDefined(attributes, GEN_AI.agentDescription, agent.description);
+  setIfDefined(attributes, GEN_AI.providerName, agent.providerName);
+  setIfDefined(attributes, GEN_AI.requestModel, agent.model);
+  setIfDefined(attributes, GEN_AI.conversationId, agent.conversationId);
   return attributes;
 }
 
@@ -484,9 +478,7 @@ export interface AgentRunSpanInfo {
 export interface AgentRunSpan {
   /**
    * Iterates `source` with this span active, so spans started while it runs become its children.
-   *
-   * Needed for lazily-started generators: their body only runs on the first `next()`, long after
-   * the factory returned, so the ambient context has to be re-entered around each pull.
+   * {@link withActiveSpan} explains why a lazily-started generator needs this.
    */
   active<T>(source: AsyncIterable<T>): AsyncIterable<T>;
   /** Awaits `value` with this span active, for a non-streaming call. */
@@ -524,10 +516,19 @@ export function startAgentRunSpan(
   info: AgentRunSpanInfo,
   inputMessages: readonly Message[] = [],
 ): AgentRunSpan {
-  const span = startSpan(spanName(GEN_AI_OPERATION.invokeAgent, info.name ?? info.id), {
-    ...agentSpanAttributes(info),
-  });
-  setMessageContent(span, GEN_AI.inputMessages, inputMessages);
+  const span = startSpan(
+    spanName(GEN_AI_OPERATION.invokeAgent, info.name ?? info.id),
+    agentSpanAttributes(info),
+  );
+  try {
+    // Serializing caller-supplied content can throw. The span has not been handed out yet, so no
+    // caller could end it — it has to be closed here, or an aborted start leaks an open span.
+    setMessageContent(span, GEN_AI.inputMessages, inputMessages);
+  } catch (error) {
+    recordSpanError(span, error);
+    span.end();
+    throw error;
+  }
   let ended = false;
   return {
     active: <T>(source: AsyncIterable<T>): AsyncIterable<T> => withActiveSpan(span, source),

--- a/packages/core/src/skills/provider.ts
+++ b/packages/core/src/skills/provider.ts
@@ -211,11 +211,11 @@ function skillTools(skills: readonly Skill[], approvals: SkillApprovalModes): To
     execute: async (input: Record<string, unknown>, toolCtx: ToolContext): Promise<string> => {
       const skillName = asName(input.skill_name);
       if (skillName === undefined) {
-        return 'Error: Skill name cannot be empty.';
+        return emptyNameError('Skill');
       }
       const skill = findSkill(skills, skillName);
       if (skill === undefined) {
-        return `Error: Skill '${skillName}' not found.`;
+        return skillNotFoundError(skillName);
       }
       return await skill.getContent(accessOptions(toolCtx));
     },
@@ -236,15 +236,15 @@ function skillTools(skills: readonly Skill[], approvals: SkillApprovalModes): To
     execute: async (input: Record<string, unknown>, toolCtx: ToolContext): Promise<unknown> => {
       const skillName = asName(input.skill_name);
       if (skillName === undefined) {
-        return 'Error: Skill name cannot be empty.';
+        return emptyNameError('Skill');
       }
       const resourceName = asName(input.resource_name);
       if (resourceName === undefined) {
-        return 'Error: Resource name cannot be empty.';
+        return emptyNameError('Resource');
       }
       const skill = findSkill(skills, skillName);
       if (skill === undefined) {
-        return `Error: Skill '${skillName}' not found.`;
+        return skillNotFoundError(skillName);
       }
       const resource = await skill.getResource?.(resourceName, accessOptions(toolCtx));
       if (resource === undefined) {
@@ -298,15 +298,15 @@ function skillTools(skills: readonly Skill[], approvals: SkillApprovalModes): To
     execute: async (input: Record<string, unknown>, toolCtx: ToolContext): Promise<unknown> => {
       const skillName = asName(input.skill_name);
       if (skillName === undefined) {
-        return 'Error: Skill name cannot be empty.';
+        return emptyNameError('Skill');
       }
       const scriptName = asName(input.script_name);
       if (scriptName === undefined) {
-        return 'Error: Script name cannot be empty.';
+        return emptyNameError('Script');
       }
       const skill = findSkill(skills, skillName);
       if (skill === undefined) {
-        return `Error: Skill '${skillName}' not found.`;
+        return skillNotFoundError(skillName);
       }
       const script = await skill.getScript?.(scriptName, accessOptions(toolCtx));
       if (script === undefined) {
@@ -337,6 +337,16 @@ function invocationContext(skill: Skill, toolCtx: ToolContext): SkillInvocationC
     ...(toolCtx.signal === undefined ? {} : { signal: toolCtx.signal }),
     ...(toolCtx.session === undefined ? {} : { session: toolCtx.session }),
   };
+}
+
+// The refusal strings are shared across the three skill tools so the wording — which the model
+// reads and acts on — cannot drift between them.
+function emptyNameError(what: 'Skill' | 'Resource' | 'Script'): string {
+  return `Error: ${what} name cannot be empty.`;
+}
+
+function skillNotFoundError(name: string): string {
+  return `Error: Skill '${name}' not found.`;
 }
 
 /** Returns the name exactly as sent, or `undefined` when it is missing or blank. */

--- a/packages/core/src/skills/skill.ts
+++ b/packages/core/src/skills/skill.ts
@@ -326,7 +326,7 @@ function byName<T extends { readonly name: string }>(items: readonly T[], name: 
  * An empty collection still produces an element — `<available_resources />` — because a model shown
  * nothing at all invents resource names, while a model shown an explicitly empty list does not.
  */
-export function resourcesBlock(resources: readonly SkillResource[]): string {
+function resourcesBlock(resources: readonly SkillResource[]): string {
   if (resources.length === 0) {
     return '<available_resources />';
   }
@@ -335,7 +335,7 @@ export function resourcesBlock(resources: readonly SkillResource[]): string {
 }
 
 /** Renders the scripts a skill offers, with each script's parameter schema when it declares one. */
-export function scriptsBlock(scripts: readonly SkillScript[]): string {
+function scriptsBlock(scripts: readonly SkillScript[]): string {
   if (scripts.length === 0) {
     return '<available_scripts />';
   }

--- a/packages/core/src/streaming/response-stream.ts
+++ b/packages/core/src/streaming/response-stream.ts
@@ -1,5 +1,31 @@
-import { StreamConsumedError, throwIfAborted } from '../errors.js';
+import { StreamConsumedError } from '../errors.js';
 import { abortErrorFrom } from './abort.js';
+
+/**
+ * Folds `value` through `hooks` in order.
+ *
+ * A hook that answers `undefined` or `null` (or nothing at all) leaves the value unchanged —
+ * "nothing to replace" — which is the one subtlety every hook loop must agree on, so it is
+ * written once and shared by the stream's own `onResult` pass and the middleware pipeline's
+ * update/result passes.
+ */
+export async function applyHooks<T>(
+  value: T,
+  // What a hook may answer varies by hook family (`void`, `undefined`, a promise of either, or a
+  // replacement); each family's own declaration enforces its shape, so this fold accepts them all
+  // and cares only about the one distinction below.
+  hooks: Iterable<(value: T) => unknown> | undefined,
+): Promise<T> {
+  let current = value;
+  for (const hook of hooks ?? []) {
+    // A `void` answer is `undefined` at runtime; the cast collapses the two for the narrow below.
+    const hooked = (await hook(current)) as T | null | undefined;
+    if (hooked !== undefined && hooked !== null) {
+      current = hooked;
+    }
+  }
+  return current;
+}
 
 /** Context handed to a stream's `start` callback on first consumption. */
 export interface StreamStartContext {
@@ -149,9 +175,9 @@ class HybridResponseStream<TUpdate, TFinal> implements ResponseStream<TUpdate, T
     this.#claimed = true;
   }
 
-  #createIterator(stream: boolean): AsyncIterator<TUpdate, void, void> {
+  #createIterator(): AsyncIterator<TUpdate, void, void> {
     return {
-      next: () => this.#next(stream),
+      next: () => this.#next(true),
       return: async () => {
         await this.#stop();
         return { done: true, value: undefined };
@@ -202,7 +228,7 @@ class HybridResponseStream<TUpdate, TFinal> implements ResponseStream<TUpdate, T
     }
     let result: IteratorResult<TUpdate>;
     try {
-      throwIfAborted(this.#init.signal);
+      this.#init.signal?.throwIfAborted();
       const iterator = await this.#source(stream);
       result = await iterator.next();
     } catch (error) {
@@ -229,7 +255,7 @@ class HybridResponseStream<TUpdate, TFinal> implements ResponseStream<TUpdate, T
       // @anthropic-ai/sdk `core/streaming.mjs`). Checking only before each pull would fold that
       // truncated turn into a normal final result — and a hosted turn would be persisted as
       // `completed` carrying output the model never finished, with no error anywhere to show for
-      // it. This is the same value `throwIfAborted` would have thrown one pull earlier, so the
+      // it. This is the same value `throwIfAborted()` would have thrown one pull earlier, so the
       // abort reports identically whichever side of the pull it lands on.
       if (this.#init.signal?.aborted === true) {
         const error = abortErrorFrom(this.#init.signal);
@@ -378,13 +404,10 @@ class HybridResponseStream<TUpdate, TFinal> implements ResponseStream<TUpdate, T
     }
     const resultCtx: StreamResultContext = { abandoned: this.#abandoned };
     this.#finalizing ??= (async (): Promise<TFinal> => {
-      let final = await this.#init.finalize(this.#updates);
-      for (const hook of this.#init.onResult ?? []) {
-        const hooked = await hook(final, resultCtx);
-        if (hooked !== undefined && hooked !== null) {
-          final = hooked;
-        }
-      }
+      const final = await applyHooks(
+        await this.#init.finalize(this.#updates),
+        this.#init.onResult?.map((hook) => (value: TFinal) => hook(value, resultCtx)),
+      );
       this.#finalResult = final;
       this.#finalized = true;
       return final;
@@ -409,7 +432,7 @@ class HybridResponseStream<TUpdate, TFinal> implements ResponseStream<TUpdate, T
 
   [Symbol.asyncIterator](): AsyncIterator<TUpdate, void, void> {
     this.#claim();
-    return this.#createIterator(true);
+    return this.#createIterator();
   }
 
   // biome-ignore lint/suspicious/noThenProperty: the stream is deliberately awaitable (thenable + async iterable hybrid)

--- a/packages/core/src/tools/json-schema.ts
+++ b/packages/core/src/tools/json-schema.ts
@@ -1,4 +1,5 @@
 import { SchemaResolutionError } from '../errors.js';
+import { isRecord } from '../types/content.js';
 import type { StandardSchemaV1 } from './standard-schema.js';
 import { isStandardSchema } from './standard-schema.js';
 
@@ -139,9 +140,7 @@ function compilePattern(source: string): RegExp | null {
 }
 
 function schemaRecord(schema: unknown): Record<string, unknown> | undefined {
-  return typeof schema === 'object' && schema !== null && !Array.isArray(schema)
-    ? (schema as Record<string, unknown>)
-    : undefined;
+  return isRecord(schema) ? schema : undefined;
 }
 
 function jsonEqual(left: unknown, right: unknown): boolean {
@@ -165,7 +164,7 @@ function typeMatches(value: unknown, type: string): boolean {
     case 'array':
       return Array.isArray(value);
     case 'object':
-      return typeof value === 'object' && value !== null && !Array.isArray(value);
+      return isRecord(value);
     case 'integer':
       return typeof value === 'number' && Number.isInteger(value);
     case 'number':
@@ -289,8 +288,8 @@ function validateValue(
     if (branch !== undefined) validateValue(value, branch, root, path, issues, activeReferences);
   }
 
-  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-    validateObject(value as Record<string, unknown>, rule, root, path, issues, activeReferences);
+  if (isRecord(value)) {
+    validateObject(value, rule, root, path, issues, activeReferences);
   }
   if (Array.isArray(value)) validateArray(value, rule, root, path, issues, activeReferences);
   if (typeof value === 'string') validateString(value, rule, path, issues);

--- a/packages/core/src/types/coalesce.ts
+++ b/packages/core/src/types/coalesce.ts
@@ -20,6 +20,17 @@ function mergeAdditionalProperties(
   return { ...a, ...b };
 }
 
+/** The folded `additionalProperties` of a run: the first item's record seeds, later keys win. */
+function mergedRunProps(
+  run: readonly { additionalProperties?: Record<string, unknown> }[],
+): Record<string, unknown> | undefined {
+  let props = run[0]?.additionalProperties;
+  for (const item of run.slice(1)) {
+    props = mergeAdditionalProperties(props, item.additionalProperties);
+  }
+  return props;
+}
+
 function withOptionalProps<T extends object>(base: T, props: Record<string, unknown> | undefined): T {
   return props === undefined ? base : { ...base, additionalProperties: props };
 }
@@ -137,9 +148,7 @@ function canMergeData(a: DataContent, b: DataContent): boolean {
 }
 
 function mergeTextRun(run: TextContent[]): TextContent {
-  const first = run[0] as TextContent;
   let text = '';
-  let props = first.additionalProperties;
   const annotations: NonNullable<Content['annotations']> = [];
   for (const item of run) {
     text += item.text;
@@ -147,10 +156,7 @@ function mergeTextRun(run: TextContent[]): TextContent {
       annotations.push(...item.annotations);
     }
   }
-  for (const item of run.slice(1)) {
-    props = mergeAdditionalProperties(props, item.additionalProperties);
-  }
-  const merged = withOptionalProps<TextContent>({ type: 'text', text }, props);
+  const merged = withOptionalProps<TextContent>({ type: 'text', text }, mergedRunProps(run));
   // Only an empty annotated item can be in this run (see `coalescableText`), so nothing here
   // shifts the offsets the annotations refer to.
   if (annotations.length > 0) {
@@ -166,15 +172,11 @@ function mergeTextReasoningRun(run: TextReasoningContent[]): TextReasoningConten
   // string is falsy). An id-less run keeps the first fragment's spelling of "no id".
   const id = run.find((item) => item.id !== undefined && item.id !== '')?.id ?? first.id;
   let protectedData: string | undefined;
-  let props = first.additionalProperties;
   for (const item of run) {
     text += item.text ?? '';
     if (item.protectedData !== undefined) {
       protectedData = item.protectedData;
     }
-  }
-  for (const item of run.slice(1)) {
-    props = mergeAdditionalProperties(props, item.additionalProperties);
   }
   const merged: TextReasoningContent = { type: 'text_reasoning' };
   if (id !== undefined) {
@@ -186,7 +188,7 @@ function mergeTextReasoningRun(run: TextReasoningContent[]): TextReasoningConten
   if (protectedData !== undefined) {
     merged.protectedData = protectedData;
   }
-  return withOptionalProps(merged, props);
+  return withOptionalProps(merged, mergedRunProps(run));
 }
 
 function mergeFunctionCallRun(run: FunctionCallContent[]): FunctionCallContent {
@@ -195,7 +197,6 @@ function mergeFunctionCallRun(run: FunctionCallContent[]): FunctionCallContent {
   let name = '';
   let callId = '';
   let informationalOnly = false;
-  let props = first.additionalProperties;
   for (const item of run) {
     if (typeof args === 'string' && typeof item.arguments === 'string') {
       args += item.arguments;
@@ -206,19 +207,15 @@ function mergeFunctionCallRun(run: FunctionCallContent[]): FunctionCallContent {
     callId ||= item.callId;
     informationalOnly ||= item.informationalOnly === true;
   }
-  for (const item of run.slice(1)) {
-    props = mergeAdditionalProperties(props, item.additionalProperties);
-  }
   const merged: FunctionCallContent = { type: 'function_call', callId, name, arguments: args };
   if (informationalOnly) {
     merged.informationalOnly = true;
   }
-  return withOptionalProps(merged, props);
+  return withOptionalProps(merged, mergedRunProps(run));
 }
 
 function mergeDataRun(run: DataContent[]): DataContent {
   const first = run[0] as DataContent;
-  let props = first.additionalProperties;
   // Concatenated with typed-array copies rather than a spread push: spreading a large decoded
   // payload as function arguments overflows the engine's argument limit (~100k elements).
   const parts = run.map((item) => decodeBase64(dataUriPayload(item.uri)));
@@ -232,9 +229,6 @@ function mergeDataRun(run: DataContent[]): DataContent {
     bytes.set(part, offset);
     offset += part.length;
   }
-  for (const item of run.slice(1)) {
-    props = mergeAdditionalProperties(props, item.additionalProperties);
-  }
   const merged: DataContent = {
     type: 'data',
     uri: `data:${first.mediaType};base64,${encodeBase64(bytes)}`,
@@ -243,7 +237,7 @@ function mergeDataRun(run: DataContent[]): DataContent {
   if (first.name !== undefined) {
     merged.name = first.name;
   }
-  return withOptionalProps(merged, props);
+  return withOptionalProps(merged, mergedRunProps(run));
 }
 
 /**

--- a/packages/core/src/types/content.ts
+++ b/packages/core/src/types/content.ts
@@ -293,6 +293,17 @@ export function isUserInputRequest(content: Content): content is UserInputReques
 }
 
 /**
+ * Whether `value` is a JSON object, as opposed to `null`, an array or a primitive.
+ *
+ * Arrays are excluded so the predicate means the same thing everywhere it is spelled this way: a
+ * guard whose name promises "a record" and quietly admits arrays is one refactor away from being
+ * read as a guarantee.
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
  * A content item whose wire `type` this version of the framework does not know.
  *
  * Deserialization never drops data: the original wire `type` is kept in
@@ -376,10 +387,7 @@ export function textContent(text: string, options?: Omit<TextContent, 'type' | '
  * ```
  */
 export function unknownContent(wire: unknown): UnknownContent {
-  const record =
-    typeof wire === 'object' && wire !== null && !Array.isArray(wire)
-      ? (wire as Record<string, unknown>)
-      : {};
+  const record = isRecord(wire) ? wire : {};
   const { type, ...rest } = record;
   return {
     ...rest,

--- a/packages/core/src/types/response.test.ts
+++ b/packages/core/src/types/response.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { must } from '../client/test-support.js';
 import { decodeBase64 } from './base64.js';
 import { coalesceContents } from './coalesce.js';
 import { dataContent, textContent, unknownContent } from './content.js';
@@ -16,12 +17,6 @@ import { addUsage } from './usage.js';
 
 function update(init: Partial<Parameters<typeof agentResponseUpdate>[0]> = {}): AgentResponseUpdate {
   return agentResponseUpdate({ contents: [], ...init });
-}
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
 }
 
 describe('mergeUpdates', () => {

--- a/packages/core/src/types/response.test.ts
+++ b/packages/core/src/types/response.test.ts
@@ -1,5 +1,4 @@
-import { describe, expect, it } from 'vitest';
-import { must } from '../client/test-support.js';
+import { assert, describe, expect, it } from 'vitest';
 import { decodeBase64 } from './base64.js';
 import { coalesceContents } from './coalesce.js';
 import { dataContent, textContent, unknownContent } from './content.js';
@@ -118,7 +117,9 @@ describe('mergeUpdates', () => {
       update({ contents: [{ type: 'function_call', callId: 'c1', name: 'f', arguments: ':1}' }] }),
     ]);
 
-    const contents = must(response.messages[0]).contents;
+    const message = response.messages[0];
+    assert.exists(message);
+    const contents = message.contents;
     expect(contents).toHaveLength(2);
     expect(contents.map((c) => (c as { arguments: string }).arguments)).toEqual(['{"a"', ':1}']);
   });
@@ -265,7 +266,8 @@ describe('coalesceContents', () => {
     const big = new Uint8Array(300_000).fill(65);
     const merged = coalesceContents([dataContent(big, 'text/plain'), dataContent(big, 'text/plain')]);
     expect(merged).toHaveLength(1);
-    const payload = must((merged[0] as { uri: string }).uri.split(',')[1]);
+    const payload = (merged[0] as { uri: string }).uri.split(',')[1];
+    assert.exists(payload);
     expect(decodeBase64(payload)).toHaveLength(600_000);
   });
 

--- a/packages/core/src/types/response.ts
+++ b/packages/core/src/types/response.ts
@@ -119,6 +119,35 @@ function defineDerived<T extends object>(target: T, key: string, get: () => unkn
   return target;
 }
 
+/**
+ * Copies the entries of `source` named by `keys` onto `target`, skipping the absent ones.
+ *
+ * `exactOptionalPropertyTypes` makes an explicitly `undefined` property a different thing from an
+ * absent one, so every optional field has to be tested before it is assigned. Written once, with
+ * the fields named in a list, rather than as a chain of `if`s per call site: several places have
+ * to copy *the same* set of fields, and a list is something a reader can compare at a glance —
+ * and, where the set is fixed, something the compiler can check for completeness.
+ *
+ * `keys` is applied in order, so a caller that cares about property order (anything whose output
+ * is serialized) gets to decide it.
+ */
+export function copyDefined<TTarget extends object, TKey extends keyof TTarget>(
+  target: TTarget,
+  // Explicit `| undefined` rather than `Partial<Pick<…>>`: under `exactOptionalPropertyTypes` an
+  // optional property refuses an explicitly-`undefined` value, and a source is just as often a
+  // record of `T | undefined` fields as it is one with the fields absent. Both are "no value here".
+  source: { readonly [K in TKey]?: TTarget[K] | undefined },
+  keys: readonly TKey[],
+): TTarget {
+  for (const key of keys) {
+    const value = source[key];
+    if (value !== undefined) {
+      target[key] = value as TTarget[TKey];
+    }
+  }
+  return target;
+}
+
 /** Creates a {@link ChatResponseUpdate} with a live `text` getter. */
 export function chatResponseUpdate(init: ChatResponseUpdateInit): ChatResponseUpdate {
   const update = { ...init } as ChatResponseUpdate;
@@ -156,16 +185,20 @@ export function chatToAgentUpdate(
   options?: { agentName?: string; agentId?: string },
 ): AgentResponseUpdate {
   const init: AgentResponseUpdateInit = { contents: update.contents, rawRepresentation: update };
+  copyDefined(init, update, [
+    'role',
+    'responseId',
+    'messageId',
+    'createdAt',
+    'finishReason',
+    'continuationToken',
+    'additionalProperties',
+  ]);
+  // The two fields that are not a plain copy: the agent's own identity fills in for whatever the
+  // update did not carry itself.
   const authorName = update.authorName ?? options?.agentName;
-  if (update.role !== undefined) init.role = update.role;
   if (authorName !== undefined) init.authorName = authorName;
   if (options?.agentId !== undefined) init.agentId = options.agentId;
-  if (update.responseId !== undefined) init.responseId = update.responseId;
-  if (update.messageId !== undefined) init.messageId = update.messageId;
-  if (update.createdAt !== undefined) init.createdAt = update.createdAt;
-  if (update.finishReason !== undefined) init.finishReason = update.finishReason;
-  if (update.continuationToken !== undefined) init.continuationToken = update.continuationToken;
-  if (update.additionalProperties !== undefined) init.additionalProperties = update.additionalProperties;
   return agentResponseUpdate(init);
 }
 
@@ -337,8 +370,7 @@ function fold(updates: readonly (ChatResponseUpdate | AgentResponseUpdate)[]): F
 export function mergeUpdates<T = undefined>(updates: readonly AgentResponseUpdate[]): AgentResponse<T> {
   const state = fold(updates);
   const init: AgentResponseInit<T> = { messages: state.messages };
-  if (state.agentId !== undefined) init.agentId = state.agentId;
-  if (state.responseId !== undefined) init.responseId = state.responseId;
+  copyDefined(init, state, ['agentId', 'responseId']);
   setFoldMetadata(init, state);
   return agentResponse<T>(init);
 }
@@ -347,9 +379,7 @@ export function mergeUpdates<T = undefined>(updates: readonly AgentResponseUpdat
 export function mergeChatUpdates<T = undefined>(updates: readonly ChatResponseUpdate[]): ChatResponse<T> {
   const state = fold(updates);
   const init: ChatResponseInit<T> = { messages: state.messages };
-  if (state.responseId !== undefined) init.responseId = state.responseId;
-  if (state.conversationId !== undefined) init.conversationId = state.conversationId;
-  if (state.model !== undefined) init.model = state.model;
+  copyDefined(init, state, ['responseId', 'conversationId', 'model']);
   setFoldMetadata(init, state);
   return chatResponse<T>(init);
 }
@@ -359,12 +389,14 @@ function setFoldMetadata(
   init: ChatResponseInit<unknown> | AgentResponseInit<unknown>,
   state: FoldState,
 ): void {
-  if (state.createdAt !== undefined) init.createdAt = state.createdAt;
-  if (state.finishReason !== undefined) init.finishReason = state.finishReason;
-  if (state.usageDetails !== undefined) init.usageDetails = state.usageDetails;
-  if (state.continuationToken !== undefined) init.continuationToken = state.continuationToken;
-  if (state.additionalProperties !== undefined) init.additionalProperties = state.additionalProperties;
-  if (state.rawRepresentation !== undefined) init.rawRepresentation = state.rawRepresentation;
+  copyDefined(init, state, [
+    'createdAt',
+    'finishReason',
+    'usageDetails',
+    'continuationToken',
+    'additionalProperties',
+    'rawRepresentation',
+  ]);
 }
 
 /** Constructor input common to both update flavors: {@link ResponseUpdateBase} without `text`. */
@@ -383,14 +415,12 @@ function responseToUpdates(
   const inits: ResponseUpdateInitBase[] = [];
   for (const msg of response.messages) {
     const init: ResponseUpdateInitBase = { contents: msg.contents, role: msg.role };
-    if (msg.rawRepresentation !== undefined) init.rawRepresentation = msg.rawRepresentation;
-    if (msg.additionalProperties !== undefined) init.additionalProperties = msg.additionalProperties;
-    if (msg.messageId !== undefined) init.messageId = msg.messageId;
-    if (msg.authorName !== undefined) init.authorName = msg.authorName;
+    copyDefined(init, msg, ['rawRepresentation', 'additionalProperties', 'messageId', 'authorName']);
+    // The message's own timestamp, falling back to the response's, so an update is never undated
+    // when the response is.
     const createdAt = msg.createdAt ?? response.createdAt;
     if (createdAt !== undefined) init.createdAt = createdAt;
-    if (response.responseId !== undefined) init.responseId = response.responseId;
-    if (response.finishReason !== undefined) init.finishReason = response.finishReason;
+    copyDefined(init, response, ['responseId', 'finishReason']);
     addExtras(init);
     inits.push(init);
   }
@@ -401,13 +431,9 @@ function responseToUpdates(
     const init: ResponseUpdateInitBase = {
       contents: hasUsage ? [{ type: 'usage', usageDetails: response.usageDetails as UsageDetails }] : [],
     };
-    if (response.responseId !== undefined) init.responseId = response.responseId;
-    if (response.createdAt !== undefined) init.createdAt = response.createdAt;
-    if (response.continuationToken !== undefined) init.continuationToken = response.continuationToken;
+    copyDefined(init, response, ['responseId', 'createdAt', 'continuationToken']);
     addExtras(init);
-    if (response.finishReason !== undefined) init.finishReason = response.finishReason;
-    if (response.additionalProperties !== undefined)
-      init.additionalProperties = response.additionalProperties;
+    copyDefined(init, response, ['finishReason', 'additionalProperties']);
     inits.push(init);
   }
   return inits;
@@ -423,8 +449,7 @@ function responseToUpdates(
  */
 export function chatResponseToUpdates(response: ChatResponse<unknown>): ChatResponseUpdate[] {
   return responseToUpdates(response, (init: ChatResponseUpdateInit) => {
-    if (response.conversationId !== undefined) init.conversationId = response.conversationId;
-    if (response.model !== undefined) init.model = response.model;
+    copyDefined(init, response, ['conversationId', 'model']);
   }).map((init) => chatResponseUpdate(init));
 }
 
@@ -437,7 +462,7 @@ export function chatResponseToUpdates(response: ChatResponse<unknown>): ChatResp
  */
 export function agentResponseToUpdates(response: AgentResponse<unknown>): AgentResponseUpdate[] {
   return responseToUpdates(response, (init: AgentResponseUpdateInit) => {
-    if (response.agentId !== undefined) init.agentId = response.agentId;
+    copyDefined(init, response, ['agentId']);
   }).map((init) => agentResponseUpdate(init));
 }
 

--- a/packages/core/src/types/serialization.test.ts
+++ b/packages/core/src/types/serialization.test.ts
@@ -1,5 +1,4 @@
-import { describe, expect, it } from 'vitest';
-import { must } from '../client/test-support.js';
+import { assert, describe, expect, it } from 'vitest';
 import { unknownContent } from './content.js';
 import type { Message } from './message.js';
 import { deserializeMessage, serializeContent, serializeMessage } from './serialization.js';
@@ -23,7 +22,9 @@ describe('message serialization', () => {
     const wire = serializeMessage(msg);
     expect(wire).not.toHaveProperty('rawRepresentation');
     expect(wire.contents[0]).not.toHaveProperty('rawRepresentation');
-    expect((must(wire.contents[1]).annotations as unknown[])[0]).not.toHaveProperty('rawRepresentation');
+    const cited = wire.contents[1];
+    assert.exists(cited);
+    expect((cited.annotations as unknown[])[0]).not.toHaveProperty('rawRepresentation');
     expect(JSON.parse(JSON.stringify(wire))).toEqual(wire);
   });
 
@@ -321,5 +322,7 @@ describe('unknownContent', () => {
 function deserializeContentHelper(
   data: Record<string, unknown>,
 ): ReturnType<typeof deserializeMessage>['contents'][number] {
-  return must(deserializeMessage({ role: 'assistant', contents: [data] }).contents[0]);
+  const content = deserializeMessage({ role: 'assistant', contents: [data] }).contents[0];
+  assert.exists(content);
+  return content;
 }

--- a/packages/core/src/types/serialization.test.ts
+++ b/packages/core/src/types/serialization.test.ts
@@ -1,13 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { must } from '../client/test-support.js';
 import { unknownContent } from './content.js';
 import type { Message } from './message.js';
 import { deserializeMessage, serializeContent, serializeMessage } from './serialization.js';
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}
 
 describe('message serialization', () => {
   it('drops rawRepresentation from the message and from every content item', () => {

--- a/packages/core/src/types/serialization.ts
+++ b/packages/core/src/types/serialization.ts
@@ -1,4 +1,5 @@
 import type { Annotation, Content, ContentType } from './content.js';
+import { isRecord } from './content.js';
 import type { Message } from './message.js';
 
 /** A {@link Content} item in its wire form. */
@@ -82,10 +83,6 @@ const NESTED_CONTENT_KEYS = ['functionCall', 'inputs', 'output', 'outputs', 'ite
  * `outputs` and `items`, never under `result`.
  */
 const SERIALIZED_NESTED_CONTENT_KEYS = [...NESTED_CONTENT_KEYS, 'result'] as const;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 /**
  * Whether `value` is shaped like a content item, as opposed to arbitrary JSON.

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { definePackageBuild } from '../../scripts/tsdown-config.ts';
 
 export default definePackageBuild({
-  entry: ['src/index.ts', 'src/testing.ts', 'src/node.ts'],
+  entry: ['src/index.ts', 'src/testing.ts', 'src/internal.ts', 'src/node.ts'],
   platform: 'neutral',
   neverBundle: ['@opentelemetry/api'],
 });

--- a/packages/foundry/src/chat-client.test.ts
+++ b/packages/foundry/src/chat-client.test.ts
@@ -1,24 +1,12 @@
-import type { AccessToken, TokenCredential } from '@azure/identity';
 import { ConfigurationError, textContent } from '@polymind-inc/agent-framework-core';
 import type OpenAI from 'openai';
 import { describe, expect, it, vi } from 'vitest';
 import { FoundryChatClient } from './chat-client.js';
 import { FoundryProject } from './project.js';
 import { normalizeProjectEndpoint, resolveEndpoint } from './target.js';
+import { fakeCredential } from './test-helpers.js';
 
 const PROJECT = 'https://my-resource.services.ai.azure.com/api/projects/my-project';
-
-/** A credential whose tokens expire `ttlMs` from now. */
-function fakeCredential(ttlMs = 60 * 60 * 1000): TokenCredential & { calls: number } {
-  const credential = {
-    calls: 0,
-    async getToken(): Promise<AccessToken> {
-      credential.calls++;
-      return { token: `token-${credential.calls}`, expiresOnTimestamp: Date.now() + ttlMs };
-    },
-  };
-  return credential;
-}
 
 function fakeProject(): FoundryProject {
   return new FoundryProject(PROJECT, fakeCredential());

--- a/packages/foundry/src/chat-client.ts
+++ b/packages/foundry/src/chat-client.ts
@@ -63,20 +63,23 @@ export class FoundryChatClient extends OpenAIChatClient {
     // there is nothing to name here: .NET removes `$.model` from the request and Go leaves it
     // unset. Sending a placeholder would reach the wire, `metadata.modelId` and telemetry alike.
     const model = isModelTarget(config.target) ? config.target.model : undefined;
-    const project = config.client === undefined ? config.project : undefined;
-    const endpoint = project === undefined ? undefined : resolveEndpoint(project.endpoint, config.target);
-    const fetch = config.fetch ?? project?.fetch;
 
-    const client =
-      config.client ??
-      new OpenAI({
-        baseURL: (endpoint as { baseURL: string }).baseURL,
+    let client: OpenAI;
+    if (config.client !== undefined) {
+      client = config.client;
+    } else {
+      const project = config.project;
+      const endpoint = resolveEndpoint(project.endpoint, config.target);
+      const fetch = config.fetch ?? project.fetch;
+      client = new OpenAI({
+        baseURL: endpoint.baseURL,
         // The SDK calls this before every request, so rotation is handled for us.
-        apiKey: () => (project as FoundryProject).getToken(),
-        ...(endpoint?.defaultQuery === undefined ? {} : { defaultQuery: endpoint.defaultQuery }),
+        apiKey: () => project.getToken(),
+        ...(endpoint.defaultQuery === undefined ? {} : { defaultQuery: endpoint.defaultQuery }),
         ...(config.defaultHeaders === undefined ? {} : { defaultHeaders: config.defaultHeaders }),
         ...(fetch === undefined ? {} : { fetch }),
       });
+    }
 
     super({
       client,

--- a/packages/foundry/src/credential.ts
+++ b/packages/foundry/src/credential.ts
@@ -1,5 +1,4 @@
 import type { AccessToken, TokenCredential } from '@azure/identity';
-import { FOUNDRY_SCOPE } from './target.js';
 
 /** Refresh this long before expiry so a request never carries an about-to-expire token. */
 const REFRESH_MARGIN_MS = 5 * 60 * 1000;
@@ -16,10 +15,7 @@ const REFRESH_MARGIN_MS = 5 * 60 * 1000;
  * Point a Foundry client at a host you do not control and you hand that host a token for your
  * project.
  */
-export function tokenProvider(
-  credential: TokenCredential,
-  scope: string = FOUNDRY_SCOPE,
-): () => Promise<string> {
+export function tokenProvider(credential: TokenCredential, scope: string): () => Promise<string> {
   let cached: AccessToken | undefined;
   let inFlight: Promise<AccessToken> | undefined;
 

--- a/packages/foundry/src/hosting/approval-storage.ts
+++ b/packages/foundry/src/hosting/approval-storage.ts
@@ -5,6 +5,7 @@ import {
   writeJsonFile,
 } from '@polymind-inc/agent-framework-agentserver/internal';
 import type { FunctionApprovalRequestContent } from '@polymind-inc/agent-framework-core';
+import { compositeKey } from './composite-key.js';
 
 /**
  * Remembers the approval requests this container issued, keyed by the id they went out under.
@@ -26,26 +27,12 @@ export interface ApprovalStorage {
 export class InMemoryApprovalStorage implements ApprovalStorage {
   readonly #requests = new Map<string, FunctionApprovalRequestContent>();
 
-  /**
-   * A map key that cannot collide across `(userId, wireId)` pairs.
-   *
-   * Both halves are untrusted at load: the user id is a platform header and the wire id is the
-   * request body's `approval_request_id`. Joining them with *any* delimiter lets one pair
-   * impersonate another — under the previous space-joined scheme, `("alice", "smith mcpr_1")`
-   * read the entry saved for `("alice smith", "mcpr_1")`, which is another user's pending
-   * approval. `JSON.stringify` escapes every character, so the composition is injective. Same
-   * defect and same fix as {@link InMemoryAgentSessionStore}.
-   */
-  static #compositeKey(userId: string, wireId: string): string {
-    return JSON.stringify([userId, wireId]);
-  }
-
   async save(userId: string, wireId: string, request: FunctionApprovalRequestContent): Promise<void> {
-    this.#requests.set(InMemoryApprovalStorage.#compositeKey(userId, wireId), request);
+    this.#requests.set(compositeKey(userId, wireId), request);
   }
 
   async load(userId: string, wireId: string): Promise<FunctionApprovalRequestContent | undefined> {
-    return this.#requests.get(InMemoryApprovalStorage.#compositeKey(userId, wireId));
+    return this.#requests.get(compositeKey(userId, wireId));
   }
 }
 

--- a/packages/foundry/src/hosting/composite-key.ts
+++ b/packages/foundry/src/hosting/composite-key.ts
@@ -1,0 +1,13 @@
+/**
+ * One string key for a pair of strings, collision-free across pairs.
+ *
+ * Both halves are typically untrusted (a header, a request body, gateway-authored text), so
+ * joining them with *any* delimiter character lets a crafted value impersonate another pair —
+ * a space join collapses `("alice", "smith x")` with `("alice smith", "x")`, and the previous
+ * NUL join failed the same way while also making the file unsearchable (ripgrep reads NUL as
+ * binary). `JSON.stringify` escapes every character, so the pair is recoverable and the
+ * composition is structurally injective.
+ */
+export function compositeKey(first: string, second: string): string {
+  return JSON.stringify([first, second]);
+}

--- a/packages/foundry/src/hosting/consent-channel.test.ts
+++ b/packages/foundry/src/hosting/consent-channel.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { createConsentChannel, reportConsent, withConsentChannel } from './consent-channel.js';
+
+describe('withConsentChannel', () => {
+  it('keeps the channel installed while the stream is torn down early', async () => {
+    const channel = createConsentChannel();
+    const consent = { serverLabel: 'crm', consentLink: 'https://consent.example/crm' };
+    async function* source(): AsyncGenerator<number> {
+      try {
+        yield 1;
+        yield 2;
+      } finally {
+        // Where a tool tears down when the consumer stops early — a consent break, a disconnect,
+        // a shutdown all arrive here. A consent hit during teardown must still land in this
+        // turn's channel, not vanish into "no turn in flight".
+        reportConsent('call_1', [consent]);
+      }
+    }
+
+    for await (const value of withConsentChannel(channel, source())) {
+      void value;
+      break;
+    }
+
+    expect(channel.byCallId.get('call_1')).toEqual([consent]);
+  });
+});

--- a/packages/foundry/src/hosting/consent-channel.ts
+++ b/packages/foundry/src/hosting/consent-channel.ts
@@ -28,6 +28,7 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { ToolboxConsentRequest } from './consent.js';
+import { runInScope } from './run-in-scope.js';
 
 /** One turn's consent reports, keyed by the `callId` of the tool call that hit the refusal. */
 export interface ConsentChannel {
@@ -67,29 +68,13 @@ export function reportConsent(callId: string, consents: readonly ToolboxConsentR
 }
 
 /**
- * Drives `stream` with `channel` installed as the ambient channel.
- *
- * Each `next()` is invoked *inside* `AsyncLocalStorage.run`, which is where the agent runs the
- * round — including the tool calls — so a report from a tool lands in this turn's channel and
- * nowhere else. Wrapping the whole `for await` instead would leave the store's propagation into
- * the generator's resumption up to where the loop happened to be suspended.
+ * Drives `stream` with `channel` installed as the ambient channel, so a report from a tool —
+ * including one made during teardown after an early stop — lands in this turn's channel and
+ * nowhere else (see {@link runInScope} for the scoping mechanics).
  */
-export async function* withConsentChannel<T>(
+export function withConsentChannel<T>(
   channel: ConsentChannel,
   stream: AsyncIterable<T>,
 ): AsyncGenerator<T, void, undefined> {
-  const iterator = stream[Symbol.asyncIterator]();
-  try {
-    for (;;) {
-      const next = await storage.run(channel, () => iterator.next());
-      if (next.done === true) {
-        return;
-      }
-      yield next.value;
-    }
-  } finally {
-    // `break` in the consumer has to reach the agent's own cleanup (session save, tool teardown)
-    // exactly as it would without this wrapper.
-    await iterator.return?.();
-  }
+  return runInScope(storage, channel, stream);
 }

--- a/packages/foundry/src/hosting/consent.ts
+++ b/packages/foundry/src/hosting/consent.ts
@@ -17,6 +17,8 @@
  * it reports out of band instead — `consent-channel.ts`.
  */
 
+import { isRecord } from '@polymind-inc/agent-framework-core/internal';
+
 /** The JSON-RPC error code the Foundry MCP gateway uses for CONSENT_REQUIRED. */
 export const CONSENT_REQUIRED_JSON_RPC_CODE = -32006;
 
@@ -54,10 +56,6 @@ export class ToolboxConsentRequiredError extends Error {
     this.name = 'ToolboxConsentRequiredError';
     this.consents = [...consents];
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }
 
 /**

--- a/packages/foundry/src/hosting/converters.ts
+++ b/packages/foundry/src/hosting/converters.ts
@@ -172,6 +172,28 @@ function parseArguments(raw: unknown): Record<string, unknown> | string {
 }
 
 /**
+ * An assistant `function_call` replayed for information only, under a well-known name — this
+ * container cannot re-drive the call, but the model must keep seeing what it did. The arguments
+ * source stays a structured object where it is one: stringifying it would make the arguments
+ * unparseable on the next hop.
+ */
+function informationalCall(item: OutputItem, name: string, args: unknown): Message {
+  return {
+    role: 'assistant',
+    contents: [
+      {
+        type: 'function_call',
+        callId: typeof item.call_id === 'string' ? item.call_id : (item.id ?? ''),
+        name,
+        arguments: parseArguments(args),
+        informationalOnly: true,
+        rawRepresentation: item,
+      },
+    ],
+  };
+}
+
+/**
  * Converts one Responses input or output item into a framework message.
  *
  * Returns `undefined` only for items that are deliberately not replayed because another mechanism
@@ -183,20 +205,14 @@ function parseArguments(raw: unknown): Record<string, unknown> | string {
  */
 export function itemToMessage(item: OutputItem): Message | undefined {
   switch (item.type) {
-    case 'message': {
-      const role = typeof item.role === 'string' ? item.role : 'user';
+    case 'message':
+    case 'output_message': {
+      // `output_message` is an assistant turn under its dedicated wire type; the parts are the
+      // same message shapes, only the fallback role differs.
+      const fallbackRole = item.type === 'message' ? 'user' : 'assistant';
+      const role = typeof item.role === 'string' ? item.role : fallbackRole;
       const contents = contentsOfMessage(item.content, item);
       return { role, contents, ...(typeof item.id === 'string' ? { messageId: item.id } : {}) };
-    }
-
-    case 'output_message': {
-      // An assistant turn under its dedicated wire type; the parts are the same message shapes.
-      const contents = contentsOfMessage(item.content, item);
-      return {
-        role: typeof item.role === 'string' ? item.role : 'assistant',
-        contents,
-        ...(typeof item.id === 'string' ? { messageId: item.id } : {}),
-      };
     }
 
     case 'function_call':
@@ -428,22 +444,7 @@ export function itemToMessage(item: OutputItem): Message | undefined {
       };
 
     case 'computer_call':
-      // Reported for information only, under a well-known name — this container cannot re-drive
-      // a computer-use session, but the model must keep seeing what it did. The action stays a
-      // structured object: stringifying it would make the arguments unparseable on the next hop.
-      return {
-        role: 'assistant',
-        contents: [
-          {
-            type: 'function_call',
-            callId: typeof item.call_id === 'string' ? item.call_id : (item.id ?? ''),
-            name: 'computer_use',
-            arguments: parseArguments(item.action),
-            informationalOnly: true,
-            rawRepresentation: item,
-          },
-        ],
-      };
+      return informationalCall(item, 'computer_use', item.action);
 
     case 'computer_call_output':
       return {
@@ -460,34 +461,10 @@ export function itemToMessage(item: OutputItem): Message | undefined {
       };
 
     case 'custom_tool_call':
-      return {
-        role: 'assistant',
-        contents: [
-          {
-            type: 'function_call',
-            callId: typeof item.call_id === 'string' ? item.call_id : (item.id ?? ''),
-            name: typeof item.name === 'string' ? item.name : '',
-            arguments: parseArguments(item.input),
-            informationalOnly: true,
-            rawRepresentation: item,
-          },
-        ],
-      };
+      return informationalCall(item, typeof item.name === 'string' ? item.name : '', item.input);
 
     case 'apply_patch_call':
-      return {
-        role: 'assistant',
-        contents: [
-          {
-            type: 'function_call',
-            callId: typeof item.call_id === 'string' ? item.call_id : (item.id ?? ''),
-            name: 'apply_patch',
-            arguments: parseArguments(item.operation),
-            informationalOnly: true,
-            rawRepresentation: item,
-          },
-        ],
-      };
+      return informationalCall(item, 'apply_patch', item.operation);
 
     case 'apply_patch_call_output':
       return {

--- a/packages/foundry/src/hosting/foundry-storage-client.ts
+++ b/packages/foundry/src/hosting/foundry-storage-client.ts
@@ -1,6 +1,7 @@
 import { platformHeaders } from '@polymind-inc/agent-framework-agentserver';
+import { bodyText, drainBody, foundryFailureMessage, foundryRequestInit, foundryUrl } from '../http.js';
 import type { FoundryProject } from '../project.js';
-import { FOUNDRY_API_VERSION } from '../target.js';
+import { sleep } from '../sleep.js';
 
 /** The statuses worth another attempt, matching the reference retry policy's set. */
 const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([408, 429, 500, 502, 503, 504]);
@@ -8,8 +9,13 @@ const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([408, 429, 500, 502, 503
 /** The total request budget per call, including the first attempt. */
 const RETRY_ATTEMPTS = 3;
 
-function delay(ms: number): Promise<void> {
-  return ms <= 0 ? Promise.resolve() : new Promise((resolve) => setTimeout(resolve, ms));
+/**
+ * The backoff before the next attempt. A configured base delay of `0` means no waiting at all —
+ * not even a zero-millisecond timer task — which is a different zero than {@link sleep}'s (whose
+ * zero still hops through the timer so aborts land and poll loops yield).
+ */
+function retryDelay(ms: number): Promise<void> {
+  return ms <= 0 ? Promise.resolve() : sleep(ms);
 }
 
 interface FoundryStorageClientConfig {
@@ -37,15 +43,13 @@ export interface FoundryStorageAttempt {
  * built on top: create-versus-update, history pagination, write reconciliation and replay fencing.
  */
 export class FoundryStorageClient {
-  readonly #endpoint: string;
-  readonly #getToken: () => Promise<string>;
+  readonly #project: FoundryProject;
   readonly #fetch: typeof globalThis.fetch;
   readonly #forwardCallId: boolean;
   readonly #retryBaseDelayMs: number;
 
   constructor(project: FoundryProject, options: FoundryStorageClientConfig = {}) {
-    this.#endpoint = project.endpoint;
-    this.#getToken = () => project.getToken();
+    this.#project = project;
     this.#fetch = options.fetch ?? project.fetch ?? globalThis.fetch;
     this.#forwardCallId = options.forwardCallId ?? true;
     this.#retryBaseDelayMs = options.retry?.baseDelayMs ?? 500;
@@ -53,12 +57,7 @@ export class FoundryStorageClient {
 
   /** The storage base URL, for diagnostics. */
   get baseUrl(): string {
-    return `${this.#endpoint}/storage/`;
-  }
-
-  #url(path: string, extra: Record<string, string> = {}): string {
-    const query = new URLSearchParams({ 'api-version': FOUNDRY_API_VERSION, ...extra });
-    return `${this.baseUrl}${path}?${query.toString()}`;
+    return `${this.#project.endpoint}/storage/`;
   }
 
   async request(method: string, path: string, options: FoundryStorageRequestOptions = {}): Promise<Response> {
@@ -85,35 +84,27 @@ export class FoundryStorageClient {
       // request in flight, never to construction time — one container serves many users.
       let token: string;
       try {
-        token = await this.#getToken();
+        token = await this.#project.getToken();
       } catch (error) {
         // Credential refresh is transient too, but no request reached the service, so it cannot
         // make a later conflict ambiguous.
         if (last) throw error;
-        await delay(this.#retryBaseDelayMs * 2 ** attempt);
+        await retryDelay(this.#retryBaseDelayMs * 2 ** attempt);
         continue;
       }
-      const headers: Record<string, string> = {
-        authorization: `Bearer ${token}`,
-        accept: 'application/json',
-        ...(this.#forwardCallId ? platformHeaders() : {}),
-      };
-      if (options.body !== undefined) {
-        headers['content-type'] = 'application/json';
-      }
       try {
-        const response = await this.#fetch(this.#url(path, options.query ?? {}), {
-          method,
-          headers,
-          ...(options.body === undefined ? {} : { body: JSON.stringify(options.body) }),
-        });
+        const response = await this.#fetch(
+          foundryUrl(this.baseUrl, path, options.query ?? {}),
+          foundryRequestInit(method, token, {
+            ...(this.#forwardCallId ? { headers: platformHeaders() } : {}),
+            body: options.body,
+          }),
+        );
         if (last || !RETRYABLE_STATUSES.has(response.status)) {
           return { response, ambiguous };
         }
         ambiguous = true;
-        // A discarded response's body would otherwise hold its connection until GC; cancelling
-        // is best-effort resource hygiene, never a failure.
-        await response.body?.cancel().catch(() => {});
+        await drainBody(response);
       } catch (error) {
         // A network-level failure is transient by definition; the last one surfaces as-is.
         if (last) {
@@ -121,18 +112,11 @@ export class FoundryStorageClient {
         }
         ambiguous = true;
       }
-      await delay(this.#retryBaseDelayMs * 2 ** attempt);
+      await retryDelay(this.#retryBaseDelayMs * 2 ** attempt);
     }
   }
 
-  /**
-   * The failure to raise for a storage response that did not succeed.
-   *
-   * The service's own message is included. Without it a failure reads only as
-   * `Foundry storage returned 500`, which says nothing about whether the payload was wrong, the
-   * caller unresolvable, or the service down — and this runs inside a container where attaching a
-   * debugger is not an option, so the error text is the entire diagnostic.
-   */
+  /** The failure to raise for a storage response that did not succeed (see `foundryFailureMessage`). */
   async failure(response: Response, what: string): Promise<Error> {
     return this.failureFrom(response.status, await this.body(response), what);
   }
@@ -144,16 +128,10 @@ export class FoundryStorageClient {
    * reads it here and hands the same string to {@link failureFrom} rather than re-reading.
    */
   async body(response: Response): Promise<string> {
-    try {
-      return await response.text();
-    } catch {
-      // A body that cannot be read must not replace the status with a read error.
-      return '';
-    }
+    return bodyText(response);
   }
 
   failureFrom(status: number, body: string, what: string): Error {
-    const detail = body.slice(0, 500);
-    return new Error(`Foundry storage returned ${status} for ${what}.${detail === '' ? '' : ` ${detail}`}`);
+    return new Error(foundryFailureMessage('storage', status, body, what));
   }
 }

--- a/packages/foundry/src/hosting/handler.ts
+++ b/packages/foundry/src/hosting/handler.ts
@@ -14,20 +14,19 @@ import type {
   AgentLike,
   AgentSession,
   Content,
-  Message,
   SerializedAgentSession,
   UsageDetails,
 } from '@polymind-inc/agent-framework-core';
 import { addUsage, approvalResponse, AgentSession as Session } from '@polymind-inc/agent-framework-core';
 import type { ApprovalStorage } from './approval-storage.js';
 import { FileApprovalStorage, InMemoryApprovalStorage } from './approval-storage.js';
+import { compositeKey } from './composite-key.js';
 import type { ToolboxConsentRequest } from './consent.js';
 import { consentRequestsOf } from './consent.js';
 import { createConsentChannel, withConsentChannel } from './consent-channel.js';
 import {
   approvalResponseTarget,
   inputToMessages,
-  itemToMessage,
   requestToChatOptions,
   usageToResponseUsage,
 } from './converters.js';
@@ -41,6 +40,7 @@ import {
   sessionWriteKey,
   userPartition,
 } from './session-store.js';
+import { requireHostedUserId } from './user-id.js';
 
 /**
  * Picks the session store the environment calls for.
@@ -96,10 +96,7 @@ function dedupeConsents(consents: readonly ToolboxConsentRequest[]): ToolboxCons
   const seen = new Set<string>();
   const unique: ToolboxConsentRequest[] = [];
   for (const consent of consents) {
-    // JSON, not a separator: any chosen delimiter collides once a label or link can contain
-    // it, and both are gateway-authored strings (the same delimiter-collision defect fixed in
-    // the session store). A raw NUL also made this file unsearchable — ripgrep reads it as binary.
-    const key = JSON.stringify([consent.serverLabel, consent.consentLink]);
+    const key = compositeKey(consent.serverLabel, consent.consentLink);
     if (!seen.has(key)) {
       seen.add(key);
       unique.push(consent);
@@ -259,15 +256,8 @@ export function createFoundryHandler(options: FoundryHandlerConfig): ResponseHan
       assertNoExplicitHistory(agent);
     }
 
-    // An *empty* header is rejected the same as a missing one: it would silently fall through to
-    // the anonymous partition, and every caller of a misconfigured gateway would share it.
-    if (hosted && (context.request.userId === undefined || context.request.userId === '')) {
-      throw new ProtocolError(
-        400,
-        'The hosted environment is missing the platform user id. The request did not come from a ' +
-          'Foundry platform service.',
-        { code: 'missing_user_id', source: 'platform' },
-      );
+    if (hosted) {
+      requireHostedUserId(context.request.userId);
     }
 
     const userId = userPartition(context.request.userId);
@@ -335,15 +325,7 @@ export function createFoundryHandler(options: FoundryHandlerConfig): ResponseHan
     // model API's — sending it as `previous_response_id` is what the service rejects.
     clearLocalHistory(agent, session);
 
-    const history: Message[] = [];
-    for (const item of context.history) {
-      const message = itemToMessage(item);
-      if (message !== undefined) {
-        history.push(message);
-      }
-    }
-
-    const messages = [...history, ...inputToMessages(request.input)];
+    const messages = [...inputToMessages(context.history), ...inputToMessages(request.input)];
     const approvals = await resolveApprovals(request, approvalStorage, userId);
     if (approvals.length > 0) {
       messages.push({ role: 'user', contents: approvals });

--- a/packages/foundry/src/hosting/hosted-context.test.ts
+++ b/packages/foundry/src/hosting/hosted-context.test.ts
@@ -1,25 +1,10 @@
-import type { HandlerContext } from '@polymind-inc/agent-framework-agentserver';
-import { createRequestContext } from '@polymind-inc/agent-framework-agentserver';
 import { describe, expect, it } from 'vitest';
+import { testHandlerContext } from '../test-helpers.js';
 import { getHostedAgentContext, hostedAgentContextOf, withHostedAgentContext } from './hosted-context.js';
-
-function makeHandlerContext(): HandlerContext {
-  const responseId = 'caresp_test';
-  return {
-    responseId,
-    conversationId: undefined,
-    request: createRequestContext(new Headers({ 'x-agent-user-id': 'alice' })),
-    agentReference: { type: 'agent_reference', name: 'test-agent' },
-    agentSessionId: 'session-test',
-    history: [],
-    signal: new AbortController().signal,
-    response: { id: responseId, object: 'response', created_at: 0, status: 'queued', output: [] },
-  };
-}
 
 describe('withHostedAgentContext', () => {
   it('keeps the context installed while the stream is torn down early', async () => {
-    const context = hostedAgentContextOf(makeHandlerContext());
+    const context = hostedAgentContextOf(testHandlerContext({ 'x-agent-user-id': 'alice' }));
     // 'unread' rather than undefined, so a finally that never ran cannot pass the assertion.
     let seenInFinally: unknown = 'unread';
     async function* source(): AsyncGenerator<number> {
@@ -44,7 +29,7 @@ describe('withHostedAgentContext', () => {
 
 describe('hostedAgentContextOf', () => {
   it('freezes the agent reference as a copy, apart from the protocol resource', () => {
-    const handlerContext = makeHandlerContext();
+    const handlerContext = testHandlerContext({ 'x-agent-user-id': 'alice' });
     const context = hostedAgentContextOf(handlerContext);
 
     expect(Object.isFrozen(context)).toBe(true);

--- a/packages/foundry/src/hosting/hosted-context.ts
+++ b/packages/foundry/src/hosting/hosted-context.ts
@@ -29,6 +29,7 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { AgentReference, HandlerContext } from '@polymind-inc/agent-framework-agentserver';
+import { runInScope } from './run-in-scope.js';
 
 /** What one hosted turn knows about itself. One frozen instance per turn. */
 export interface HostedAgentContext {
@@ -92,30 +93,13 @@ export function getHostedAgentContext(): HostedAgentContext | undefined {
 }
 
 /**
- * Drives `stream` with `context` installed as the ambient hosted context.
- *
- * Each `next()` is invoked inside `AsyncLocalStorage.run`, which is where the agent runs the
- * round — the model call, the tools, the context providers — so a read from any of them lands on
- * this turn's context and nowhere else, including while another turn is interleaved on the same
- * container.
+ * Drives `stream` with `context` installed as the ambient hosted context, so a read from a tool,
+ * a context provider or middleware — including during teardown after an early stop — lands on
+ * this turn's context and nowhere else (see {@link runInScope} for the scoping mechanics).
  */
-export async function* withHostedAgentContext<T>(
+export function withHostedAgentContext<T>(
   context: HostedAgentContext,
   stream: AsyncIterable<T>,
 ): AsyncGenerator<T, void, undefined> {
-  const iterator = stream[Symbol.asyncIterator]();
-  try {
-    for (;;) {
-      const next = await storage.run(context, () => iterator.next());
-      if (next.done === true) {
-        return;
-      }
-      yield next.value;
-    }
-  } finally {
-    // `break` in the consumer has to reach the agent's own cleanup (session save, tool teardown,
-    // afterRun hooks) exactly as it would without this wrapper — and that cleanup runs *inside*
-    // the context, because an early end is still part of the turn it ends.
-    await storage.run(context, () => iterator.return?.());
-  }
+  return runInScope(storage, context, stream);
 }

--- a/packages/foundry/src/hosting/hosting.test.ts
+++ b/packages/foundry/src/hosting/hosting.test.ts
@@ -27,10 +27,9 @@ import {
   textContent,
   tool,
 } from '@polymind-inc/agent-framework-core';
-import { must } from '@polymind-inc/agent-framework-core/internal';
 import type { MockTurn } from '@polymind-inc/agent-framework-core/testing';
 import { MockChatClient } from '@polymind-inc/agent-framework-core/testing';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
 import { FoundryProject } from '../project.js';
 import { FileApprovalStorage, InMemoryApprovalStorage } from './approval-storage.js';
 import { consentRequestsFromMessage, ToolboxConsentRequiredError } from './consent.js';
@@ -68,17 +67,19 @@ function textOf(response: ResponseObject): string {
 
 /** Polls `GET /responses/{id}` until the response completes, failing the test after ~4s. */
 async function waitUntilCompleted(app: ResponsesServer, id: string): Promise<ResponseObject> {
-  for (let attempt = 0; attempt < 400; attempt += 1) {
-    const response = await app.handle(new Request(`http://localhost:8088/responses/${id}`));
-    if (response.status === 200) {
-      const body = (await response.json()) as ResponseObject;
-      if (body.status === 'completed') {
-        return body;
+  return vi.waitUntil(
+    async () => {
+      const response = await app.handle(new Request(`http://localhost:8088/responses/${id}`));
+      if (response.status === 200) {
+        const body = (await response.json()) as ResponseObject;
+        if (body.status === 'completed') {
+          return body;
+        }
       }
-    }
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-  throw new Error(`response ${id} never completed`);
+      return false;
+    },
+    { timeout: 4_000, interval: 10 },
+  );
 }
 
 describe('function_call_output encoding', () => {
@@ -188,7 +189,9 @@ describe('hosted agent over the protocol', () => {
 
     await app.handle(post({ input: 'hi', parallel_tool_calls: false }));
 
-    expect((must(client.calls[0]?.options) as { parallelToolCalls?: boolean }).parallelToolCalls).toBe(false);
+    const options = client.calls[0]?.options;
+    assert.exists(options);
+    expect((options as { parallelToolCalls?: boolean }).parallelToolCalls).toBe(false);
     // Anything left in `additionalProperties` is copied onto the wire request verbatim.
     expect(client.calls[0]?.options?.additionalProperties).toBeUndefined();
   });
@@ -223,7 +226,8 @@ describe('hosted agent over the protocol', () => {
       m.contents.flatMap((c) => (c.type === 'text' ? [c.text] : [])),
     );
     // 'one' appears once, from the platform history — not also from a local history provider.
-    expect(must(texts).filter((t) => t === 'one')).toHaveLength(1);
+    assert.exists(texts);
+    expect(texts.filter((t) => t === 'one')).toHaveLength(1);
   });
 
   it('never sends the container response id to the model provider', async () => {
@@ -277,12 +281,11 @@ describe('hosted agent over the protocol', () => {
     const events = body
       .split('\n\n')
       .filter((block) => block.trim() !== '' && !block.startsWith(':'))
-      .map(
-        (block) =>
-          JSON.parse(
-            must(block.split('\n').find((line) => line.startsWith('data: '))).slice('data: '.length),
-          ) as Record<string, unknown>,
-      );
+      .map((block) => {
+        const dataLine = block.split('\n').find((line) => line.startsWith('data: '));
+        assert.exists(dataLine);
+        return JSON.parse(dataLine.slice('data: '.length)) as Record<string, unknown>;
+      });
 
     expect(events.map((event) => event.type)).toEqual([
       'response.created',
@@ -298,12 +301,15 @@ describe('hosted agent over the protocol', () => {
 
     // `logprobs` is required on the text events even with nothing to report; leaving it out is a
     // schema violation on the platform side.
-    const delta = must(events.find((event) => event.type === 'response.output_text.delta'));
+    const delta = events.find((event) => event.type === 'response.output_text.delta');
+    assert.exists(delta);
     expect(delta.logprobs).toEqual([]);
     expect(delta.content_index).toBe(0);
-    const partAdded = must(events.find((event) => event.type === 'response.content_part.added'));
+    const partAdded = events.find((event) => event.type === 'response.content_part.added');
+    assert.exists(partAdded);
     expect(partAdded.part).toEqual({ type: 'output_text', text: '', annotations: [], logprobs: [] });
-    const textDone = must(events.find((event) => event.type === 'response.output_text.done'));
+    const textDone = events.find((event) => event.type === 'response.output_text.done');
+    assert.exists(textDone);
     expect(textDone.text).toBe('Hello there');
   });
 
@@ -692,7 +698,8 @@ describe('tool approval over the protocol', () => {
     // The consumer walks away; the generator's cleanup runs as it would on a real disconnect.
     await events.return?.(undefined);
 
-    expect(await approvalStorage.load('alice', must(wireId))).toBeDefined();
+    assert.exists(wireId);
+    expect(await approvalStorage.load('alice', wireId)).toBeDefined();
   });
 });
 
@@ -874,7 +881,8 @@ describe('MCP call output items', () => {
     expect(added.item).toMatchObject({ type: 'mcp_call', status: 'in_progress', arguments: '' });
     const deltas = events.filter((event) => event.type === 'response.mcp_call_arguments.delta');
     expect(deltas.map((event) => event.delta)).toEqual(['{"q":', '"x"}']);
-    const argumentsDone = must(events.find((event) => event.type === 'response.mcp_call_arguments.done'));
+    const argumentsDone = events.find((event) => event.type === 'response.mcp_call_arguments.done');
+    assert.exists(argumentsDone);
     expect(argumentsDone.arguments).toBe('{"q":"x"}');
     const done = events.at(-1) as unknown as { item: OutputItem };
     expect(done.item).toMatchObject({
@@ -915,16 +923,15 @@ describe('MCP call output items', () => {
   it('replays a stored mcp_call item as the call and its result', () => {
     // Without this the model loses what a provider-run MCP tool was asked and what it returned,
     // and re-calls it or contradicts its own transcript (Python `_item_to_message`).
-    const message = must(
-      itemToMessage({
-        type: 'mcp_call',
-        id: 'mcp_1',
-        server_label: 'github',
-        name: 'search',
-        arguments: '{"q":1}',
-        output: 'ok',
-      } as OutputItem),
-    );
+    const message = itemToMessage({
+      type: 'mcp_call',
+      id: 'mcp_1',
+      server_label: 'github',
+      name: 'search',
+      arguments: '{"q":1}',
+      output: 'ok',
+    } as OutputItem);
+    assert.exists(message);
 
     expect(message.role).toBe('assistant');
     expect(message.contents[0]).toMatchObject({
@@ -962,12 +969,15 @@ describe('reasoning output items', () => {
     ]);
     const added = events[0] as unknown as { item: OutputItem };
     expect(added.item).toMatchObject({ type: 'reasoning', status: 'in_progress' });
-    const partAdded = must(events[1]);
+    const partAdded = events[1];
+    assert.exists(partAdded);
     expect(partAdded.summary_index).toBe(0);
     expect(partAdded.part).toEqual({ type: 'summary_text', text: '' });
-    const textDone = must(events.find((event) => event.type === 'response.reasoning_summary_text.done'));
+    const textDone = events.find((event) => event.type === 'response.reasoning_summary_text.done');
+    assert.exists(textDone);
     expect(textDone.text).toBe('first second');
-    const partDone = must(events.find((event) => event.type === 'response.reasoning_summary_part.done'));
+    const partDone = events.find((event) => event.type === 'response.reasoning_summary_part.done');
+    assert.exists(partDone);
     expect(partDone.part).toEqual({ type: 'summary_text', text: 'first second' });
     const done = events.at(-1) as unknown as { item: OutputItem };
     expect(done.item).toMatchObject({ type: 'reasoning', status: 'completed' });
@@ -1021,7 +1031,8 @@ describe('reasoning output items', () => {
     expect(done.item.summary).toEqual([{ type: 'summary_text', text: 'thinking…' }]);
 
     // The round trip that was previously broken: replayed history restores the payload verbatim.
-    const replayed = must(itemToMessage(done.item));
+    const replayed = itemToMessage(done.item);
+    assert.exists(replayed);
     expect(replayed.contents[0]).toMatchObject({
       type: 'text_reasoning',
       id: providerId,
@@ -1205,17 +1216,23 @@ describe('in-memory session store keying', () => {
 
     // Mutating either the caller's value or a loaded working copy must not rewrite `root`.
     (root.state.counter as { value: number }).value = 99;
-    const firstBranch = must(await store.load('alice', 'root'));
+    const firstBranch = await store.load('alice', 'root');
+    assert.exists(firstBranch);
     (firstBranch.state.counter as { value: number }).value = 2;
     await store.save('alice', 'branch-a', firstBranch);
 
-    const secondBranch = must(await store.load('alice', 'root'));
+    const secondBranch = await store.load('alice', 'root');
+    assert.exists(secondBranch);
     expect((secondBranch.state.counter as { value: number }).value).toBe(1);
 
     // A consumer cannot mutate a saved branch through a value returned by `load`, either.
     (secondBranch.state.counter as { value: number }).value = 3;
-    expect((must(await store.load('alice', 'root')).state.counter as { value: number }).value).toBe(1);
-    expect((must(await store.load('alice', 'branch-a')).state.counter as { value: number }).value).toBe(2);
+    const loadedRoot = await store.load('alice', 'root');
+    const loadedBranch = await store.load('alice', 'branch-a');
+    assert.exists(loadedRoot);
+    assert.exists(loadedBranch);
+    expect((loadedRoot.state.counter as { value: number }).value).toBe(1);
+    expect((loadedBranch.state.counter as { value: number }).value).toBe(2);
   });
 });
 
@@ -1273,7 +1290,8 @@ describe('hosted tool content mappings', () => {
 
     // Replay round trip: the stored item restores as the call, keyed by the item id (Python
     // `from_image_generation_tool_call(image_id=ig.id)`).
-    const replayed = must(itemToMessage(done.item));
+    const replayed = itemToMessage(done.item);
+    assert.exists(replayed);
     expect(replayed.role).toBe('assistant');
     expect(replayed.contents[0]).toMatchObject({
       type: 'image_generation_tool_call',
@@ -1324,7 +1342,8 @@ describe('hosted tool content mappings', () => {
     expect(String(result.id)).toMatch(/^lsho_/);
 
     // Replay round trip (Python `_item_to_message` for `shell_call` / `shell_call_output`).
-    const replayedCall = must(itemToMessage(call));
+    const replayedCall = itemToMessage(call);
+    assert.exists(replayedCall);
     expect(replayedCall.role).toBe('assistant');
     expect(replayedCall.contents[0]).toMatchObject({
       type: 'shell_tool_call',
@@ -1332,7 +1351,8 @@ describe('hosted tool content mappings', () => {
       commands: ['ls', 'pwd'],
       status: 'completed',
     });
-    const replayedResult = must(itemToMessage(result));
+    const replayedResult = itemToMessage(result);
+    assert.exists(replayedResult);
     expect(replayedResult.role).toBe('tool');
     expect(replayedResult.contents[0]).toMatchObject({
       type: 'shell_tool_result',
@@ -1389,7 +1409,8 @@ describe('hosted tool content mappings', () => {
     });
     expect(String(item.id)).toMatch(/^ctco_/);
 
-    const replayed = must(itemToMessage(item));
+    const replayed = itemToMessage(item);
+    assert.exists(replayed);
     expect(replayed.role).toBe('tool');
     expect(replayed.contents[0]).toMatchObject({ type: 'mcp_server_tool_result', callId: 'mcp_call1' });
     expect((replayed.contents[0] as { output: Array<{ text: string }> }).output[0]?.text).toBe(
@@ -1397,14 +1418,13 @@ describe('hosted tool content mappings', () => {
     );
 
     // A non-MCP call id replays as an ordinary function result.
-    const other = must(
-      itemToMessage({
-        type: 'custom_tool_call_output',
-        id: 'ctco_x',
-        call_id: 'ctc_1',
-        output: '42',
-      } as OutputItem),
-    );
+    const other = itemToMessage({
+      type: 'custom_tool_call_output',
+      id: 'ctco_x',
+      call_id: 'ctc_1',
+      output: '42',
+    } as OutputItem);
+    assert.exists(other);
     expect(other.contents[0]).toMatchObject({ type: 'function_result', callId: 'ctc_1', result: '42' });
   });
 
@@ -1468,7 +1488,9 @@ describe('stored-history replay', () => {
       void event;
     }
 
-    const contents = must(client.calls[0]).messages.flatMap((message) => message.contents);
+    const firstCall = client.calls[0];
+    assert.exists(firstCall);
+    const contents = firstCall.messages.flatMap((message) => message.contents);
     expect(contents).toContainEqual(
       expect.objectContaining({ type: 'search_tool_call', callId: 'ws_1', toolName: 'web_search' }),
     );
@@ -1686,8 +1708,8 @@ describe('background execution with the Foundry store', () => {
     // Drain the live stream so the run finishes and persists its replay log.
     const live = await created.text();
     const id = /"id":\s*"(caresp_[A-Za-z0-9]+)"/.exec(live)?.[1];
-    expect(id).toBeDefined();
-    await waitUntilCompleted(app, must(id));
+    assert.exists(id);
+    await waitUntilCompleted(app, id);
 
     // A second subscriber replays the same events from the persisted log — the run is gone.
     const replay = await app.handle(
@@ -1737,7 +1759,9 @@ describe('background execution with the Foundry store', () => {
     expect(second.error ?? null).toBeNull();
 
     // The model saw the first turn's transcript, replayed from the service store.
-    const replayedTexts = JSON.stringify(must(client.calls[1]).messages);
+    const secondCall = client.calls[1];
+    assert.exists(secondCall);
+    const replayedTexts = JSON.stringify(secondCall.messages);
     expect(replayedTexts).toContain('remember the word apple');
     expect(replayedTexts).toContain('first answer');
   });
@@ -1755,7 +1779,9 @@ describe('background execution with the Foundry store', () => {
     ).json()) as ResponseObject;
     expect(second.status).toBe('completed');
     expect(second.error ?? null).toBeNull();
-    expect(JSON.stringify(must(client.calls[1]).messages)).toContain('the color is teal');
+    const secondCall = client.calls[1];
+    assert.exists(secondCall);
+    expect(JSON.stringify(secondCall.messages)).toContain('the color is teal');
 
     // No alias record was written under the conversation id: every stored response keeps its own
     // id, and the linkage lives in the service (the alias create would have collided anyway).
@@ -1769,7 +1795,8 @@ describe('background execution with the Foundry store', () => {
 
     const created = await app.handle(post({ input: 'hi', background: true, stream: true }));
     const live = await created.text();
-    const id = must(/"id":\s*"(caresp_[A-Za-z0-9]+)"/.exec(live)?.[1]);
+    const id = /"id":\s*"(caresp_[A-Za-z0-9]+)"/.exec(live)?.[1];
+    assert.exists(id);
     await waitUntilCompleted(app, id);
 
     const tail = await app.handle(
@@ -2136,14 +2163,13 @@ describe('OAuth consent over the protocol', () => {
   });
 
   it('replays a stored oauth_consent_request as the core consent content', () => {
-    const message = must(
-      itemToMessage({
-        type: 'oauth_consent_request',
-        id: 'oacr_1',
-        consent_link: CONSENT_LINK,
-        server_label: 'github',
-      } as OutputItem),
-    );
+    const message = itemToMessage({
+      type: 'oauth_consent_request',
+      id: 'oacr_1',
+      consent_link: CONSENT_LINK,
+      server_label: 'github',
+    } as OutputItem);
+    assert.exists(message);
 
     expect(message.role).toBe('assistant');
     // `consentLink` + `userInputRequest` per the core type (Python parity), so
@@ -2193,14 +2219,11 @@ describe('streamed event sequences for provider tool items', () => {
     const types = body
       .split('\n\n')
       .filter((block) => block.trim() !== '' && !block.startsWith(':'))
-      .map(
-        (block) =>
-          (
-            JSON.parse(
-              must(block.split('\n').find((line) => line.startsWith('data: '))).slice('data: '.length),
-            ) as Record<string, unknown>
-          ).type,
-      );
+      .map((block) => {
+        const dataLine = block.split('\n').find((line) => line.startsWith('data: '));
+        assert.exists(dataLine);
+        return (JSON.parse(dataLine.slice('data: '.length)) as Record<string, unknown>).type;
+      });
 
     expect(types).toEqual([
       'response.created',
@@ -2307,7 +2330,8 @@ describe('hosted agent context', () => {
     ).json()) as ResponseObject;
     expect(response.status).toBe('completed');
 
-    const context = must(seenByTool[0]);
+    const context = seenByTool[0];
+    assert.exists(context);
     expect(context.userId).toBe('alice');
     expect(context.callId).toBe('call-77');
     expect(context.responseId).toBe(response.id);

--- a/packages/foundry/src/hosting/hosting.test.ts
+++ b/packages/foundry/src/hosting/hosting.test.ts
@@ -27,6 +27,7 @@ import {
   textContent,
   tool,
 } from '@polymind-inc/agent-framework-core';
+import { must } from '@polymind-inc/agent-framework-core/internal';
 import type { MockTurn } from '@polymind-inc/agent-framework-core/testing';
 import { MockChatClient } from '@polymind-inc/agent-framework-core/testing';
 import { describe, expect, it } from 'vitest';
@@ -63,12 +64,6 @@ function post(body: CreateResponseRequest, headers: Record<string, string> = {})
 
 function textOf(response: ResponseObject): string {
   return JSON.stringify(response.output);
-}
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
 }
 
 /** Polls `GET /responses/{id}` until the response completes, failing the test after ~4s. */
@@ -842,7 +837,7 @@ describe('MCP call output items', () => {
   });
 
   it('emits the mcp_call event family in the reference order', () => {
-    // Python `_responses.py:1006-1128`: added → arguments delta(s) → arguments.done →
+    // Python `_responses.py`: added → arguments delta(s) → arguments.done →
     // mcp_call.completed → output_item.done, with the folded result only on the finished item.
     const builder = new OutputBuilder('caresp_hint');
     const events = [
@@ -946,7 +941,7 @@ describe('MCP call output items', () => {
 
 describe('reasoning output items', () => {
   it('emits the reasoning summary part event family in the reference order', () => {
-    // Python `_responses.py:1052-1115`: added(status in_progress) → reasoning_summary_part.added
+    // Python `_responses.py`: added(status in_progress) → reasoning_summary_part.added
     // → text delta(s) → reasoning_summary_text.done → reasoning_summary_part.done →
     // output_item.done(status completed).
     const builder = new OutputBuilder('caresp_hint');

--- a/packages/foundry/src/hosting/invocations.test.ts
+++ b/packages/foundry/src/hosting/invocations.test.ts
@@ -9,12 +9,8 @@ import {
 } from '@polymind-inc/agent-framework-core';
 import type { MockTurn } from '@polymind-inc/agent-framework-core/testing';
 import { MockChatClient } from '@polymind-inc/agent-framework-core/testing';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { InvocationsHostServer } from './invocations.js';
-
-afterEach(() => {
-  vi.unstubAllEnvs();
-});
 
 function say(text: string): MockTurn {
   return { contents: [textContent(text)], finishReason: 'stop' };

--- a/packages/foundry/src/hosting/invocations.ts
+++ b/packages/foundry/src/hosting/invocations.ts
@@ -14,7 +14,8 @@ import {
   unavailable,
 } from '@polymind-inc/agent-framework-agentserver';
 import type { AgentLike, AgentSession } from '@polymind-inc/agent-framework-core';
-import { ConfigurationError } from '@polymind-inc/agent-framework-core';
+import { isRecord, validateSafeInteger } from '@polymind-inc/agent-framework-core/internal';
+import { requireHostedUserId } from './user-id.js';
 
 const DEFAULT_MAX_SESSIONS = 1024;
 
@@ -32,13 +33,6 @@ export interface InvocationsHostServerConfig extends Pick<InvocationsServerConfi
   maxBodyBytes?: number;
   /** Maximum number of idle/in-use conversations retained in memory. Defaults to 1024. */
   maxSessions?: number;
-}
-
-function positiveLimit(name: string, value: number): number {
-  if (!Number.isSafeInteger(value) || value < 1) {
-    throw new ConfigurationError(`${name} must be a positive safe integer.`);
-  }
-  return value;
 }
 
 /**
@@ -68,17 +62,7 @@ function partitionKey(context: InvocationContext, hosted: boolean): string {
       'unsupported_container_protocol_version',
     );
   }
-  const userId = context.request.userId;
-  // An *empty* header is rejected the same as a missing one: it would silently fall through to
-  // an anonymous partition every caller of a misconfigured gateway would share.
-  if (userId === undefined || userId === '') {
-    throw new ProtocolError(
-      400,
-      'The hosted environment is missing the platform user id. The request did not come from a ' +
-        'Foundry platform service.',
-      { code: 'missing_user_id', source: 'platform' },
-    );
-  }
+  const userId = requireHostedUserId(context.request.userId);
   // The reference spells this `sessionId:userId`, but a bare join is not injective: the session
   // id is caller-supplied and may itself contain `:`, so `S:v` × user `u` and `S` × user `v:u`
   // would collapse into one identity (the same delimiter-collision defect the Responses session
@@ -90,7 +74,7 @@ function partitionKey(context: InvocationContext, hosted: boolean): string {
 
 /** What a well-formed invocation body carries. */
 function parseInvocation(payload: unknown): { message: string; stream: boolean } {
-  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+  if (!isRecord(payload)) {
     throw badRequest('The request body must be a JSON object.');
   }
   const { message, stream } = payload as { message?: unknown; stream?: unknown };
@@ -279,8 +263,8 @@ export class InvocationsHostServer extends InvocationsServer {
         // split the container's behaviour over one variable. Only an explicit option is checked.
         options.maxBodyBytes === undefined
           ? maxBodyBytes()
-          : positiveLimit('maxBodyBytes', options.maxBodyBytes),
-        positiveLimit('maxSessions', options.maxSessions ?? DEFAULT_MAX_SESSIONS),
+          : validateSafeInteger('maxBodyBytes', options.maxBodyBytes, 1),
+        validateSafeInteger('maxSessions', options.maxSessions ?? DEFAULT_MAX_SESSIONS, 1),
       ),
       ...(options.prefix === undefined ? {} : { prefix: options.prefix }),
     });

--- a/packages/foundry/src/hosting/memory-scope.test.ts
+++ b/packages/foundry/src/hosting/memory-scope.test.ts
@@ -1,27 +1,12 @@
-import type { HandlerContext } from '@polymind-inc/agent-framework-agentserver';
-import { createRequestContext } from '@polymind-inc/agent-framework-agentserver';
 import { ConfigurationError } from '@polymind-inc/agent-framework-core';
 import { describe, expect, it } from 'vitest';
+import { testHandlerContext } from '../test-helpers.js';
 import { hostedAgentContextOf, withHostedAgentContext } from './hosted-context.js';
 import { hostedUserScope } from './memory-scope.js';
 
-function handlerContext(headers: Record<string, string>): HandlerContext {
-  const responseId = 'caresp_test';
-  return {
-    responseId,
-    conversationId: undefined,
-    request: createRequestContext(new Headers(headers)),
-    agentReference: { type: 'agent_reference', name: 'test-agent' },
-    agentSessionId: 'session-test',
-    history: [],
-    signal: new AbortController().signal,
-    response: { id: responseId, object: 'response', created_at: 0, status: 'queued', output: [] },
-  };
-}
-
 /** Reads `scope` from inside a hosted turn built on `headers`. */
 async function insideTurn(headers: Record<string, string>, scope: () => string): Promise<unknown> {
-  const context = hostedAgentContextOf(handlerContext(headers));
+  const context = hostedAgentContextOf(testHandlerContext(headers));
   async function* source(): AsyncGenerator<unknown> {
     try {
       yield scope();

--- a/packages/foundry/src/hosting/output.ts
+++ b/packages/foundry/src/hosting/output.ts
@@ -5,6 +5,7 @@ import type {
   FunctionApprovalRequestContent,
   TextReasoningContent,
 } from '@polymind-inc/agent-framework-core';
+import { isRecord } from '@polymind-inc/agent-framework-core/internal';
 import { reasoningEncryptedContent, stringifyMcpOutput } from '@polymind-inc/agent-framework-openai/internal';
 import type { ToolboxConsentRequest } from './consent.js';
 import { AGENT_FRAMEWORK_SERVER_LABEL, encodeFunctionOutput } from './converters.js';
@@ -145,8 +146,8 @@ function argumentsRecord(args: Record<string, unknown> | string | undefined): Re
   if (typeof args === 'string' && args !== '') {
     try {
       const parsed: unknown = JSON.parse(args);
-      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-        return parsed as Record<string, unknown>;
+      if (isRecord(parsed)) {
+        return parsed;
       }
     } catch {
       // Fall through to the empty object.

--- a/packages/foundry/src/hosting/response-store.test.ts
+++ b/packages/foundry/src/hosting/response-store.test.ts
@@ -9,7 +9,7 @@ import {
   runWithRequestContext,
 } from '@polymind-inc/agent-framework-agentserver';
 import { ConfigurationError } from '@polymind-inc/agent-framework-core';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FoundryProject } from '../project.js';
 import { FoundryResponseStore } from './response-store.js';
 import { defaultStore } from './server.js';
@@ -92,17 +92,9 @@ async function asPlatformRequest<T>(headers: Record<string, string>, fn: () => P
 
 // The write path stamps the agent identity from the environment when the response carries none, so
 // a developer shell configured for a real agent must not leak into the assertions below.
-const savedAgentEnv = {
-  name: process.env.FOUNDRY_AGENT_NAME,
-  version: process.env.FOUNDRY_AGENT_VERSION,
-};
 beforeEach(() => {
-  delete process.env.FOUNDRY_AGENT_NAME;
-  delete process.env.FOUNDRY_AGENT_VERSION;
-});
-afterEach(() => {
-  if (savedAgentEnv.name !== undefined) process.env.FOUNDRY_AGENT_NAME = savedAgentEnv.name;
-  if (savedAgentEnv.version !== undefined) process.env.FOUNDRY_AGENT_VERSION = savedAgentEnv.version;
+  vi.stubEnv('FOUNDRY_AGENT_NAME', undefined);
+  vi.stubEnv('FOUNDRY_AGENT_VERSION', undefined);
 });
 
 /** The reference the store stamps when neither the response nor the environment names an agent. */
@@ -355,28 +347,20 @@ describe('FoundryResponseStore request headers', () => {
 });
 
 describe('default store selection', () => {
-  const saved = { ...process.env };
-
-  afterEach(() => {
-    process.env = { ...saved };
-  });
-
   it('keeps a local run in memory', () => {
     expect(defaultStore(false).constructor.name).toBe('InMemoryResponseProvider');
   });
 
   it('activates the Foundry storage service in a container, the way Python does', () => {
-    process.env.FOUNDRY_PROJECT_ENDPOINT = PROJECT;
-    process.env.FOUNDRY_AGENT_NAME = 'weather-agent';
-    process.env.FOUNDRY_AGENT_VERSION = '1';
+    vi.stubEnv('FOUNDRY_PROJECT_ENDPOINT', PROJECT);
+    vi.stubEnv('FOUNDRY_AGENT_NAME', 'weather-agent');
+    vi.stubEnv('FOUNDRY_AGENT_VERSION', '1');
 
     expect(defaultStore(true).constructor.name).toBe('FoundryResponseStore');
   });
 
   it('activates it on the project endpoint alone — the agent identity has a default', () => {
-    process.env.FOUNDRY_PROJECT_ENDPOINT = PROJECT;
-    delete process.env.FOUNDRY_AGENT_NAME;
-    delete process.env.FOUNDRY_AGENT_VERSION;
+    vi.stubEnv('FOUNDRY_PROJECT_ENDPOINT', PROJECT);
 
     expect(defaultStore(true).constructor.name).toBe('FoundryResponseStore');
   });
@@ -384,7 +368,7 @@ describe('default store selection', () => {
   it('falls back to the sandbox filesystem when a hosted container has no endpoint', () => {
     // Should not happen — the platform injects FOUNDRY_PROJECT_ENDPOINT — but a misconfigured
     // container serving turns off its sandbox beats one that cannot start.
-    delete process.env.FOUNDRY_PROJECT_ENDPOINT;
+    vi.stubEnv('FOUNDRY_PROJECT_ENDPOINT', undefined);
 
     expect(defaultStore(true).constructor.name).toBe('FileResponseProvider');
   });
@@ -396,8 +380,8 @@ describe('agent reference stamping', () => {
   // from inside a hosted container). The store therefore never sends a response without one.
 
   it('stamps the environment agent identity onto a response that lacks one', async () => {
-    process.env.FOUNDRY_AGENT_NAME = 'weather-agent';
-    process.env.FOUNDRY_AGENT_VERSION = '3';
+    vi.stubEnv('FOUNDRY_AGENT_NAME', 'weather-agent');
+    vi.stubEnv('FOUNDRY_AGENT_VERSION', '3');
     const { store: subject, calls } = store([{ status: 201 }]);
 
     await subject.put({ response: response() });
@@ -418,7 +402,7 @@ describe('agent reference stamping', () => {
   });
 
   it('passes a caller-supplied agent reference through unchanged', async () => {
-    process.env.FOUNDRY_AGENT_NAME = 'weather-agent';
+    vi.stubEnv('FOUNDRY_AGENT_NAME', 'weather-agent');
     const { store: subject, calls } = store([{ status: 201 }]);
     const supplied = { type: 'agent_reference' as const, name: 'router-agent', version: '2' };
 

--- a/packages/foundry/src/hosting/response-store.test.ts
+++ b/packages/foundry/src/hosting/response-store.test.ts
@@ -9,7 +9,7 @@ import {
   runWithRequestContext,
 } from '@polymind-inc/agent-framework-agentserver';
 import { ConfigurationError } from '@polymind-inc/agent-framework-core';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FoundryProject } from '../project.js';
 import { FoundryResponseStore } from './response-store.js';
 import { defaultStore } from './server.js';
@@ -170,7 +170,7 @@ describe('FoundryResponseStore', () => {
 
   it('falls back to an update when the conflict arrives as a 400 with a conflict code', async () => {
     // The service expresses duplicate-create as either status; the reference's `_is_conflict`
-    // (`store/_foundry_provider.py:41-61`) reads the body, not the status line.
+    // (`store/_foundry_provider.py`) reads the body, not the status line.
     const { store: subject, calls } = store([
       { status: 400, body: { error: { code: 'already_exists', message: 'nope' } } },
       { status: 200 },
@@ -706,6 +706,21 @@ describe('bounded retry', () => {
     await subject.put({ response: response() });
 
     expect(calls).toHaveLength(2);
+  });
+
+  it('retries with no timer at all when baseDelayMs is 0', async () => {
+    // "Zero base delay" means no waiting — not even a zero-millisecond timer task, which is why
+    // this runs under fake timers that are never advanced.
+    vi.useFakeTimers();
+    try {
+      const { store: subject, calls } = store([{ status: 503 }, { status: 201 }]);
+
+      await subject.put({ response: response() });
+
+      expect(calls).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('gives up after the attempt budget and surfaces the last failure', async () => {

--- a/packages/foundry/src/hosting/response-store.ts
+++ b/packages/foundry/src/hosting/response-store.ts
@@ -14,6 +14,7 @@ import {
   resolveAgentReference,
   stateRoot,
 } from '@polymind-inc/agent-framework-agentserver';
+import { isRecord } from '@polymind-inc/agent-framework-core/internal';
 import type { FoundryProject } from '../project.js';
 import { FoundryStorageClient } from './foundry-storage-client.js';
 
@@ -25,11 +26,11 @@ export interface FoundryResponseStoreConfig {
    * The project's endpoint must be the **project** endpoint — not a storage URL. `/storage/` is
    * appended unconditionally, so a value that already ends in `/storage` produces
    * `.../storage/storage/`. That is deliberate parity, not an oversight: both response-store
-   * references append without looking (Python `store/_foundry_settings.py:55`
-   * `endpoint.rstrip("/") + "/storage/"`, .NET `ResponsesServerServiceCollectionExtensions.cs:170`
+   * references append without looking (Python `store/_foundry_settings.py`
+   * `endpoint.rstrip("/") + "/storage/"`, .NET `ResponsesServerServiceCollectionExtensions.cs`
    * `uri...TrimEnd('/') + "/storage/"`), and the platform never sets `FOUNDRY_PROJECT_ENDPOINT` to
    * a storage URL. .NET's *shared* `FoundryStorageEndpoint.FromEndpoint`
-   * (`AgentServer.Core/src/Storage/FoundryStorageEndpoint.cs:77-79`) does skip a `/storage` suffix,
+   * (`AgentServer.Core/src/Storage/FoundryStorageEndpoint.cs`) does skip a `/storage` suffix,
    * but it documents its parameter as "the project endpoint **or** a full `.../storage` URL" — a
    * wider contract, for the state store, which this package does not have. Narrowing the accepted
    * form keeps a misconfigured endpoint a visible 404 rather than something silently repaired.
@@ -80,7 +81,7 @@ interface CreateBody {
  * The `error.code` values the service uses for a duplicate create.
  *
  * Verbatim from the reference's `_is_conflict`
- * (`azure-ai-agentserver-responses/.../store/_foundry_provider.py:41-61`).
+ * (`azure-ai-agentserver-responses/.../store/_foundry_provider.py`).
  */
 const CONFLICT_CODES = new Set(['conflict', 'already_exists', 'duplicate']);
 
@@ -88,13 +89,13 @@ const CONFLICT_CODES = new Set(['conflict', 'already_exists', 'duplicate']);
  * Whether a failed create is the service saying *this id already exists*.
  *
  * **The status line alone is not the signal.** The reference maps HTTP 400 *and* 409 to the same
- * `FoundryBadRequestError` (`store/_foundry_errors.py:59-62`) and then separates a duplicate create
+ * `FoundryBadRequestError` (`store/_foundry_errors.py`) and then separates a duplicate create
  * from a genuine bad request by the body — `error.code` in {@link CONFLICT_CODES}, or the phrase
- * `already exists` in `error.message` (`store/_foundry_provider.py:280`). Reading only the status
+ * `already exists` in `error.message` (`store/_foundry_provider.py`). Reading only the status
  * would turn a 400-flavoured conflict into a lost turn.
  *
  * A body that is not the Foundry error envelope is *not* a conflict: the reference's message in
- * that case is its own generated fallback (`_foundry_errors.py:96`), which matches neither test.
+ * that case is its own generated fallback (`_foundry_errors.py`), which matches neither test.
  */
 function isDuplicateCreate(body: string): boolean {
   let parsed: unknown;
@@ -103,14 +104,14 @@ function isDuplicateCreate(body: string): boolean {
   } catch {
     return false;
   }
-  if (typeof parsed !== 'object' || parsed === null) {
+  if (!isRecord(parsed)) {
     return false;
   }
-  const error = (parsed as { error?: unknown }).error;
-  if (typeof error !== 'object' || error === null) {
+  const error = parsed.error;
+  if (!isRecord(error)) {
     return false;
   }
-  const { code, message } = error as { code?: unknown; message?: unknown };
+  const { code, message } = error;
   if (typeof code === 'string' && CONFLICT_CODES.has(code.toLowerCase())) {
     return true;
   }
@@ -172,7 +173,7 @@ function sameTurn(local: ResponseObject, remote: ResponseObject): boolean {
  *
  * Transient failures get a bounded retry (see {@link FoundryResponseStoreConfig.retry}), the way
  * both references get one from their platform HTTP stack — Python an `AsyncPipelineClient` with
- * `policies.AsyncRetryPolicy()` (`store/_foundry_provider.py:181-204`), .NET a
+ * `policies.AsyncRetryPolicy()` (`store/_foundry_provider.py`), .NET a
  * `ClientOptions`-derived `HttpPipeline`. Retrying the **non-idempotent** `POST responses` is
  * safe here for the same reason it is in Python: a create that landed before its response was
  * lost answers the retry as a duplicate, which `put` already treats as the update branch.
@@ -180,9 +181,9 @@ function sameTurn(local: ResponseObject, remote: ResponseObject): boolean {
  * **Abort propagation is a separate claim, and it does not hold.** Neither reference cancels a
  * storage call from the request. Python's provider takes no cancellation argument at all; .NET's
  * takes `CancellationToken cancellationToken = default` on every method and its hosting layer
- * passes one at **zero** call sites — every `_provider.CreateResponseAsync` /
- * `UpdateResponseAsync` / `GetResponseAsync` / `DeleteResponseAsync` in
- * `Internal/ResponseOrchestrator.cs` (:377, :569, :574, :898, :904) supplies only the platform
+ * passes one at **zero** call sites — all five `_provider.CreateResponseAsync` /
+ * `UpdateResponseAsync` / `GetResponseAsync` / `DeleteResponseAsync` calls in
+ * `Internal/ResponseOrchestrator.cs` supply only the platform
  * context, leaving `CancellationToken.None`. That is the safe reading: aborting a *terminal*
  * persist when a client hangs up is how a finished turn becomes an unrecoverable one, which is
  * also why background runs are independent of the request signal to begin with. Threading a

--- a/packages/foundry/src/hosting/run-in-scope.ts
+++ b/packages/foundry/src/hosting/run-in-scope.ts
@@ -1,0 +1,34 @@
+import type { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Drives `source` with `value` installed in `storage`, as an async generator.
+ *
+ * Each `next()` is invoked *inside* `AsyncLocalStorage.run`, which is where the agent runs the
+ * round — the model call, the tools, the context providers — so a read from any of them lands on
+ * this turn's value and nowhere else, including while another turn is interleaved on the same
+ * container. Wrapping the whole `for await` instead would leave the store's propagation into the
+ * generator's resumption up to where the loop happened to be suspended.
+ *
+ * The teardown runs inside the scope too: `break` in the consumer has to reach the agent's own
+ * cleanup (session save, tool teardown, afterRun hooks) exactly as it would without this wrapper —
+ * and that cleanup runs *inside* the scope, because an early end is still part of the turn it
+ * ends.
+ */
+export async function* runInScope<T, V>(
+  storage: AsyncLocalStorage<V>,
+  value: V,
+  source: AsyncIterable<T>,
+): AsyncGenerator<T, void, undefined> {
+  const iterator = source[Symbol.asyncIterator]();
+  try {
+    for (;;) {
+      const next = await storage.run(value, () => iterator.next());
+      if (next.done === true) {
+        return;
+      }
+      yield next.value;
+    }
+  } finally {
+    await storage.run(value, () => iterator.return?.());
+  }
+}

--- a/packages/foundry/src/hosting/session-store.ts
+++ b/packages/foundry/src/hosting/session-store.ts
@@ -5,9 +5,10 @@ import {
   writeJsonFile,
 } from '@polymind-inc/agent-framework-agentserver/internal';
 import type { SerializedAgentSession } from '@polymind-inc/agent-framework-core';
+import { compositeKey } from './composite-key.js';
 
 /** A session snapshot plus the user it belongs to. */
-export interface StoredSession {
+interface StoredSession {
   userId: string;
   session: SerializedAgentSession;
 }
@@ -101,21 +102,8 @@ export class FileSystemAgentSessionStore implements AgentSessionStore {
 export class InMemoryAgentSessionStore implements AgentSessionStore {
   readonly #sessions = new Map<string, StoredSession>();
 
-  /**
-   * A map key that cannot collide across `(userId, key)` pairs.
-   *
-   * Both halves are untrusted strings (a header, a request body), so joining them with *any*
-   * delimiter character lets a crafted conversation id impersonate another pair — the previous
-   * NUL-joined scheme let `key = "alice\u0000conv1"` overwrite the entry for `("alice", "conv1")`.
-   * `JSON.stringify` escapes every character, so the pair is recoverable and the composition is
-   * structurally injective.
-   */
-  static #compositeKey(userId: string, key: string): string {
-    return JSON.stringify([userId, key]);
-  }
-
   async load(userId: string, key: string): Promise<SerializedAgentSession | undefined> {
-    const stored = this.#sessions.get(InMemoryAgentSessionStore.#compositeKey(userId, key));
+    const stored = this.#sessions.get(compositeKey(userId, key));
     // A key another user owns is reported as absent, not as forbidden: a distinguishable refusal
     // tells the caller that *someone* holds that conversation id, and a conversation id is
     // guessable in a way an identity is not. The caller gets a
@@ -126,7 +114,7 @@ export class InMemoryAgentSessionStore implements AgentSessionStore {
   async save(userId: string, key: string, session: SerializedAgentSession): Promise<void> {
     // Keyed by the pair, so one user's write can never reach another user's entry — the same
     // isolation the filesystem store gets from its `[userId, key]` path.
-    this.#sessions.set(InMemoryAgentSessionStore.#compositeKey(userId, key), {
+    this.#sessions.set(compositeKey(userId, key), {
       userId,
       session: cloneSession(session),
     });

--- a/packages/foundry/src/hosting/toolbox.test.ts
+++ b/packages/foundry/src/hosting/toolbox.test.ts
@@ -8,18 +8,13 @@ import {
 } from '@polymind-inc/agent-framework-agentserver';
 import type { ContextProvider, Tool } from '@polymind-inc/agent-framework-core';
 import { AgentSession, ConfigurationError, isFunctionTool } from '@polymind-inc/agent-framework-core';
+import { must } from '@polymind-inc/agent-framework-core/internal';
 import { describe, expect, it, vi } from 'vitest';
 import { FoundryProject } from '../project.js';
 import { ToolboxConsentRequiredError } from './consent.js';
 import { FoundryToolbox } from './toolbox.js';
 
 const PROJECT = 'https://my-resource.services.ai.azure.com/api/projects/my-project';
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}
 
 let tokenCounter = 0;
 const credential: TokenCredential = {

--- a/packages/foundry/src/hosting/toolbox.test.ts
+++ b/packages/foundry/src/hosting/toolbox.test.ts
@@ -8,8 +8,7 @@ import {
 } from '@polymind-inc/agent-framework-agentserver';
 import type { ContextProvider, Tool } from '@polymind-inc/agent-framework-core';
 import { AgentSession, ConfigurationError, isFunctionTool } from '@polymind-inc/agent-framework-core';
-import { must } from '@polymind-inc/agent-framework-core/internal';
-import { describe, expect, it, vi } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
 import { FoundryProject } from '../project.js';
 import { ToolboxConsentRequiredError } from './consent.js';
 import { FoundryToolbox } from './toolbox.js';
@@ -230,7 +229,9 @@ describe('FoundryToolbox tools', () => {
       name: 'search_docs',
       description: 'Search the documentation',
     });
-    expect(isFunctionTool(must(tools[0]))).toBe(true);
+    const firstTool = tools[0];
+    assert.exists(firstTool);
+    expect(isFunctionTool(firstTool)).toBe(true);
     await toolbox.close();
   });
 
@@ -413,7 +414,8 @@ describe('FoundryToolbox skills', () => {
     expect(contributed.tools.map((entry) => entry.name)).toContain('load_skill');
     // Nothing new is authenticated: the discovery request carries the same per-call token and
     // call id every `tools/call` does.
-    const read = must(calls.find((call) => call.method === 'resources/read'));
+    const read = calls.find((call) => call.method === 'resources/read');
+    assert.exists(read);
     expect(read.headers.authorization).toMatch(/^Bearer token-/);
     expect(read.headers[HEADERS.foundryCallId]).toBe('call-1');
     await toolbox.close();
@@ -427,7 +429,8 @@ describe('FoundryToolbox skills', () => {
     const contributed = await contribute(
       toolbox.asSkillsProvider({ approvals: { loadSkill: 'never_require' } }),
     );
-    const loadSkill = must(contributed.tools.filter(isFunctionTool).find((t) => t.name === 'load_skill'));
+    const loadSkill = contributed.tools.filter(isFunctionTool).find((t) => t.name === 'load_skill');
+    assert.exists(loadSkill);
     const content = await (loadSkill.execute as (i: unknown, c: { callId: string }) => Promise<string>)(
       { skill_name: 'escalation-policy' },
       { callId: 'c1' },

--- a/packages/foundry/src/hosting/user-id.ts
+++ b/packages/foundry/src/hosting/user-id.ts
@@ -1,0 +1,19 @@
+import { ProtocolError } from '@polymind-inc/agent-framework-agentserver';
+
+/**
+ * The platform-injected user id, refused when the hosted environment did not supply one.
+ *
+ * An *empty* header is rejected the same as a missing one: it would silently fall through to an
+ * anonymous partition every caller of a misconfigured gateway would share.
+ */
+export function requireHostedUserId(userId: string | undefined): string {
+  if (userId === undefined || userId === '') {
+    throw new ProtocolError(
+      400,
+      'The hosted environment is missing the platform user id. The request did not come from a ' +
+        'Foundry platform service.',
+      { code: 'missing_user_id', source: 'platform' },
+    );
+  }
+  return userId;
+}

--- a/packages/foundry/src/http.test.ts
+++ b/packages/foundry/src/http.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { bodyText, drainBody } from './http.js';
 
 describe('bodyText', () => {
@@ -31,13 +31,9 @@ describe('drainBody', () => {
   }
 
   it('cancels a normal body', async () => {
-    let cancelled = false;
-    await drainBody(
-      withBody(async () => {
-        cancelled = true;
-      }),
-    );
-    expect(cancelled).toBe(true);
+    const cancel = vi.fn(async () => {});
+    await drainBody(withBody(cancel));
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
   it('resolves when there is no body at all', async () => {

--- a/packages/foundry/src/http.test.ts
+++ b/packages/foundry/src/http.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { bodyText, drainBody } from './http.js';
+
+describe('bodyText', () => {
+  it('reads the body of a normal response', async () => {
+    expect(await bodyText(new Response('payload'))).toBe('payload');
+  });
+
+  it('degrades to an empty string when reading rejects', async () => {
+    const response = new Response('payload');
+    await response.text();
+    // A second read rejects: the body is already consumed.
+    expect(await bodyText(response)).toBe('');
+  });
+
+  it('degrades to an empty string when text() itself throws synchronously', async () => {
+    // A non-standard Response-like transport can throw instead of rejecting; the failure to read
+    // a body must never replace the status the caller is diagnosing.
+    const throwing = {
+      text(): Promise<string> {
+        throw new Error('no body access');
+      },
+    } as unknown as Response;
+    expect(await bodyText(throwing)).toBe('');
+  });
+});
+
+describe('drainBody', () => {
+  function withBody(cancel: () => Promise<void>): Response {
+    return { body: { cancel } } as unknown as Response;
+  }
+
+  it('cancels a normal body', async () => {
+    let cancelled = false;
+    await drainBody(
+      withBody(async () => {
+        cancelled = true;
+      }),
+    );
+    expect(cancelled).toBe(true);
+  });
+
+  it('resolves when there is no body at all', async () => {
+    await drainBody({ body: null } as unknown as Response);
+  });
+
+  it('resolves when cancel() rejects', async () => {
+    await drainBody(withBody(() => Promise.reject(new Error('locked'))));
+  });
+
+  it('resolves when cancel() itself throws synchronously', async () => {
+    // Best-effort resource hygiene, never a failure: a Response-like whose cancel() throws must
+    // not turn a succeeded operation into a failed one.
+    await drainBody(
+      withBody(() => {
+        throw new Error('locked');
+      }),
+    );
+  });
+});

--- a/packages/foundry/src/http.ts
+++ b/packages/foundry/src/http.ts
@@ -1,0 +1,91 @@
+/**
+ * Request assembly and failure diagnostics shared by the hand-written Foundry data-plane clients
+ * (response storage, memory stores). Retry policy stays with each client: storage retries
+ * transient failures, memory deliberately does not.
+ */
+
+import { FOUNDRY_API_VERSION } from './target.js';
+
+/** The full request URL: the base, the route, and the data-plane api-version query. */
+export function foundryUrl(base: string, path: string, extraQuery: Record<string, string> = {}): string {
+  const query = new URLSearchParams({ 'api-version': FOUNDRY_API_VERSION, ...extraQuery });
+  return `${base}${path}?${query.toString()}`;
+}
+
+/** What one Foundry data-plane request carries beyond its method and route. */
+export interface FoundryRequestOptions {
+  /** Headers beyond bearer auth and accept — platform correlation headers, feature opt-ins. */
+  headers?: Record<string, string>;
+  /** JSON-encoded onto the request, with the matching content-type. */
+  body?: unknown;
+  signal?: AbortSignal | undefined;
+}
+
+/**
+ * The `fetch` init for one authenticated JSON request: bearer auth, JSON accept, and — only when
+ * a body is present — the JSON content-type and the encoded body.
+ */
+export function foundryRequestInit(
+  method: string,
+  token: string,
+  options: FoundryRequestOptions = {},
+): RequestInit {
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${token}`,
+    accept: 'application/json',
+    ...options.headers,
+  };
+  if (options.body !== undefined) {
+    headers['content-type'] = 'application/json';
+  }
+  return {
+    method,
+    headers,
+    ...(options.body === undefined ? {} : { body: JSON.stringify(options.body) }),
+    ...(options.signal === undefined ? {} : { signal: options.signal }),
+  };
+}
+
+/**
+ * The response body as text, or `''` when it cannot be read.
+ *
+ * A body that cannot be read must not replace the status with a read error.
+ */
+export async function bodyText(response: Response): Promise<string> {
+  // try/catch rather than `.catch()`: a non-standard transport can throw from `text()` itself
+  // synchronously, and that failure degrades the same way as a rejected read.
+  try {
+    return await response.text();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * The diagnostic message for a data-plane response that did not succeed.
+ *
+ * The service's own message is included, bounded. Without it a failure reads only as
+ * `Foundry storage returned 500`, which says nothing about whether the payload was wrong, the
+ * caller unresolvable, or the service down — and this runs inside a container where attaching a
+ * debugger is not an option, so the error text is the entire diagnostic.
+ */
+export function foundryFailureMessage(service: string, status: number, body: string, what: string): string {
+  const detail = body.slice(0, 500);
+  return `Foundry ${service} returned ${status} for ${what}.${detail === '' ? '' : ` ${detail}`}`;
+}
+
+/**
+ * Cancels a discarded response's body.
+ *
+ * A response nothing reads would otherwise hold its connection until GC; cancelling is
+ * best-effort resource hygiene, never a failure.
+ */
+export async function drainBody(response: Response): Promise<void> {
+  // try/catch rather than `.catch()`: a non-standard transport can throw from `cancel()` itself
+  // synchronously, and "never a failure" has to cover that path too.
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Best-effort only.
+  }
+}

--- a/packages/foundry/src/integration-extensibility.test.ts
+++ b/packages/foundry/src/integration-extensibility.test.ts
@@ -31,6 +31,7 @@ import {
   tool,
   toolApprovalMiddleware,
 } from '@polymind-inc/agent-framework-core';
+import { must } from '@polymind-inc/agent-framework-core/internal';
 import { describe, expect, it } from 'vitest';
 import { FoundryChatClient } from './chat-client.js';
 import { FoundryProject } from './project.js';
@@ -39,12 +40,6 @@ const projectEndpoint = process.env.FOUNDRY_PROJECT_ENDPOINT;
 const modelDeployment =
   process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? process.env.FOUNDRY_MODEL_DEPLOYMENT ?? 'gpt-4o-mini';
 const TIMEOUT = 120_000;
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}
 
 const deploymentClient = (): FoundryChatClient =>
   new FoundryChatClient({

--- a/packages/foundry/src/integration-extensibility.test.ts
+++ b/packages/foundry/src/integration-extensibility.test.ts
@@ -31,8 +31,7 @@ import {
   tool,
   toolApprovalMiddleware,
 } from '@polymind-inc/agent-framework-core';
-import { must } from '@polymind-inc/agent-framework-core/internal';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import { FoundryChatClient } from './chat-client.js';
 import { FoundryProject } from './project.js';
 
@@ -41,11 +40,13 @@ const modelDeployment =
   process.env.AZURE_AI_MODEL_DEPLOYMENT_NAME ?? process.env.FOUNDRY_MODEL_DEPLOYMENT ?? 'gpt-4o-mini';
 const TIMEOUT = 120_000;
 
-const deploymentClient = (): FoundryChatClient =>
-  new FoundryChatClient({
-    project: new FoundryProject(must(projectEndpoint), new DefaultAzureCredential()),
+const deploymentClient = (): FoundryChatClient => {
+  assert.exists(projectEndpoint);
+  return new FoundryChatClient({
+    project: new FoundryProject(projectEndpoint, new DefaultAzureCredential()),
     target: { model: modelDeployment },
   });
+};
 
 /** A weather tool, the smallest thing that makes a real model call a function. */
 const getWeather = tool({

--- a/packages/foundry/src/integration.test.ts
+++ b/packages/foundry/src/integration.test.ts
@@ -17,6 +17,7 @@ import { DefaultAzureCredential } from '@azure/identity';
 import type { ResponseObject } from '@polymind-inc/agent-framework-agentserver';
 import { ID_PREFIX, newId, newResponseId } from '@polymind-inc/agent-framework-agentserver';
 import { Agent, tool } from '@polymind-inc/agent-framework-core';
+import { must } from '@polymind-inc/agent-framework-core/internal';
 import { describe, expect, it } from 'vitest';
 import { FoundryChatClient } from './chat-client.js';
 import { FoundryResponseStore } from './hosting/response-store.js';
@@ -30,12 +31,6 @@ const serverAgent = process.env.FOUNDRY_SERVER_AGENT;
 const toolboxName = process.env.FOUNDRY_TOOLBOX_NAME;
 const runIntegration = process.env.RUN_INTEGRATION_TESTS === '1';
 const TIMEOUT = 60_000;
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}
 
 const project = (): FoundryProject => new FoundryProject(must(projectEndpoint), new DefaultAzureCredential());
 

--- a/packages/foundry/src/integration.test.ts
+++ b/packages/foundry/src/integration.test.ts
@@ -17,8 +17,7 @@ import { DefaultAzureCredential } from '@azure/identity';
 import type { ResponseObject } from '@polymind-inc/agent-framework-agentserver';
 import { ID_PREFIX, newId, newResponseId } from '@polymind-inc/agent-framework-agentserver';
 import { Agent, tool } from '@polymind-inc/agent-framework-core';
-import { must } from '@polymind-inc/agent-framework-core/internal';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import { FoundryChatClient } from './chat-client.js';
 import { FoundryResponseStore } from './hosting/response-store.js';
 import { FoundryToolbox } from './hosting/toolbox.js';
@@ -32,7 +31,10 @@ const toolboxName = process.env.FOUNDRY_TOOLBOX_NAME;
 const runIntegration = process.env.RUN_INTEGRATION_TESTS === '1';
 const TIMEOUT = 60_000;
 
-const project = (): FoundryProject => new FoundryProject(must(projectEndpoint), new DefaultAzureCredential());
+const project = (): FoundryProject => {
+  assert.exists(projectEndpoint);
+  return new FoundryProject(projectEndpoint, new DefaultAzureCredential());
+};
 
 const deploymentClient = (): FoundryChatClient =>
   new FoundryChatClient({ project: project(), target: { model: modelDeployment } });
@@ -77,9 +79,10 @@ describe.runIf(runIntegration && projectEndpoint !== undefined && projectEndpoin
       'talks to an existing server agent',
       { timeout: TIMEOUT },
       async () => {
+        assert.exists(serverAgent);
         const client = new FoundryChatClient({
           project: project(),
-          target: { serverAgent: must(serverAgent) },
+          target: { serverAgent },
         });
 
         const response = await new Agent({ client }).run('Hello');
@@ -102,7 +105,10 @@ describe.runIf(
     toolboxName !== undefined &&
     toolboxName !== '',
 )('Foundry Toolbox (integration)', () => {
-  const toolbox = (): FoundryToolbox => new FoundryToolbox({ name: must(toolboxName), project: project() });
+  const toolbox = (): FoundryToolbox => {
+    assert.exists(toolboxName);
+    return new FoundryToolbox({ name: toolboxName, project: project() });
+  };
 
   it('lists the toolbox tools over MCP', { timeout: TIMEOUT }, async () => {
     const box = toolbox();

--- a/packages/foundry/src/memory/client.test.ts
+++ b/packages/foundry/src/memory/client.test.ts
@@ -161,6 +161,47 @@ describe('MemoryStoreClient', () => {
     });
   });
 
+  it('treats a success body whose text() throws synchronously as unreadable, not as a failure', async () => {
+    // The client accepts a custom fetch, so a Response-like transport can throw from `text()`
+    // itself rather than rejecting; the unreadable-success-body contract (an empty object,
+    // nothing to carry forward) applies the same way, and no raw error escapes the operation.
+    const throwing = {
+      ok: true,
+      status: 200,
+      text(): Promise<string> {
+        throw new Error('no body access');
+      },
+    } as unknown as Response;
+    const fetchStub = (async (): Promise<Response> => throwing) as typeof globalThis.fetch;
+    const subject = new MemoryStoreClient({
+      project: new FoundryProject(PROJECT, credential),
+      fetch: fetchStub,
+    });
+
+    expect(await subject.searchMemories({ name: 'store', scope: 'user-1' })).toEqual({});
+  });
+
+  it('reports a deleted scope even when discarding the body throws synchronously', async () => {
+    // Draining the unread body is best-effort hygiene; a transport whose cancel() throws must
+    // not turn the succeeded delete into a failure.
+    const hostile = {
+      ok: true,
+      status: 200,
+      body: {
+        cancel(): Promise<void> {
+          throw new Error('locked');
+        },
+      },
+    } as unknown as Response;
+    const fetchStub = (async (): Promise<Response> => hostile) as typeof globalThis.fetch;
+    const subject = new MemoryStoreClient({
+      project: new FoundryProject(PROJECT, credential),
+      fetch: fetchStub,
+    });
+
+    expect(await subject.deleteScope('store', 'user-1')).toBe(true);
+  });
+
   it('raises a typed error naming the operation, the status and the service message', async () => {
     const { client: memory } = client([{ status: 500, body: { error: { message: 'boom' } } }]);
 

--- a/packages/foundry/src/memory/client.ts
+++ b/packages/foundry/src/memory/client.ts
@@ -12,9 +12,9 @@
  * and neither does this.
  */
 
-import { AgentFrameworkError } from '@polymind-inc/agent-framework-core';
+import { AgentFrameworkError, setIfDefined } from '@polymind-inc/agent-framework-core';
+import { bodyText, drainBody, foundryFailureMessage, foundryRequestInit, foundryUrl } from '../http.js';
 import type { FoundryProject } from '../project.js';
-import { FOUNDRY_API_VERSION } from '../target.js';
 
 /**
  * The preview opt-in every memory-store route requires.
@@ -130,13 +130,11 @@ export interface MemoryStoreClientOptions {
  * and you hand it both.
  */
 export class MemoryStoreClient {
-  readonly #endpoint: string;
-  readonly #getToken: () => Promise<string>;
+  readonly #project: FoundryProject;
   readonly #fetch: typeof globalThis.fetch;
 
   constructor(options: MemoryStoreClientOptions) {
-    this.#endpoint = options.project.endpoint;
-    this.#getToken = () => options.project.getToken();
+    this.#project = options.project;
     this.#fetch = options.fetch ?? options.project.fetch ?? globalThis.fetch;
   }
 
@@ -152,12 +150,8 @@ export class MemoryStoreClient {
     signal?: AbortSignal,
   ): Promise<MemorySearchResponse> {
     const body: Record<string, unknown> = { scope: request.scope };
-    if (request.items !== undefined) {
-      body.items = request.items;
-    }
-    if (request.previousSearchId !== undefined) {
-      body.previous_search_id = request.previousSearchId;
-    }
+    setIfDefined(body, 'items', request.items);
+    setIfDefined(body, 'previous_search_id', request.previousSearchId);
     if (request.maxMemories !== undefined) {
       body.options = { max_memories: request.maxMemories };
     }
@@ -186,12 +180,8 @@ export class MemoryStoreClient {
     signal?: AbortSignal,
   ): Promise<MemoryUpdateResponse> {
     const body: Record<string, unknown> = { scope: request.scope, items: request.items };
-    if (request.previousUpdateId !== undefined) {
-      body.previous_update_id = request.previousUpdateId;
-    }
-    if (request.updateDelay !== undefined) {
-      body.update_delay = request.updateDelay;
-    }
+    setIfDefined(body, 'previous_update_id', request.previousUpdateId);
+    setIfDefined(body, 'update_delay', request.updateDelay);
     const response = await this.#send('POST', `${this.#store(request.name)}:update_memories`, {
       operation: 'update',
       body,
@@ -220,9 +210,8 @@ export class MemoryStoreClient {
       signal,
       allowNotFound: true,
     });
-    // Nothing here reads the body; draining it keeps the connection from being held open until
-    // the discarded response is collected.
-    await response.body?.cancel().catch(() => {});
+    // Nothing here reads the body.
+    await drainBody(response);
     return response.status !== 404;
   }
 
@@ -234,9 +223,8 @@ export class MemoryStoreClient {
       allowNotFound: true,
     });
     if (response.status === 404) {
-      // The body is an error envelope, not a store; draining it keeps the connection from being
-      // held open until the response is collected.
-      await response.body?.cancel().catch(() => {});
+      // The body is an error envelope, not a store.
+      await drainBody(response);
       return undefined;
     }
     return await MemoryStoreClient.#json<MemoryStoreObject>(response, 'getStore');
@@ -248,9 +236,7 @@ export class MemoryStoreClient {
     signal?: AbortSignal,
   ): Promise<MemoryStoreObject> {
     const body: Record<string, unknown> = { name: request.name, definition: request.definition };
-    if (request.description !== undefined) {
-      body.description = request.description;
-    }
+    setIfDefined(body, 'description', request.description);
     const response = await this.#send('POST', 'memory_stores', {
       operation: 'createStore',
       body,
@@ -274,21 +260,14 @@ export class MemoryStoreClient {
       allowNotFound?: boolean;
     },
   ): Promise<Response> {
-    const url = `${this.#endpoint}/${path}?${new URLSearchParams({ 'api-version': FOUNDRY_API_VERSION })}`;
-    const headers: Record<string, string> = {
-      authorization: `Bearer ${await this.#getToken()}`,
-      accept: 'application/json',
-      'Foundry-Features': MEMORY_PREVIEW_FEATURE,
-    };
-    if (options.body !== undefined) {
-      headers['content-type'] = 'application/json';
-    }
-    const response = await this.#fetch(url, {
-      method,
-      headers,
-      ...(options.body === undefined ? {} : { body: JSON.stringify(options.body) }),
-      ...(options.signal === undefined ? {} : { signal: options.signal }),
-    });
+    const response = await this.#fetch(
+      foundryUrl(`${this.#project.endpoint}/`, path),
+      foundryRequestInit(method, await this.#project.getToken(), {
+        headers: { 'Foundry-Features': MEMORY_PREVIEW_FEATURE },
+        body: options.body,
+        signal: options.signal,
+      }),
+    );
     if (!response.ok && !(options.allowNotFound === true && response.status === 404)) {
       throw await MemoryStoreClient.#failure(response, options.operation, `${method} ${path}`);
     }
@@ -303,7 +282,7 @@ export class MemoryStoreClient {
    * default, and an empty object reads downstream as "nothing to carry forward".
    */
   static async #json<T>(response: Response, operation: MemoryOperation): Promise<T> {
-    const text = await response.text().catch(() => '');
+    const text = await bodyText(response);
     if (text.trim() === '') {
       return {} as T;
     }
@@ -318,21 +297,15 @@ export class MemoryStoreClient {
     }
   }
 
-  /**
-   * The failure to raise for a refused call.
-   *
-   * The service's own message is included: this runs inside a container where the error text is
-   * the entire diagnostic.
-   */
+  /** The failure to raise for a refused call (see `foundryFailureMessage`). */
   static async #failure(
     response: Response,
     operation: MemoryOperation,
     what: string,
   ): Promise<FoundryMemoryError> {
-    const detail = (await response.text().catch(() => '')).slice(0, 500);
     return new FoundryMemoryError(
       operation,
-      `Foundry memory returned ${response.status} for ${what}.${detail === '' ? '' : ` ${detail}`}`,
+      foundryFailureMessage('memory', response.status, await bodyText(response), what),
       { status: response.status },
     );
   }

--- a/packages/foundry/src/memory/provider.test.ts
+++ b/packages/foundry/src/memory/provider.test.ts
@@ -637,6 +637,34 @@ describe('FoundryMemoryProvider', () => {
       expect(Date.now() - started).toBeLessThan(2_000);
     });
 
+    it('stops an immediate-interval poll the moment the caller aborts', { timeout: 2_000 }, async () => {
+      const { memory } = provider({
+        update: [{ status: 202, body: { update_id: 'upd_a' } }],
+        store: [{ body: { update_id: 'upd_a', status: 'in_progress' } }],
+      });
+      await agentWith(memory).agent.run('hello');
+
+      const controller = new AbortController();
+      const waiting = memory.whenUpdatesCompleted({ pollIntervalMs: 0, signal: controller.signal });
+      setTimeout(() => controller.abort(), 10);
+
+      await expect(waiting).rejects.toThrow();
+    });
+
+    it('yields to the event loop between immediate-interval polls', { timeout: 2_000 }, async () => {
+      // The completion arrives via a real timer; a zero-interval loop that never left the
+      // microtask queue would starve that timer and hang here.
+      const storeReplies = [{ body: { update_id: 'upd_a', status: 'in_progress' } }];
+      const { memory } = provider({
+        update: [{ status: 202, body: { update_id: 'upd_a' } }],
+        store: storeReplies,
+      });
+      await agentWith(memory).agent.run('hello');
+
+      setTimeout(() => storeReplies.push({ body: { update_id: 'upd_a', status: 'completed' } }), 10);
+      await memory.whenUpdatesCompleted({ pollIntervalMs: 0 });
+    });
+
     it('raises when the extraction failed', async () => {
       const { memory } = provider({
         update: [{ status: 202, body: { update_id: 'upd_a' } }],

--- a/packages/foundry/src/memory/provider.ts
+++ b/packages/foundry/src/memory/provider.ts
@@ -13,6 +13,7 @@ import {
   textOf,
 } from '@polymind-inc/agent-framework-core';
 import type { FoundryProject } from '../project.js';
+import { sleep } from '../sleep.js';
 import type { MemoryInputItem, MemoryOperation, MemoryStoreDefinition, MemoryStoreObject } from './client.js';
 import { FoundryMemoryError, MemoryStoreClient } from './client.js';
 
@@ -420,25 +421,6 @@ export class FoundryMemoryProvider implements ContextProvider {
       throw error;
     }
   }
-}
-
-/** Resolves after `ms`, or rejects the moment `signal` aborts instead of at the timer. */
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (signal?.aborted === true) {
-      reject(signal.reason);
-      return;
-    }
-    const onAbort = (): void => {
-      clearTimeout(timer);
-      reject(signal?.reason);
-    };
-    const timer = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    }, ms);
-    signal?.addEventListener('abort', onAbort, { once: true });
-  });
 }
 
 /** The memory texts a search answered with, in order, dropping the blank ones. */

--- a/packages/foundry/src/project.test.ts
+++ b/packages/foundry/src/project.test.ts
@@ -1,21 +1,10 @@
-import type { AccessToken, TokenCredential } from '@azure/identity';
+import type { TokenCredential } from '@azure/identity';
 import { ConfigurationError } from '@polymind-inc/agent-framework-core';
 import { describe, expect, it, vi } from 'vitest';
 import { FoundryProject } from './project.js';
+import { fakeCredential } from './test-helpers.js';
 
 const PROJECT = 'https://my-resource.services.ai.azure.com/api/projects/my-project';
-
-/** A credential whose tokens expire `ttlMs` from now. */
-function fakeCredential(ttlMs = 60 * 60 * 1000): TokenCredential & { calls: number } {
-  const credential = {
-    calls: 0,
-    async getToken(): Promise<AccessToken> {
-      credential.calls++;
-      return { token: `token-${credential.calls}`, expiresOnTimestamp: Date.now() + ttlMs };
-    },
-  };
-  return credential;
-}
 
 describe('FoundryProject', () => {
   it('normalizes the endpoint and exposes it', () => {

--- a/packages/foundry/src/project.test.ts
+++ b/packages/foundry/src/project.test.ts
@@ -29,7 +29,7 @@ describe('FoundryProject', () => {
 
     expect(await project.getToken()).toBe('token-1');
     expect(await project.getToken()).toBe('token-1');
-    expect(credential.calls).toBe(1);
+    expect(credential.getToken).toHaveBeenCalledOnce();
   });
 
   it('refreshes a token that is about to expire', async () => {
@@ -48,7 +48,7 @@ describe('FoundryProject', () => {
     const tokens = await Promise.all([project.getToken(), project.getToken(), project.getToken()]);
 
     expect(tokens).toEqual(['token-1', 'token-1', 'token-1']);
-    expect(credential.calls).toBe(1);
+    expect(credential.getToken).toHaveBeenCalledOnce();
   });
 
   it('requests the Foundry data-plane scope by default', async () => {
@@ -78,7 +78,7 @@ describe('FoundryProject', () => {
     await project.getToken();
     await project.getToken('https://other.example/.default');
 
-    expect(credential.calls).toBe(2);
+    expect(credential.getToken).toHaveBeenCalledTimes(2);
   });
 
   it('reports a credential that cannot produce a token', async () => {

--- a/packages/foundry/src/sleep.test.ts
+++ b/packages/foundry/src/sleep.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { sleep } from './sleep.js';
+
+describe('sleep', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('lands an abort raised immediately after a zero-delay call', async () => {
+    // Even a zero delay registers its timer and abort listener before resolving: a caller that
+    // aborts in the same task still gets the rejection. ("No waiting at zero" is the *storage
+    // retry* contract, applied at its call sites — not this function's.)
+    const controller = new AbortController();
+    const reason = new Error('stop');
+    const pending = sleep(0, controller.signal);
+    controller.abort(reason);
+    await expect(pending).rejects.toBe(reason);
+  });
+
+  it('resolves a zero delay on the timer task, so a poll loop yields the event loop', async () => {
+    vi.useFakeTimers();
+    let resolved = false;
+    void sleep(0).then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(true);
+  });
+
+  it('waits for the timer on a positive delay', async () => {
+    vi.useFakeTimers();
+    let resolved = false;
+    void sleep(50).then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(resolved).toBe(true);
+  });
+
+  it('rejects with the signal reason when already aborted, even at zero delay', async () => {
+    const controller = new AbortController();
+    const reason = new Error('stop');
+    controller.abort(reason);
+    await expect(sleep(0, controller.signal)).rejects.toBe(reason);
+  });
+
+  it('rejects with the signal reason the moment the signal aborts', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const reason = new Error('stop');
+    const pending = sleep(1000, controller.signal);
+    const outcome = expect(pending).rejects.toBe(reason);
+    controller.abort(reason);
+    await outcome;
+  });
+});

--- a/packages/foundry/src/sleep.ts
+++ b/packages/foundry/src/sleep.ts
@@ -1,0 +1,28 @@
+/**
+ * Resolves after `ms`, or rejects the moment `signal` aborts instead of at the timer; with no
+ * signal it is a plain sleep.
+ *
+ * Deliberately not `node:timers/promises`: its `setTimeout` rejects an abort with its own
+ * `AbortError` rather than the signal's reason, and callers here surface the reason as-is.
+ */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted === true) {
+      reject(signal.reason);
+      return;
+    }
+    // Deliberately no fast path at zero: even `sleep(0)` goes through the timer, so an abort
+    // raised in the same task still lands, and a zero-interval poll loop yields the event loop
+    // on every round instead of starving it. A caller whose contract says "zero means no waiting
+    // at all" (the storage retry) makes that call-site decision itself.
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(signal?.reason);
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}

--- a/packages/foundry/src/test-helpers.ts
+++ b/packages/foundry/src/test-helpers.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared fixtures for this package's tests.
+ *
+ * Not part of the published build: nothing reachable from `src/index.ts` or `src/hosting.ts`
+ * imports it, and the test runner collects only `*.test.ts` files.
+ */
+
+import type { AccessToken, TokenCredential } from '@azure/identity';
+import type { HandlerContext } from '@polymind-inc/agent-framework-agentserver';
+import { createRequestContext } from '@polymind-inc/agent-framework-agentserver';
+
+/** A credential whose tokens expire `ttlMs` from now. */
+export function fakeCredential(ttlMs: number = 60 * 60 * 1000): TokenCredential & { calls: number } {
+  const credential = {
+    calls: 0,
+    async getToken(): Promise<AccessToken> {
+      credential.calls++;
+      return { token: `token-${credential.calls}`, expiresOnTimestamp: Date.now() + ttlMs };
+    },
+  };
+  return credential;
+}
+
+/** A handler context for one hosted turn, built on the given request headers. */
+export function testHandlerContext(headers: Record<string, string>): HandlerContext {
+  const responseId = 'caresp_test';
+  return {
+    responseId,
+    conversationId: undefined,
+    request: createRequestContext(new Headers(headers)),
+    agentReference: { type: 'agent_reference', name: 'test-agent' },
+    agentSessionId: 'session-test',
+    history: [],
+    signal: new AbortController().signal,
+    response: { id: responseId, object: 'response', created_at: 0, status: 'queued', output: [] },
+  };
+}

--- a/packages/foundry/src/test-helpers.ts
+++ b/packages/foundry/src/test-helpers.ts
@@ -8,17 +8,17 @@
 import type { AccessToken, TokenCredential } from '@azure/identity';
 import type { HandlerContext } from '@polymind-inc/agent-framework-agentserver';
 import { createRequestContext } from '@polymind-inc/agent-framework-agentserver';
+import { type Mocked, vi } from 'vitest';
 
 /** A credential whose tokens expire `ttlMs` from now. */
-export function fakeCredential(ttlMs: number = 60 * 60 * 1000): TokenCredential & { calls: number } {
-  const credential = {
-    calls: 0,
-    async getToken(): Promise<AccessToken> {
-      credential.calls++;
-      return { token: `token-${credential.calls}`, expiresOnTimestamp: Date.now() + ttlMs };
-    },
-  };
-  return credential;
+export function fakeCredential(ttlMs: number = 60 * 60 * 1000): Mocked<TokenCredential> {
+  let calls = 0;
+  return {
+    getToken: vi.fn<TokenCredential['getToken']>(async (): Promise<AccessToken> => {
+      calls += 1;
+      return { token: `token-${calls}`, expiresOnTimestamp: Date.now() + ttlMs };
+    }),
+  } satisfies TokenCredential;
 }
 
 /** A handler context for one hosted turn, built on the given request headers. */

--- a/packages/mcp/src/client.test.ts
+++ b/packages/mcp/src/client.test.ts
@@ -19,7 +19,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { McpClient } from './client.js';
 import { fromMcpContent } from './content.js';
 import type { TestTool } from './test-server.js';
-import { TestMcpServer } from './test-server.js';
+import { SlowStartServer, TestMcpServer } from './test-server.js';
 
 function server(): TestMcpServer {
   return new TestMcpServer([
@@ -431,35 +431,6 @@ describe('connection recovery', () => {
     await mcp.close();
   });
 });
-
-/** A transport whose first `start()` blocks until the test releases it. */
-class SlowStartServer extends TestMcpServer {
-  release!: () => void;
-  /** Resolves once the client's connect has reached the transport. */
-  readonly reached: Promise<void>;
-  readonly #gate: Promise<void>;
-  #reachedResolve!: () => void;
-  #first = true;
-
-  constructor(tools: TestTool[]) {
-    super(tools);
-    this.#gate = new Promise((resolve) => {
-      this.release = resolve;
-    });
-    this.reached = new Promise((resolve) => {
-      this.#reachedResolve = resolve;
-    });
-  }
-
-  override async start(): Promise<void> {
-    if (this.#first) {
-      this.#first = false;
-      this.#reachedResolve();
-      await this.#gate;
-    }
-    await super.start();
-  }
-}
 
 /** A transport that accepts `tools/call` and never answers it, so the call stays in flight. */
 class HangingCallServer extends TestMcpServer {

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -12,6 +12,7 @@ import {
   textOfContents,
   tool,
 } from '@polymind-inc/agent-framework-core';
+import { errorMessageOf } from '@polymind-inc/agent-framework-core/internal';
 import { McpConnection } from './connection.js';
 import { fromMcpContents, mcpMetaProperties } from './content.js';
 import type { McpHeaderProvider } from './headers.js';
@@ -207,14 +208,13 @@ export class McpClient {
   }
 
   #toFunctionTool(declared: DeclaredTool): FunctionTool<Record<string, unknown>, unknown> {
-    const target = this.#target;
     return tool({
       name: declared.name,
       // Python parity (`_mcp.py`: `tool.description or ""`): a missing description stays empty
       // rather than the name doubling as prose.
       description: declared.description ?? '',
       // The server's JSON Schema is the contract; the framework does not re-derive it.
-      parameters: (declared.inputSchema ?? { type: 'object' }) as Record<string, unknown>,
+      parameters: declared.inputSchema ?? { type: 'object' },
       approvalMode: approvalModeFor(this.#config.approvalMode, declared.name),
       execute: async (input: unknown, ctx: ToolContext): Promise<Content[]> => {
         try {
@@ -260,7 +260,7 @@ export class McpClient {
           }
           throw new ToolInvocationError(
             declared.name,
-            `MCP call to ${target} failed: ${error instanceof Error ? error.message : String(error)}`,
+            `MCP call to ${this.#target} failed: ${errorMessageOf(error)}`,
             { cause: error },
           );
         }

--- a/packages/mcp/src/connection.test.ts
+++ b/packages/mcp/src/connection.test.ts
@@ -11,7 +11,7 @@ import { ConfigurationError } from '@polymind-inc/agent-framework-core';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MCP_CLIENT_VERSION, McpConnection } from './connection.js';
 import type { TestTool } from './test-server.js';
-import { TestMcpServer } from './test-server.js';
+import { SlowStartServer, TestMcpServer } from './test-server.js';
 
 function echoTool(): TestTool {
   return {
@@ -380,32 +380,3 @@ describe('telemetry', () => {
     expect(span?.status.message).toBe('the tool is broken');
   });
 });
-
-/** A transport whose first `start()` blocks until the test releases it. */
-class SlowStartServer extends TestMcpServer {
-  release!: () => void;
-  /** Resolves once the client's connect has reached the transport. */
-  readonly reached: Promise<void>;
-  readonly #gate: Promise<void>;
-  #reachedResolve!: () => void;
-  #first = true;
-
-  constructor(tools: TestTool[]) {
-    super(tools);
-    this.#gate = new Promise((resolve) => {
-      this.release = resolve;
-    });
-    this.reached = new Promise((resolve) => {
-      this.#reachedResolve = resolve;
-    });
-  }
-
-  override async start(): Promise<void> {
-    if (this.#first) {
-      this.#first = false;
-      this.#reachedResolve();
-      await this.#gate;
-    }
-    await super.start();
-  }
-}

--- a/packages/mcp/src/connection.ts
+++ b/packages/mcp/src/connection.ts
@@ -322,9 +322,8 @@ export class McpConnection {
       name,
       { ...this.#spanAttributes(), [GEN_AI.toolName]: name, [GEN_AI.toolType]: 'mcp' },
       async (span) => {
-        const requestOptions = options?.signal === undefined ? undefined : { signal: options.signal };
         const result = await this.#withReconnect((client) =>
-          client.callTool({ name, arguments: args }, requestOptions),
+          client.callTool({ name, arguments: args }, options),
         );
         if (result.isError === true) {
           const text = textOfBlocks(result.content);
@@ -346,10 +345,7 @@ export class McpConnection {
       'resources/read',
       undefined,
       { ...this.#spanAttributes(), [MCP.resourceUri]: uri },
-      async () => {
-        const requestOptions = options?.signal === undefined ? undefined : { signal: options.signal };
-        return this.#withReconnect((client) => client.readResource({ uri }, requestOptions));
-      },
+      async () => this.#withReconnect((client) => client.readResource({ uri }, options)),
     );
   }
 

--- a/packages/mcp/src/headers.ts
+++ b/packages/mcp/src/headers.ts
@@ -7,7 +7,7 @@
 export type McpHeaderProvider = () => Record<string, string> | Promise<Record<string, string>>;
 
 /** Reads the configured headers, calling the provider when there is one. */
-export async function resolveHeaders(
+async function resolveHeaders(
   headers: Record<string, string> | McpHeaderProvider | undefined,
 ): Promise<Record<string, string>> {
   if (headers === undefined) {

--- a/packages/mcp/src/integration.test.ts
+++ b/packages/mcp/src/integration.test.ts
@@ -19,8 +19,7 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
-import { must } from '@polymind-inc/agent-framework-core/internal';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import { McpClient } from './client.js';
 
 const url = process.env.MCP_SERVER_URL;
@@ -30,8 +29,9 @@ const toolArgs = process.env.MCP_TOOL_ARGS ?? '{"query":"Azure AI Foundry agent"
 const TIMEOUT = 60_000;
 
 function connect(): McpClient {
+  assert.exists(url);
   return new McpClient({
-    url: must(url),
+    url,
     ...(authToken === undefined ? {} : { headers: { authorization: `Bearer ${authToken}` } }),
   });
 }
@@ -90,7 +90,8 @@ describe.runIf(process.env.RUN_INTEGRATION_TESTS === '1' && url !== undefined &&
       // A reachable host that speaks HTTP but not MCP — a copied-and-pasted URL, a proxy in front of
       // the wrong route. The connection must fail rather than hang, and it must fail on the first
       // `getTools()` rather than at construction, since the client is deliberately lazy.
-      const origin = new URL(must(url)).origin;
+      assert.exists(url);
+      const origin = new URL(url).origin;
       const mcp = new McpClient({ url: origin });
 
       expect(mcp.connected).toBe(false);
@@ -120,7 +121,8 @@ describe.runIf(process.env.RUN_INTEGRATION_TESTS === '1' && url !== undefined &&
         expect(call?.kind).toBe(SpanKind.CLIENT);
         expect(call?.attributes['mcp.method.name']).toBe('tools/call');
         expect(call?.attributes['gen_ai.tool.type']).toBe('mcp');
-        expect(call?.attributes['server.address']).toBe(new URL(must(url)).hostname);
+        assert.exists(url);
+        expect(call?.attributes['server.address']).toBe(new URL(url).hostname);
       } finally {
         await mcp.close();
         await provider.shutdown();

--- a/packages/mcp/src/integration.test.ts
+++ b/packages/mcp/src/integration.test.ts
@@ -19,6 +19,7 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
+import { must } from '@polymind-inc/agent-framework-core/internal';
 import { describe, expect, it } from 'vitest';
 import { McpClient } from './client.js';
 
@@ -27,12 +28,6 @@ const authToken = process.env.MCP_AUTH_TOKEN;
 const toolName = process.env.MCP_TOOL_NAME ?? 'microsoft_docs_search';
 const toolArgs = process.env.MCP_TOOL_ARGS ?? '{"query":"Azure AI Foundry agent"}';
 const TIMEOUT = 60_000;
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
-}
 
 function connect(): McpClient {
   return new McpClient({

--- a/packages/mcp/src/skills.test.ts
+++ b/packages/mcp/src/skills.test.ts
@@ -92,6 +92,20 @@ describe('discovery', () => {
     await connection.close();
   });
 
+  it('reports an index whose root is a JSON array as invalid, like any non-object', async () => {
+    const failures: SkillLoadFailure[] = [];
+    const { connection } = serverWith([{ uri: INDEX_URI, text: '[]' }]);
+
+    const skills = await mcpSkillsSource(connection).getSkills(
+      context({ reportSkillError: (failure) => failures.push(failure) }),
+    );
+
+    expect(skills).toEqual([]);
+    expect(failures).toHaveLength(1);
+    expect(String(failures[0]?.error)).toContain('must contain a JSON object');
+    await connection.close();
+  });
+
   it('surfaces a real failure instead of reading it as "no skills"', async () => {
     // An authorization rejection must not look the same as an empty catalogue: an agent that
     // silently lost its skills is worse than one that says why.

--- a/packages/mcp/src/skills.ts
+++ b/packages/mcp/src/skills.ts
@@ -11,6 +11,7 @@ import type {
   SkillsSourceContext,
 } from '@polymind-inc/agent-framework-core';
 import { AgentFrameworkError, dataContent, skillFrontmatter } from '@polymind-inc/agent-framework-core';
+import { errorMessageOf, isRecord } from '@polymind-inc/agent-framework-core/internal';
 
 /**
  * The one capability skill discovery needs from a connection.
@@ -140,19 +141,15 @@ async function readIndex(
     ctx.reportSkillError({ origin: indexUri, error });
     return [];
   }
-  if (typeof parsed !== 'object' || parsed === null) {
+  if (!isRecord(parsed)) {
     ctx.reportSkillError({
       origin: indexUri,
       error: new AgentFrameworkError(`${indexUri} must contain a JSON object.`),
     });
     return [];
   }
-  const skills = (parsed as { skills?: unknown }).skills;
+  const skills = parsed.skills;
   return Array.isArray(skills) ? (skills.filter(isRecord) as SkillIndexEntry[]) : [];
-}
-
-function isRecord(value: unknown): boolean {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /** Builds one skill, or reports why the entry was skipped and returns `undefined`. */
@@ -189,9 +186,7 @@ function buildSkill(
       description: typeof entry.description === 'string' ? entry.description : '',
     });
   } catch (error) {
-    return skip(
-      `Skipping skill index entry '${named ?? '(unnamed)'}': ${error instanceof Error ? error.message : String(error)}`,
-    );
+    return skip(`Skipping skill index entry '${named ?? '(unnamed)'}': ${errorMessageOf(error)}`);
   }
 
   return mcpSkill(connection, frontmatter, entry.url);

--- a/packages/mcp/src/test-server.ts
+++ b/packages/mcp/src/test-server.ts
@@ -1,4 +1,5 @@
 import type { Transport } from '@modelcontextprotocol/client';
+import { errorMessageOf } from '@polymind-inc/agent-framework-core/internal';
 
 /** A tool a {@link TestMcpServer} answers `tools/list` with. */
 export interface TestTool {
@@ -113,6 +114,11 @@ export class TestMcpServer implements Transport {
       id: request.id as string | number,
       result,
     });
+    const fail = (code: number, message: string, data?: unknown): JsonRpcMessage => ({
+      jsonrpc: '2.0',
+      id: request.id as string | number,
+      error: { code, message, ...(data === undefined ? {} : { data }) },
+    });
     switch (request.method) {
       case 'initialize':
         this.initializeParams = request.params ?? {};
@@ -138,20 +144,12 @@ export class TestMcpServer implements Transport {
         this.calls.push({ name, arguments: args });
         const target = this.#tools.find((entry) => entry.name === name);
         if (target === undefined) {
-          return {
-            jsonrpc: '2.0',
-            id: request.id as string | number,
-            error: { code: -32602, message: `Unknown tool: ${name}` },
-          };
+          return fail(-32602, `Unknown tool: ${name}`);
         }
         try {
           return respond(target.call(args));
         } catch (error) {
-          return {
-            jsonrpc: '2.0',
-            id: request.id as string | number,
-            error: { code: -32603, message: error instanceof Error ? error.message : String(error) },
-          };
+          return fail(-32603, errorMessageOf(error));
         }
       }
       case 'resources/read': {
@@ -161,11 +159,7 @@ export class TestMcpServer implements Transport {
         if (found === undefined) {
           // What a compliant server answers for a URI it does not serve: Invalid Params with the
           // requested URI echoed in `data`, which is how the SDK reconstructs its typed error.
-          return {
-            jsonrpc: '2.0',
-            id: request.id as string | number,
-            error: { code: -32602, message: `Resource not found: ${uri}`, data: { uri } },
-          };
+          return fail(-32602, `Resource not found: ${uri}`, { uri });
         }
         const { uri: _uri, ...contents } = found;
         return respond({ contents: [{ uri, ...contents }] });
@@ -173,11 +167,36 @@ export class TestMcpServer implements Transport {
       case 'ping':
         return respond({});
       default:
-        return {
-          jsonrpc: '2.0',
-          id: request.id as string | number,
-          error: { code: -32601, message: `Method not found: ${String(request.method)}` },
-        };
+        return fail(-32601, `Method not found: ${String(request.method)}`);
     }
+  }
+}
+
+/** A transport whose first `start()` blocks until the test releases it. */
+export class SlowStartServer extends TestMcpServer {
+  release!: () => void;
+  /** Resolves once the client's connect has reached the transport. */
+  readonly reached: Promise<void>;
+  readonly #gate: Promise<void>;
+  #reachedResolve!: () => void;
+  #first = true;
+
+  constructor(tools: TestTool[]) {
+    super(tools);
+    this.#gate = new Promise((resolve) => {
+      this.release = resolve;
+    });
+    this.reached = new Promise((resolve) => {
+      this.#reachedResolve = resolve;
+    });
+  }
+
+  override async start(): Promise<void> {
+    if (this.#first) {
+      this.#first = false;
+      this.#reachedResolve();
+      await this.#gate;
+    }
+    await super.start();
   }
 }

--- a/packages/openai/src/chat-client.test.ts
+++ b/packages/openai/src/chat-client.test.ts
@@ -2,6 +2,7 @@ import type { Message } from '@polymind-inc/agent-framework-core';
 import {
   Agent,
   approvalResponse,
+  arrayToStream,
   ChatClientError,
   ConfigurationError,
   ContentFilterError,
@@ -10,6 +11,7 @@ import {
   textContent,
   tool,
 } from '@polymind-inc/agent-framework-core';
+import { must } from '@polymind-inc/agent-framework-core/internal';
 import OpenAI, { AzureOpenAI } from 'openai';
 import { describe, expect, it, vi } from 'vitest';
 import { OpenAIChatClient } from './chat-client.js';
@@ -28,12 +30,6 @@ interface InputItem {
   call_id?: string;
   output?: string;
   content?: Array<Record<string, unknown>>;
-}
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
 }
 
 function completedResponse(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -63,12 +59,6 @@ function completedResponse(overrides: Record<string, unknown> = {}): Record<stri
 function fakeClient(create: ReturnType<typeof vi.fn>, baseURL = 'https://api.openai.com/v1'): OpenAI {
   const fake: FakeOpenAI = { responses: { create }, baseURL };
   return fake as unknown as OpenAI;
-}
-
-async function* streamEvents(events: unknown[]): AsyncGenerator<unknown> {
-  for (const event of events) {
-    yield event;
-  }
 }
 
 /** A minimal non-empty transcript, for tests that only exercise other options. */
@@ -408,7 +398,7 @@ describe('OpenAIChatClient request mapping', () => {
 
   // `include` is *computed*, so a raw pass-through that replaced it wholesale would silently disable
   // encrypted-reasoning replay. Python appends to whatever the caller supplied
-  // (`_chat_client.py:1414-1417`), so the entry can never be lost.
+  // (`_chat_client.py`), so the entry can never be lost.
   it('keeps encrypted reasoning in include even when additionalProperties supplies its own', () => {
     const request = client.buildRequest(HI, {
       additionalProperties: { include: ['message.output_text.logprobs'] },
@@ -567,7 +557,7 @@ describe('OpenAIChatClient response mapping', () => {
 
   it('streams text deltas and folds usage from the completed event', async () => {
     const create = vi.fn(async (_request?: Record<string, unknown>) =>
-      streamEvents([
+      arrayToStream([
         { type: 'response.created', response: { id: 'resp_1' } },
         { type: 'response.output_text.delta', delta: 'Hel' },
         { type: 'response.output_text.delta', delta: 'lo!' },
@@ -592,7 +582,7 @@ describe('OpenAIChatClient response mapping', () => {
 
   it('assembles streamed function call arguments', async () => {
     const create = vi.fn(async (_request?: Record<string, unknown>) =>
-      streamEvents([
+      arrayToStream([
         {
           type: 'response.output_item.added',
           output_index: 0,
@@ -623,7 +613,7 @@ describe('OpenAIChatClient response mapping', () => {
 
   it('emits reasoning payloads from output_item.done but not duplicate done text', async () => {
     const create = vi.fn(async (_request?: Record<string, unknown>) =>
-      streamEvents([
+      arrayToStream([
         { type: 'response.reasoning_text.delta', item_id: 'rs_1', delta: 'think' },
         { type: 'response.reasoning_text.done', item_id: 'rs_1', text: 'think' },
         {
@@ -1105,7 +1095,7 @@ describe('provider error mapping', () => {
 
   it('keeps an unmodelled streamed output item as unknown content', async () => {
     const create = vi.fn().mockResolvedValue(
-      streamEvents([
+      arrayToStream([
         { type: 'response.created', response: { id: 'resp_1', status: 'in_progress' } },
         {
           type: 'response.output_item.done',
@@ -1130,7 +1120,7 @@ describe('provider error mapping', () => {
 
   it('does not duplicate items the stream already reconstructed from deltas', async () => {
     const create = vi.fn().mockResolvedValue(
-      streamEvents([
+      arrayToStream([
         { type: 'response.output_text.delta', delta: 'hi', item_id: 'msg_1', output_index: 0 },
         {
           type: 'response.output_item.done',

--- a/packages/openai/src/chat-client.test.ts
+++ b/packages/openai/src/chat-client.test.ts
@@ -11,9 +11,8 @@ import {
   textContent,
   tool,
 } from '@polymind-inc/agent-framework-core';
-import { must } from '@polymind-inc/agent-framework-core/internal';
 import OpenAI, { AzureOpenAI } from 'openai';
-import { describe, expect, it, vi } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
 import { OpenAIChatClient } from './chat-client.js';
 
 interface FakeOpenAI {
@@ -922,7 +921,9 @@ describe('Agent over OpenAIChatClient', () => {
     const requests = first.userInputRequests.filter(isApprovalRequest);
     expect(requests.map((request) => request.id)).toEqual(['mcpr_1']);
 
-    const resumed = await agent.run(approvalResponse(must(requests[0]), true), { session });
+    const [request] = requests;
+    assert.exists(request);
+    const resumed = await agent.run(approvalResponse(request, true), { session });
 
     // The decision has to arrive as an `mcp_approval_response` item. Handling it locally would
     // answer the model with a "not found" tool result and leave the MCP server waiting forever.
@@ -954,7 +955,9 @@ describe('Agent over OpenAIChatClient', () => {
     // conversation state is a separate opt-in.
     expect(session.serviceSessionId).toBeUndefined();
     expect(create.mock.calls[1]?.[0].previous_response_id).toBeUndefined();
-    expect((must(create.mock.calls[1])[0].input as InputItem[]).map((item) => item.role)).toEqual([
+    const secondCall = create.mock.calls[1];
+    assert.exists(secondCall);
+    expect((secondCall[0].input as InputItem[]).map((item) => item.role)).toEqual([
       'user',
       'assistant',
       'user',

--- a/packages/openai/src/chat-client.ts
+++ b/packages/openai/src/chat-client.ts
@@ -112,7 +112,7 @@ export interface EndpointNamedModel {
 const AZURE_HOST_PATTERN = /\.(openai|cognitiveservices|services\.ai)\.azure\.com|\.azure-api\.net/i;
 
 function detectProviderName(client: OpenAI): string {
-  const baseURL = String((client as { baseURL?: unknown }).baseURL ?? '');
+  const baseURL = String(client.baseURL ?? '');
   if (AZURE_HOST_PATTERN.test(baseURL)) {
     return 'azure.ai.openai';
   }
@@ -225,14 +225,13 @@ export class OpenAIChatClient
   readonly #model: string | undefined;
   readonly #includeReasoningEncryptedContent: boolean;
   /**
-   * Normalizes anything thrown around an SDK call into the value this client throws.
+   * Normalizes anything thrown around an SDK call into the value this client throws, following
+   * the `createClientErrorNormalizer` contract: a cancellation passes through as the
+   * standards-shaped abort value rather than being laundered into a provider failure.
    *
-   * A cancellation is not a provider failure and must not be laundered into one: hosting maps
-   * `AbortError` to `response.incomplete`/`interrupted` and everything else to `response.failed`.
-   * The SDK's own abort error is *not* named `AbortError` — `APIUserAbortError` never sets
-   * `this.name`, so it arrives as a plain `"Error"` (openai@7 `core/error.mjs`); the normalizer
-   * recognizes it by type and converts it to the standards-shaped abort value the rest of the
-   * stack matches on, preferring the caller's own abort reason.
+   * This SDK's specifics: `APIUserAbortError` never sets `this.name`, so it arrives as a plain
+   * `"Error"` (openai@7 `core/error.mjs`) and is recognized by type; and the `wrap` branch maps a
+   * content-filter rejection to {@link ContentFilterError} instead of the general error type.
    */
   readonly #toClientError: ClientErrorNormalizer = createClientErrorNormalizer({
     abortErrorClass: OpenAI.APIUserAbortError,
@@ -386,7 +385,7 @@ export class OpenAIChatClient
       request.text = text;
     }
 
-    Object.assign(request, options?.additionalProperties ?? {});
+    Object.assign(request, extra);
 
     // `include` is *computed*, so it is merged after the raw pass-through rather than before it.
     // Without service-side storage the transcript is replayed from our side, and a reasoning model

--- a/packages/openai/src/from-openai.test.ts
+++ b/packages/openai/src/from-openai.test.ts
@@ -1,7 +1,6 @@
 import type { ChatResponseUpdate, Content, Message, TextContent } from '@polymind-inc/agent-framework-core';
 import { deserializeMessage, mergeChatUpdates, serializeMessage } from '@polymind-inc/agent-framework-core';
-import { must } from '@polymind-inc/agent-framework-core/internal';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import type { ParseContext } from './from-openai.js';
 import { createStreamParseState, parseResponse, parseStreamEvent } from './from-openai.js';
 import { toResponsesInput } from './to-openai.js';
@@ -68,7 +67,8 @@ describe('response envelope parity', () => {
 
     const awaited = parseResponse(wireResponse, ctx);
     const terminalEvent = { type: eventType, response: wireResponse, logprobs: [{ token: 'done' }] };
-    const terminalUpdate = must(parseStreamEvent(terminalEvent, createStreamParseState(), ctx));
+    const terminalUpdate = parseStreamEvent(terminalEvent, createStreamParseState(), ctx);
+    assert.exists(terminalUpdate);
     const streamed = mergeChatUpdates([terminalUpdate]);
     const metadataOf = (response: typeof awaited): Record<string, unknown> => ({
       responseId: response.responseId,
@@ -124,7 +124,9 @@ describe('reasoning text vs reasoning summary', () => {
   // awaited one does not.
   it('pairs each private reasoning fragment with its summary in an awaited response', () => {
     const response = parseResponse(awaitedResponse);
-    const [privateThought] = must(response.messages[0]).contents;
+    const [message] = response.messages;
+    assert.exists(message);
+    const [privateThought] = message.contents;
     expect(privateThought?.additionalProperties).toEqual({
       reasoning_text: true,
       summary: { type: 'summary_text', text: 'public summary' },
@@ -147,7 +149,9 @@ describe('reasoning text vs reasoning summary', () => {
 
   it('keeps them as separate items in an awaited response', () => {
     const response = parseResponse(awaitedResponse);
-    expect(reasoningShape(must(response.messages[0]).contents)).toEqual([
+    const [message] = response.messages;
+    assert.exists(message);
+    expect(reasoningShape(message.contents)).toEqual([
       { id: 'rs_1', text: 'private thought', protectedData: undefined, reasoningText: true },
       { id: 'rs_1', text: 'public summary', protectedData: undefined, reasoningText: undefined },
     ]);
@@ -156,9 +160,11 @@ describe('reasoning text vs reasoning summary', () => {
   it('produces the same transcript when streamed as when awaited', () => {
     const streamed = mergeChatUpdates(fold(streamedEvents));
     const awaited = parseResponse(awaitedResponse);
-    expect(reasoningShape(must(streamed.messages[0]).contents)).toEqual(
-      reasoningShape(must(awaited.messages[0]).contents),
-    );
+    const [streamedMessage] = streamed.messages;
+    const [awaitedMessage] = awaited.messages;
+    assert.exists(streamedMessage);
+    assert.exists(awaitedMessage);
+    expect(reasoningShape(streamedMessage.contents)).toEqual(reasoningShape(awaitedMessage.contents));
   });
 
   it('replays a streamed turn with the summary as summary_text, not as private reasoning text', () => {
@@ -427,7 +433,9 @@ describe('unmodelled output items round-trip through serialization', () => {
   it('keeps every unmodelled field of an awaited output item', () => {
     const response = parseResponse({ id: 'resp_1', status: 'completed', output: [futureItem] });
 
-    expect(serializeMessage(must(response.messages[0])).contents).toEqual([futureItem]);
+    const [message] = response.messages;
+    assert.exists(message);
+    expect(serializeMessage(message).contents).toEqual([futureItem]);
   });
 
   it('keeps every unmodelled field of a streamed output item', () => {
@@ -438,7 +446,9 @@ describe('unmodelled output items round-trip through serialization', () => {
     ]);
 
     const merged = mergeChatUpdates(updates);
-    expect(serializeMessage(must(merged.messages[0])).contents).toEqual([futureItem]);
+    const [message] = merged.messages;
+    assert.exists(message);
+    expect(serializeMessage(message).contents).toEqual([futureItem]);
   });
 
   it('keeps an unmodelled part inside an awaited message item', () => {
@@ -449,19 +459,26 @@ describe('unmodelled output items round-trip through serialization', () => {
       output: [{ type: 'message', role: 'assistant', content: [part] }],
     });
 
-    expect(serializeMessage(must(response.messages[0])).contents).toEqual([part]);
+    const [message] = response.messages;
+    assert.exists(message);
+    expect(serializeMessage(message).contents).toEqual([part]);
   });
 
   it('keeps an unmodelled streamed content part', () => {
     const part = { type: 'future_output', id: 'part_1', payload: { value: 42 } };
     const updates = fold([{ type: 'response.content_part.added', output_index: 0, part }]);
 
-    expect(serializeMessage(must(mergeChatUpdates(updates).messages[0])).contents).toEqual([part]);
+    const merged = mergeChatUpdates(updates);
+    const [message] = merged.messages;
+    assert.exists(message);
+    expect(serializeMessage(message).contents).toEqual([part]);
   });
 
   it('restores the same content after a full JSON session round trip', () => {
     const response = parseResponse({ id: 'resp_1', status: 'completed', output: [futureItem] });
-    const persisted = JSON.parse(JSON.stringify(serializeMessage(must(response.messages[0]))));
+    const [message] = response.messages;
+    assert.exists(message);
+    const persisted = JSON.parse(JSON.stringify(serializeMessage(message)));
 
     const restored = deserializeMessage(persisted);
     expect(restored.contents[0]).toMatchObject({
@@ -725,7 +742,9 @@ describe('annotation round trips', () => {
 
     // A session round trip drops rawRepresentation; the rebuild must keep the citation form
     // instead of degrading it to a plain file_citation.
-    delete must(text.annotations?.[0]).rawRepresentation;
+    const annotation = text.annotations?.[0];
+    assert.exists(annotation);
+    delete annotation.rawRepresentation;
     const [message] = toResponsesInput([{ role: 'assistant', contents: [text] }]) as [WireMessage];
     expect(message.content[0]?.annotations).toEqual([
       {
@@ -760,7 +779,9 @@ describe('annotation round trips', () => {
     const [text] = contentsOf(parsed) as [TextContent];
     expect(text.annotations?.[0]?.additionalProperties).toEqual({ index: 2 });
 
-    delete must(text.annotations?.[0]).rawRepresentation;
+    const annotation = text.annotations?.[0];
+    assert.exists(annotation);
+    delete annotation.rawRepresentation;
     const [message] = toResponsesInput([{ role: 'assistant', contents: [text] }]) as [WireMessage];
     expect(message.content[0]?.annotations).toEqual([
       { type: 'file_citation', file_id: 'f_1', filename: 'a.pdf', index: 2 },

--- a/packages/openai/src/from-openai.test.ts
+++ b/packages/openai/src/from-openai.test.ts
@@ -1,5 +1,6 @@
 import type { ChatResponseUpdate, Content, Message, TextContent } from '@polymind-inc/agent-framework-core';
 import { deserializeMessage, mergeChatUpdates, serializeMessage } from '@polymind-inc/agent-framework-core';
+import { must } from '@polymind-inc/agent-framework-core/internal';
 import { describe, expect, it } from 'vitest';
 import type { ParseContext } from './from-openai.js';
 import { createStreamParseState, parseResponse, parseStreamEvent } from './from-openai.js';
@@ -8,12 +9,6 @@ import { toResponsesInput } from './to-openai.js';
 /** All contents of a parsed response, flattened. */
 function contentsOf(response: { messages: Message[] }): Content[] {
   return response.messages.flatMap((msg) => msg.contents);
-}
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
 }
 
 /** The wire shape of a replayed assistant message, as far as these assertions read it. */
@@ -124,7 +119,7 @@ describe('reasoning text vs reasoning summary', () => {
   ];
 
   // Python pairs each private reasoning fragment with the summary that sits at the
-  // same index, on *both* paths (`_chat_client.py:2648-2651` awaited, `:3138-3144` streamed).
+  // same index, on *both* the awaited and streamed paths (`_chat_client.py`).
   // Both paths here must carry that pairing, or a streamed transcript would carry metadata an
   // awaited one does not.
   it('pairs each private reasoning fragment with its summary in an awaited response', () => {
@@ -195,9 +190,8 @@ describe('reasoning text vs reasoning summary', () => {
 });
 
 // Python surfaces log probabilities as response metadata rather than as transcript
-// content (`_get_metadata_from_response`, `_chat_client.py:3414-3420`), merged into
-// `additional_properties` on both the awaited response (`:2813`) and every streamed update
-// (`:3388`).
+// content (`_get_metadata_from_response` in `_chat_client.py`), merged into
+// `additional_properties` on both the awaited response and every streamed update.
 describe('logprobs', () => {
   const LOGPROBS = [{ token: 'hi', logprob: -0.25, top_logprobs: [] }];
 
@@ -333,7 +327,7 @@ describe('failed responses surface their error', () => {
 
 // Python maps `response.image_generation_call.partial_image` to the same
 // call/result pair the finished item produces, with the preview marked so a consumer can tell the
-// two apart (`_chat_client.py:3196-3222`). The event only exists when the caller asked for it via
+// two apart (`_chat_client.py`). The event only exists when the caller asked for it via
 // `partial_images` on the image generation tool.
 describe('streamed partial images', () => {
   // A PNG header, so the media type is detected rather than defaulted.
@@ -381,7 +375,7 @@ describe('streamed partial images', () => {
 });
 
 // Python seeds every streamed update with the configured model and lets the
-// terminal event overwrite it with the one the response reports (`_chat_client.py:3331`, `:3032`).
+// terminal event overwrite it with the one the response reports (`_chat_client.py`).
 describe('model on streamed updates', () => {
   it('carries the configured model on non-terminal updates', () => {
     const updates = fold(

--- a/packages/openai/src/from-openai.ts
+++ b/packages/openai/src/from-openai.ts
@@ -150,11 +150,19 @@ function failureContent(
   if (response?.status !== 'failed' && message === '' && code === '') {
     return undefined;
   }
+  return failureErrorContent(message, code, rawEvent);
+}
+
+/**
+ * Builds the `error` content for a reported failure, substituting the generic defaults when the
+ * wire carries no usable message or code so the failure is never silent.
+ */
+function failureErrorContent(message: string, code: string, rawRepresentation: unknown): ErrorContent {
   return {
     type: 'error',
     message: message.trim() === '' ? DEFAULT_FAILURE_MESSAGE : message,
     errorCode: code === '' ? DEFAULT_FAILURE_CODE : code,
-    rawRepresentation: rawEvent,
+    rawRepresentation,
   };
 }
 
@@ -546,6 +554,33 @@ function codeInterpreterOutputs(item: Wire<ResponseCodeInterpreterToolCall>): Co
   return outputs;
 }
 
+/**
+ * Maps one message content part — `output_text`, `refusal`, or something newer — onto framework
+ * content.
+ *
+ * Shared by the awaited message-item path and the streamed `response.content_part.added` branch.
+ * For the two modelled part types, the caller chooses what `rawRepresentation` points at (the
+ * part itself when a complete response is parsed, the enclosing stream event otherwise) and
+ * whether annotations were parsed. A part this build does not model becomes unknown content
+ * derived from the part alone — `rawRepresentation` and `annotations` do not apply to it.
+ */
+function partContent(
+  part: unknown,
+  rawRepresentation: unknown,
+  annotations?: Content['annotations'],
+): Content {
+  const raw = part as { type?: unknown; text?: string; refusal?: string } | null | undefined;
+  if (raw?.type === 'output_text') {
+    const content: Content = { type: 'text', text: raw.text ?? '', rawRepresentation };
+    if (annotations !== undefined) content.annotations = annotations;
+    return content;
+  }
+  if (raw?.type === 'refusal') {
+    return { type: 'text', text: raw.refusal ?? '', rawRepresentation };
+  }
+  return unknownContent(part);
+}
+
 /** Converts one Responses API output item into framework contents. */
 function outputItemToContents(item: unknown): Content[] {
   const raw = item as Wire<ResponseOutputItem> | null | undefined;
@@ -553,16 +588,8 @@ function outputItemToContents(item: unknown): Content[] {
     case 'message': {
       const contents: Content[] = [];
       for (const part of raw.content ?? []) {
-        if (part?.type === 'output_text') {
-          const content: Content = { type: 'text', text: part.text ?? '', rawRepresentation: part };
-          const annotations = parseAnnotations(part.annotations);
-          if (annotations !== undefined) content.annotations = annotations;
-          contents.push(content);
-        } else if (part?.type === 'refusal') {
-          contents.push({ type: 'text', text: part.refusal ?? '', rawRepresentation: part });
-        } else {
-          contents.push(unknownContent(part));
-        }
+        const annotations = part?.type === 'output_text' ? parseAnnotations(part.annotations) : undefined;
+        contents.push(partContent(part, part, annotations));
       }
       return contents;
     }
@@ -757,26 +784,14 @@ export function parseStreamEvent(
     case 'error': {
       const message = typeof raw.message === 'string' ? raw.message : '';
       const code = typeof raw.code === 'string' ? raw.code : '';
-      contents.push({
-        type: 'error',
-        message: message.trim() === '' ? DEFAULT_FAILURE_MESSAGE : message,
-        errorCode: code === '' ? DEFAULT_FAILURE_CODE : code,
-        rawRepresentation: event,
-      });
+      contents.push(failureErrorContent(message, code, event));
       break;
     }
 
     case 'response.content_part.added': {
       // The part's initial text is usually empty, but Python emits whatever it carries so a
       // pre-filled part is not lost; deltas then stream the rest.
-      const part = raw.part;
-      if (part?.type === 'output_text') {
-        contents.push({ type: 'text', text: part.text ?? '', rawRepresentation: event });
-      } else if (part?.type === 'refusal') {
-        contents.push({ type: 'text', text: part.refusal ?? '', rawRepresentation: event });
-      } else {
-        contents.push(unknownContent(part));
-      }
+      contents.push(partContent(raw.part, event));
       break;
     }
 

--- a/packages/openai/src/from-openai.wire-fallbacks.test.ts
+++ b/packages/openai/src/from-openai.wire-fallbacks.test.ts
@@ -60,7 +60,7 @@ describe('parseUsage fallbacks', () => {
 });
 
 describe('parseFinishReason', () => {
-  // Python `_get_finish_reason_from_openai_response` (`_chat_client.py:2513-2520`): the
+  // Python `_get_finish_reason_from_openai_response` (`_chat_client.py`): the
   // incomplete reason wins over the status, a completed response reports `tool_calls` only when
   // its output contains a function call, and anything still in flight reports nothing.
   it('maps an incomplete content_filter response', () => {
@@ -88,7 +88,7 @@ describe('parseFinishReason', () => {
 });
 
 describe('conversation id', () => {
-  // Python `_get_conversation_id` (`_chat_client.py:924-936`): `store=False` suppresses the id
+  // Python `_get_conversation_id` (`_chat_client.py`): `store=False` suppresses the id
   // entirely, a non-empty conversation id wins over the response id, and an empty one falls
   // through to the response id.
   it('suppresses the conversation id when the request opted out of storage', () => {
@@ -159,7 +159,7 @@ describe('media type detection of generated images', () => {
 
 describe('awaited message parts', () => {
   it('maps a refusal part to text, as Python does', () => {
-    // Python `_parse_response_from_openai` (`_chat_client.py:2636-2639`).
+    // Python `_parse_response_from_openai` (`_chat_client.py`).
     const contents = contentsOf(
       parseResponse({
         output: [{ type: 'message', content: [{ type: 'refusal', refusal: 'cannot help' }] }],
@@ -430,7 +430,7 @@ describe('function and hosted tool call fallbacks', () => {
 
 describe('stream event fallbacks', () => {
   it('maps a refusal delta to text', () => {
-    // Python `_parse_chunk_from_openai` (`_chat_client.py:2913-2914`).
+    // Python `_parse_chunk_from_openai` (`_chat_client.py`).
     const update = parseOne({ type: 'response.refusal.delta', delta: 'cannot help' });
     expect(update?.contents).toEqual([expect.objectContaining({ type: 'text', text: 'cannot help' })]);
   });

--- a/packages/openai/src/hosted-tools.test.ts
+++ b/packages/openai/src/hosted-tools.test.ts
@@ -13,9 +13,8 @@ import {
   supportsWebSearch,
   textContent,
 } from '@polymind-inc/agent-framework-core';
-import { must } from '@polymind-inc/agent-framework-core/internal';
 import type OpenAI from 'openai';
-import { describe, expect, it, vi } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
 import { OpenAIChatClient } from './chat-client.js';
 import { parseResponse } from './from-openai.js';
 import { toResponsesInput, toResponsesTools } from './to-openai.js';
@@ -166,7 +165,9 @@ describe('hosted tool output mapping', () => {
     const [call, result] = contentsOf(response) as [HostedToolCallContent, HostedToolResultContent];
 
     expect(call.type).toBe('code_interpreter_tool_call');
-    expect((must(call.inputs?.[0]) as TextContent).text).toBe('print(1)');
+    const input = call.inputs?.[0];
+    assert.exists(input);
+    expect((input as TextContent).text).toBe('print(1)');
     expect(result.type).toBe('code_interpreter_tool_result');
     expect(result.outputs?.map((o) => o.type)).toEqual(['text', 'uri']);
   });

--- a/packages/openai/src/hosted-tools.test.ts
+++ b/packages/openai/src/hosted-tools.test.ts
@@ -13,6 +13,7 @@ import {
   supportsWebSearch,
   textContent,
 } from '@polymind-inc/agent-framework-core';
+import { must } from '@polymind-inc/agent-framework-core/internal';
 import type OpenAI from 'openai';
 import { describe, expect, it, vi } from 'vitest';
 import { OpenAIChatClient } from './chat-client.js';
@@ -27,12 +28,6 @@ function client(): OpenAIChatClient {
 /** All contents of a parsed response, flattened. */
 function contentsOf(response: { messages: Message[] }): Content[] {
   return response.messages.flatMap((msg) => msg.contents);
-}
-
-/** Narrows away undefined; a missing value fails the test with a clear error. */
-function must<T>(value: T | null | undefined): T {
-  if (value == null) throw new Error('expected a value');
-  return value;
 }
 
 describe('hosted tool capability protocol', () => {

--- a/packages/openai/src/hosted-tools.ts
+++ b/packages/openai/src/hosted-tools.ts
@@ -6,6 +6,7 @@ import type {
   WebSearchToolOptions,
 } from '@polymind-inc/agent-framework-core';
 import { ConfigurationError, hostedTool, withoutUndefined } from '@polymind-inc/agent-framework-core';
+import { normalizeServerLabel } from '@polymind-inc/agent-framework-core/internal';
 
 /** Declares the provider-hosted web search tool. */
 export function webSearchTool(options: WebSearchToolOptions = {}): HostedTool {
@@ -66,11 +67,7 @@ export function codeInterpreterTool(options: CodeInterpreterToolOptions = {}): H
  * reach. `headers` is sent to that server on every call, so anything in it is disclosed to it.
  */
 export function mcpTool(options: McpToolOptions): HostedTool {
-  if (options.serverLabel.trim() === '') {
-    throw new ConfigurationError('mcpTool requires a non-empty serverLabel.');
-  }
-  // The API rejects labels with spaces; Python's `get_mcp_tool` applies the same substitution.
-  const serverLabel = options.serverLabel.replaceAll(' ', '_');
+  const serverLabel = normalizeServerLabel(options.serverLabel);
   // The object form of `require_approval` is a per-side tool filter: each side is an object with
   // a `tool_names` list, not a bare array (openai SDK `Mcp.McpToolApprovalFilter`, Python
   // `get_mcp_tool`).

--- a/packages/openai/src/to-openai.ts
+++ b/packages/openai/src/to-openai.ts
@@ -17,6 +17,7 @@ import {
   resolveResponseFormat,
   topLevelMediaType,
 } from '@polymind-inc/agent-framework-core';
+import { answeredCallIds, safeStringify } from '@polymind-inc/agent-framework-core/internal';
 
 /** A Responses API input item, kept loose so unmodelled item types pass through. */
 export type ResponsesInputItem = Record<string, unknown>;
@@ -29,13 +30,9 @@ function stringifyArguments(args: Record<string, unknown> | string): string {
  * Renders a tool or model result value as the string a wire field carries.
  *
  * A string passes through, an absent value (`undefined` / `null`) becomes an empty string, and
- * anything else is JSON-encoded — the same shape Python's `Content.from_function_result` and
- * .NET's `EncodeFunctionResultAsJsonStringPayload` give a function result. A value
- * `JSON.stringify` cannot encode — it throws on a cycle or a `BigInt`, and answers `undefined`
- * for a symbol or a function — degrades to `String(value)` instead, mirroring Python's
- * `str(result)` fallback: a wire mapper renders a transcript that already exists, so failing the
- * whole request over one unencodable value is not an option, and the string form still says
- * *something* about what the tool answered.
+ * anything else goes through {@link safeStringify} — the same shape Python's
+ * `Content.from_function_result` and .NET's `EncodeFunctionResultAsJsonStringPayload` give a
+ * function result.
  *
  * The single implementation of this rendering: the live provider path and the Foundry hosting
  * replay and persist paths all go through it, so they cannot drift apart.
@@ -47,18 +44,7 @@ export function stringifyResult(value: unknown): string {
   if (value === undefined || value === null) {
     return '';
   }
-  const fallback = (): string => {
-    try {
-      return String(value);
-    } catch {
-      return '[unserializable]';
-    }
-  };
-  try {
-    return JSON.stringify(value) ?? fallback();
-  } catch {
-    return fallback();
-  }
+  return safeStringify(value);
 }
 
 /**
@@ -250,19 +236,6 @@ function contentToMessagePart(role: Role, content: Content): ResponsesInputItem 
     default:
       return undefined;
   }
-}
-
-/** Collects the `callId`s answered by a `function_result` anywhere in the transcript. */
-function answeredCallIds(messages: readonly Message[]): Set<string> {
-  const answered = new Set<string>();
-  for (const msg of messages) {
-    for (const content of msg.contents) {
-      if (content.type === 'function_result') {
-        answered.add(content.callId);
-      }
-    }
-  }
-  return answered;
 }
 
 /**

--- a/scripts/type-resolution/smoke.ts
+++ b/scripts/type-resolution/smoke.ts
@@ -13,13 +13,16 @@ import '@polymind-inc/agent-framework/agentserver/observability';
 
 import '@polymind-inc/agent-framework-core';
 import '@polymind-inc/agent-framework-core/testing';
+import '@polymind-inc/agent-framework-core/internal';
 import '@polymind-inc/agent-framework-core/node';
 import '@polymind-inc/agent-framework-openai';
+import '@polymind-inc/agent-framework-openai/internal';
 import '@polymind-inc/agent-framework-anthropic';
 import '@polymind-inc/agent-framework-mcp';
 import '@polymind-inc/agent-framework-a2a';
 import '@polymind-inc/agent-framework-foundry';
 import '@polymind-inc/agent-framework-foundry/hosting';
 import '@polymind-inc/agent-framework-agentserver';
+import '@polymind-inc/agent-framework-agentserver/internal';
 import '@polymind-inc/agent-framework-agentserver/node';
 import '@polymind-inc/agent-framework-agentserver/observability';

--- a/scripts/vitest-config.ts
+++ b/scripts/vitest-config.ts
@@ -8,6 +8,7 @@ function source(path: string): string {
 // Subpaths precede their package roots so Vite's prefix matching always selects the exact entry.
 const workspaceAliases = {
   '@polymind-inc/agent-framework-core/testing': source('core/src/testing.ts'),
+  '@polymind-inc/agent-framework-core/internal': source('core/src/internal.ts'),
   '@polymind-inc/agent-framework-core/node': source('core/src/node.ts'),
   '@polymind-inc/agent-framework-core': source('core/src/index.ts'),
   '@polymind-inc/agent-framework-foundry/hosting': source('foundry/src/hosting.ts'),

--- a/scripts/vitest-config.ts
+++ b/scripts/vitest-config.ts
@@ -28,6 +28,6 @@ const workspaceAliases = {
 export function definePackageTests() {
   return defineConfig({
     resolve: { alias: workspaceAliases },
-    test: { include: ['src/**/*.test.ts'] },
+    test: { include: ['src/**/*.test.ts'], unstubEnvs: true },
   });
 }


### PR DESCRIPTION
## What this changes

A repository-wide consolidation sweep: cross-package utilities move to one implementation on a new `core/internal` subpath, foundry's HTTP assembly and `AsyncLocalStorage` generator pumps are unified, the `invoke_agent` span lifecycle moves onto the existing `AgentRunSpan` abstraction (closing the span when input-message recording throws), and hand-written test utilities are replaced with Vitest built-ins (`assert.exists`, `vi.stubEnv` + `unstubEnvs`, `vi.waitFor`/`vi.waitUntil`, `vi.fn`). Removes the unused `MiddlewareKind` type and the `TERMINAL_EVENT_TYPES` re-export. A follow-up on the remaining publicly exported provider helpers is tracked in #92.

## Parity

- Reference checked: Python `agent_framework` — `get_mcp_tool` (server-label space substitution) and the `json.dumps` → `str` degradation the shared `safeStringify` mirrors; Go `autocall.go` for the function-calling loop's options gating (comments only). The sweep shares existing implementations rather than changing semantics.
- Wire format affected: no
- Public API affected: yes
- Breaking change: yes (`MiddlewareKind`, `TERMINAL_EVENT_TYPES`)

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
