### PR TITLE
Move the provider request-assembly helpers off the supported core surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **[BREAKING] `@polymind-inc/agent-framework-core`** — `setIfDefined`, `withoutUndefined`,
+  `topLevelMediaType` and `arrayToStream` are no longer exported from the root entry. They assemble
+  a request payload for a specific provider SDK — an implementation detail of writing a
+  `ChatClient`, not part of the programming model — and none of the reference implementations
+  publishes a counterpart in this shape. They now live on the `/internal` subpath the framework's
+  own packages share, which carries no compatibility promise. Each is under ten lines and inlines
+  directly: `setIfDefined`/`withoutUndefined` drop the entries whose value is `undefined`,
+  `topLevelMediaType` lowercases the part of a media type before the `/`, and `arrayToStream`
+  yields an array's items from an async generator.
 - **[BREAKING] `@polymind-inc/agent-framework-core`** — the `MiddlewareKind` type is removed. It
   was a free-standing alias nothing in the framework consumed; the discriminant lives on the
   middleware objects themselves, so `Middleware['kind']` expresses the same type where one is

--- a/packages/anthropic/src/chat-client.test.ts
+++ b/packages/anthropic/src/chat-client.test.ts
@@ -2,7 +2,6 @@ import Anthropic from '@anthropic-ai/sdk';
 import type { Content, Message } from '@polymind-inc/agent-framework-core';
 import {
   Agent,
-  arrayToStream,
   ChatClientError,
   ConfigurationError,
   deserializeMessage,
@@ -12,6 +11,7 @@ import {
   textContent,
   tool,
 } from '@polymind-inc/agent-framework-core';
+import { arrayToStream } from '@polymind-inc/agent-framework-core/internal';
 import { describe, expect, it } from 'vitest';
 import { AnthropicChatClient, DEFAULT_BETA_FLAGS } from './chat-client.js';
 import {

--- a/packages/anthropic/src/chat-client.ts
+++ b/packages/anthropic/src/chat-client.ts
@@ -14,7 +14,6 @@ import type {
   WebSearchToolOptions,
 } from '@polymind-inc/agent-framework-core';
 import {
-  arrayToStream,
   ChatClientError,
   ConfigurationError,
   chatResponseToUpdates,
@@ -22,8 +21,8 @@ import {
   createResponseStream,
   guardClientStream,
   mergeChatUpdates,
-  setIfDefined,
 } from '@polymind-inc/agent-framework-core';
+import { arrayToStream, setIfDefined } from '@polymind-inc/agent-framework-core/internal';
 import { createStreamParseState, parseMessage, parseStreamEvent } from './from-anthropic.js';
 import { mcpTool, webSearchTool } from './hosted-tools.js';
 import type { AnthropicChatOptions } from './options.js';

--- a/packages/anthropic/src/hosted-tools.ts
+++ b/packages/anthropic/src/hosted-tools.ts
@@ -1,6 +1,6 @@
 import type { HostedTool, McpToolOptions, WebSearchToolOptions } from '@polymind-inc/agent-framework-core';
-import { hostedTool, withoutUndefined } from '@polymind-inc/agent-framework-core';
-import { normalizeServerLabel } from '@polymind-inc/agent-framework-core/internal';
+import { hostedTool } from '@polymind-inc/agent-framework-core';
+import { normalizeServerLabel, withoutUndefined } from '@polymind-inc/agent-framework-core/internal';
 
 /**
  * Declares the provider-hosted web search tool.

--- a/packages/anthropic/src/to-anthropic.ts
+++ b/packages/anthropic/src/to-anthropic.ts
@@ -12,9 +12,8 @@ import {
   resolveResponseFormat,
   serializeContent,
   textOfContents,
-  topLevelMediaType,
 } from '@polymind-inc/agent-framework-core';
-import { isRecord, safeStringify } from '@polymind-inc/agent-framework-core/internal';
+import { isRecord, safeStringify, topLevelMediaType } from '@polymind-inc/agent-framework-core/internal';
 import { MCP_SERVER_SPEC_TYPE } from './hosted-tools.js';
 
 /** A Messages API content block, kept loose so unmodelled block types pass through. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,7 +33,6 @@ export { createClientErrorNormalizer, guardClientStream } from './client/client-
 export { FunctionInvocationLimitError } from './client/function-execution.js';
 export type { FunctionInvocationConfig } from './client/function-invocation.js';
 export { withFunctionInvocation } from './client/function-invocation.js';
-export { arrayToStream, setIfDefined, topLevelMediaType, withoutUndefined } from './client/provider-utils.js';
 export type { ResolvedResponseFormat } from './client/structured-output.js';
 export {
   applyStructuredOutput,

--- a/packages/core/src/internal.test.ts
+++ b/packages/core/src/internal.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import * as root from './index.js';
+import * as internal from './internal.js';
+
+// Assembling a request payload against a provider SDK is a `ChatClient` implementation detail, not
+// part of the programming model — none of the reference implementations publishes a free-function
+// counterpart. These live on `/internal` so the supported surface does not promise them.
+const REQUEST_ASSEMBLY_HELPERS = ['arrayToStream', 'setIfDefined', 'topLevelMediaType', 'withoutUndefined'];
+
+describe('the internal contract', () => {
+  it('carries the provider request-assembly helpers', () => {
+    expect(Object.keys(internal)).toEqual(expect.arrayContaining(REQUEST_ASSEMBLY_HELPERS));
+  });
+
+  it('keeps them off the root entry', () => {
+    expect(REQUEST_ASSEMBLY_HELPERS.filter((name) => name in root)).toEqual([]);
+  });
+
+  it('shares nothing with the supported root entry', () => {
+    // An `/internal` export is unsupported and may change in any release; a root export is a
+    // promise. A symbol on both entries makes that promise ambiguous, so the two sets stay
+    // disjoint by construction rather than by review.
+    expect(Object.keys(internal).filter((name) => name in root)).toEqual([]);
+  });
+});

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -3,13 +3,20 @@
  *
  * These are the utilities the provider packages share so that one rule (error rendering, integer
  * validation, record narrowing, wire-string degradation, MCP label normalization, answered-call
- * bookkeeping) has exactly one implementation. None of them has a public counterpart in the
- * reference implementations, so none of them belongs on the package's supported surface.
- * Everything exported here may change or disappear in any release; import from
+ * bookkeeping, request-payload assembly) has exactly one implementation. None of them has a public
+ * counterpart in the reference implementations, so none of them belongs on the package's supported
+ * surface. Everything exported here may change or disappear in any release; import from
  * `@polymind-inc/agent-framework-core` instead for the supported surface.
  */
 
 export { answeredCallIds } from './client/function-invocation.js';
-export { normalizeServerLabel, safeStringify } from './client/provider-utils.js';
+export {
+  arrayToStream,
+  normalizeServerLabel,
+  safeStringify,
+  setIfDefined,
+  topLevelMediaType,
+  withoutUndefined,
+} from './client/provider-utils.js';
 export { errorMessageOf, validateSafeInteger } from './errors.js';
 export { isRecord } from './types/content.js';

--- a/packages/foundry/src/memory/client.ts
+++ b/packages/foundry/src/memory/client.ts
@@ -12,7 +12,8 @@
  * and neither does this.
  */
 
-import { AgentFrameworkError, setIfDefined } from '@polymind-inc/agent-framework-core';
+import { AgentFrameworkError } from '@polymind-inc/agent-framework-core';
+import { setIfDefined } from '@polymind-inc/agent-framework-core/internal';
 import { bodyText, drainBody, foundryFailureMessage, foundryRequestInit, foundryUrl } from '../http.js';
 import type { FoundryProject } from '../project.js';
 

--- a/packages/openai/src/chat-client.test.ts
+++ b/packages/openai/src/chat-client.test.ts
@@ -2,7 +2,6 @@ import type { Message } from '@polymind-inc/agent-framework-core';
 import {
   Agent,
   approvalResponse,
-  arrayToStream,
   ChatClientError,
   ConfigurationError,
   ContentFilterError,
@@ -11,6 +10,7 @@ import {
   textContent,
   tool,
 } from '@polymind-inc/agent-framework-core';
+import { arrayToStream } from '@polymind-inc/agent-framework-core/internal';
 import OpenAI, { AzureOpenAI } from 'openai';
 import { assert, describe, expect, it, vi } from 'vitest';
 import { OpenAIChatClient } from './chat-client.js';

--- a/packages/openai/src/chat-client.ts
+++ b/packages/openai/src/chat-client.ts
@@ -18,7 +18,6 @@ import type {
   WebSearchToolOptions,
 } from '@polymind-inc/agent-framework-core';
 import {
-  arrayToStream,
   ChatClientError,
   ConfigurationError,
   ContentFilterError,
@@ -28,8 +27,8 @@ import {
   guardClientStream,
   mergeChatUpdates,
   NotImplementedError,
-  setIfDefined,
 } from '@polymind-inc/agent-framework-core';
+import { arrayToStream, setIfDefined } from '@polymind-inc/agent-framework-core/internal';
 import OpenAI, { AzureOpenAI } from 'openai';
 import type { ParseContext } from './from-openai.js';
 import {

--- a/packages/openai/src/hosted-tools.ts
+++ b/packages/openai/src/hosted-tools.ts
@@ -5,8 +5,8 @@ import type {
   McpToolOptions,
   WebSearchToolOptions,
 } from '@polymind-inc/agent-framework-core';
-import { ConfigurationError, hostedTool, withoutUndefined } from '@polymind-inc/agent-framework-core';
-import { normalizeServerLabel } from '@polymind-inc/agent-framework-core/internal';
+import { ConfigurationError, hostedTool } from '@polymind-inc/agent-framework-core';
+import { normalizeServerLabel, withoutUndefined } from '@polymind-inc/agent-framework-core/internal';
 
 /** Declares the provider-hosted web search tool. */
 export function webSearchTool(options: WebSearchToolOptions = {}): HostedTool {

--- a/packages/openai/src/to-openai.ts
+++ b/packages/openai/src/to-openai.ts
@@ -15,9 +15,12 @@ import {
   isHostedApproval,
   MESSAGE_SOURCE_KEY,
   resolveResponseFormat,
-  topLevelMediaType,
 } from '@polymind-inc/agent-framework-core';
-import { answeredCallIds, safeStringify } from '@polymind-inc/agent-framework-core/internal';
+import {
+  answeredCallIds,
+  safeStringify,
+  topLevelMediaType,
+} from '@polymind-inc/agent-framework-core/internal';
 
 /** A Responses API input item, kept loose so unmodelled item types pass through. */
 export type ResponsesInputItem = Record<string, unknown>;


### PR DESCRIPTION
## What this changes

Closes #92. `setIfDefined`, `withoutUndefined`, `topLevelMediaType` and `arrayToStream` move off the root entry of `@polymind-inc/agent-framework-core` and are exported from `@polymind-inc/agent-framework-core/internal` instead; the in-repo consumers (anthropic, openai, foundry) switch to that import. A new test keeps the root entry and `/internal` disjoint, so a helper cannot sit on both a supported and an unsupported entry again.

## Parity

These helpers assemble a request payload for a provider SDK — an implementation detail of writing a `ChatClient`, not part of the programming model — and no reference implementation publishes a counterpart in this shape.

- Reference checked:
  - `setIfDefined` / `withoutUndefined` — Python writes the dict comprehension at each site (`python/packages/core/agent_framework/_agents.py:176`, `_settings.py:247`) with no shared public helper; .NET uses optional arguments and `AdditionalProperties`; Go uses `omitempty` tags.
  - `arrayToStream` — no counterpart; Go builds an `iter.Seq` from a slice with the standard library.
  - `topLevelMediaType` — the concept is public in all three, but as a member of the content type: Go `DataContent.TopLevelMediaType()` (`message/content.go:249`), Python `Content.has_top_level_media_type()` (`_types.py:1584`), .NET `DataContent.HasTopLevelMediaType(string)`. Go keeps the free function that takes a raw media-type string (`message/datauri.go:132`) **unexported** — the same split this PR applies. The TypeScript helper mirrors neither public form: it takes `string | undefined` rather than a content, and returns the type rather than a predicate. If a supported counterpart is wanted later, the faithful shape is an accessor over a `Content`, which this move leaves open.
- Wire format affected: no
- Public API affected: yes
- Breaking change: yes — the four helpers are gone from the root entry. Each is under ten lines and inlines directly; the changelog entry says what each one did.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change (the new surface test fails both ways: before the move, and with the root export temporarily restored)
- [x] Public API changes are reflected in the package README and `CHANGELOG.md` (no README mentions these helpers — verified by search)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
