### PR TITLE
Default a missing input item type to message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ contain breaking changes**; patch releases are fixes only.
   `$.input[i].role` and `$.input[i].content` rather than only `$.input[i]`, and referencing a
   stored item still needs the explicit `item_reference` discriminator.
 
+- **[BREAKING] `@polymind-inc/agent-framework-agentserver`** — an input item that names
+  `type: "message"` is held to the message rules, the same ones an item that omits its `type`
+  answers for. Both reference servers dispatch the two spellings to one validator — Python's
+  `_validate_OpenAI_ItemMessage` requires `role` and `content` whether the discriminator was
+  written out or defaulted — so writing `"type": "message"` no longer buys a laxer check than
+  leaving it off. `{ "type": "message", "id": "x" }` was accepted before and is now a 400 naming
+  `$.input[i].role` and `$.input[i].content`. To point at a stored item, use
+  `{ "type": "item_reference", "id": "x" }`; to send a message, give it a `role` and `content`.
+  Items of every other type are unaffected.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ The umbrella `@polymind-inc/agent-framework` package and all `@polymind-inc/agen
 packages are versioned in lockstep; one entry here covers the set. During 0.x, **minor releases may
 contain breaking changes**; patch releases are fixes only.
 
+## Unreleased
+
+- **`@polymind-inc/agent-framework-agentserver`** — `POST /responses` now accepts an input item
+  that omits its `type`, the shape a plain OpenAI Responses `EasyInputMessage`
+  (`{ "role": "user", "content": "hello" }`) has and both reference servers accept. The absent
+  discriminator resolves to `message` — .NET's item validator supplies that default from its custom
+  discriminator resolver, Python's `_request_validators.py` reads `value.get("type", "message")` —
+  and the resolved `type` is written onto a copy of the item, so the handler, the minted item id
+  and the stored transcript all see `message` instead of quietly dropping an untyped item out of
+  persistence. The default applies only when the property is absent: `type: null` and any other
+  non-string `type` are still a 400. Defaulting does not waive the message rules, so an item with
+  no `type` must carry `role` and `content` — `{ "id": "x" }` is still rejected, now naming
+  `$.input[i].role` and `$.input[i].content` rather than only `$.input[i]`, and referencing a
+  stored item still needs the explicit `item_reference` discriminator.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/packages/agentserver/src/server.test.ts
+++ b/packages/agentserver/src/server.test.ts
@@ -101,7 +101,7 @@ describe('routes', () => {
   it('gets, lists input items for, and deletes a response', async () => {
     const server = makeServer();
     const created = (await (
-      await server.handle(post({ input: [{ type: 'message', id: 'in_1' }] }))
+      await server.handle(post({ input: [{ type: 'message', id: 'in_1', role: 'user', content: 'one' }] }))
     ).json()) as ResponseObject;
 
     const fetched = await server.handle(new Request(`http://localhost:8088/responses/${created.id}`));
@@ -267,9 +267,9 @@ describe('routes', () => {
   it('lists input items newest-first by default, and accepts order case-insensitively', async () => {
     const server = makeServer();
     const input = [
-      { type: 'message', id: 'in_1' },
-      { type: 'message', id: 'in_2' },
-      { type: 'message', id: 'in_3' },
+      { type: 'message', id: 'in_1', role: 'user', content: 'one' },
+      { type: 'message', id: 'in_2', role: 'user', content: 'two' },
+      { type: 'message', id: 'in_3', role: 'user', content: 'three' },
     ];
     const created = (await (await server.handle(post({ input }))).json()) as ResponseObject;
 
@@ -319,10 +319,15 @@ describe('routes', () => {
     });
 
     const first = (await (
-      await server.handle(post({ input: [{ type: 'message', id: 'in_1' }] }))
+      await server.handle(post({ input: [{ type: 'message', id: 'in_1', role: 'user', content: 'one' }] }))
     ).json()) as ResponseObject;
     const second = (await (
-      await server.handle(post({ input: [{ type: 'message', id: 'in_2' }], previous_response_id: first.id }))
+      await server.handle(
+        post({
+          input: [{ type: 'message', id: 'in_2', role: 'user', content: 'two' }],
+          previous_response_id: first.id,
+        }),
+      )
     ).json()) as ResponseObject;
 
     // A new conversation starts empty; the follow-up replays the first turn's input *and* output.
@@ -368,7 +373,9 @@ describe('cross-user isolation', () => {
       yield { type: 'response.completed', response: { ...context.response, status: 'completed' } };
     });
 
-    const mine = await createFor(server, alice, { input: [{ type: 'message', id: 'secret_1' }] });
+    const mine = await createFor(server, alice, {
+      input: [{ type: 'message', id: 'secret_1', role: 'user', content: 'secret' }],
+    });
     const stolen = await server.handle(post({ input: 'x', previous_response_id: mine.id }, mallory));
 
     // 404 rather than 403: whether the id exists is itself Alice's business.
@@ -384,7 +391,7 @@ describe('cross-user isolation', () => {
     });
 
     await createFor(server, alice, {
-      input: [{ type: 'message', id: 'secret_1' }],
+      input: [{ type: 'message', id: 'secret_1', role: 'user', content: 'secret' }],
       conversation: { id: `caresp_${'c'.repeat(18)}${'d'.repeat(32)}` },
     });
     const stolen = await server.handle(
@@ -755,7 +762,12 @@ describe('request limits', () => {
       handler: lifecycleHandler({ echo: true }),
       limits: { maxInputItems: 2 },
     });
-    const items = Array.from({ length: 3 }, (_, i) => ({ type: 'message', id: `in_${i}` }));
+    const items = Array.from({ length: 3 }, (_, i) => ({
+      type: 'message',
+      id: `in_${i}`,
+      role: 'user',
+      content: `item ${i}`,
+    }));
 
     const response = await server.handle(post({ input: items }));
 

--- a/packages/agentserver/src/server.test.ts
+++ b/packages/agentserver/src/server.test.ts
@@ -153,6 +153,37 @@ describe('routes', () => {
     expect(partitionKeyOf(list.data[0]?.id)).toBe(partitionKeyOf(created.id));
   });
 
+  it('accepts an input item with no type and shows the handler and the store a message', async () => {
+    // `{ role, content }` with no discriminator is a valid OpenAI Responses input item, and both
+    // reference servers default the missing `type` to `message` before anything else looks at the
+    // item. Without that default the item reaches the handler untyped and — having no known id
+    // prefix — silently drops out of the stored transcript.
+    let seen: unknown;
+    const server = makeServer(async function* (request, context) {
+      seen = request.input;
+      yield { type: 'response.completed', response: context.response };
+    });
+
+    const response = await server.handle(post({ input: [{ role: 'user', content: 'hello' }] }));
+    const created = (await response.json()) as ResponseObject;
+
+    expect(response.status).toBe(200);
+    expect(seen).toEqual([{ type: 'message', role: 'user', content: 'hello' }]);
+
+    const items = await server.handle(
+      new Request(`http://localhost:8088/responses/${created.id}/input_items`),
+    );
+    const list = (await items.json()) as {
+      data: Array<{ type: string; role?: string; content?: unknown; id?: string }>;
+    };
+
+    expect(list.data).toHaveLength(1);
+    expect(list.data[0]?.type).toBe('message');
+    expect(list.data[0]?.role).toBe('user');
+    expect(list.data[0]?.content).toBe('hello');
+    expect(list.data[0]?.id).toMatch(/^msg_/);
+  });
+
   it('mints ids across the reference id-generator dispatch, not just the common types', async () => {
     // The prefix table has to cover everything Python's `IdGenerator.new_item_id` covers: a type
     // missing from it is silently left out of persistence, and the next turn replays a
@@ -636,12 +667,32 @@ describe('validation', () => {
     }
   });
 
-  it('rejects an input item without a type', async () => {
+  it('rejects a type-less input item that is not a valid message', async () => {
+    // Defaulting to `message` does not make an id-only object valid: it still has to carry `role`
+    // and `content`. Pointing at a stored item needs the explicit `item_reference` discriminator.
     const response = await makeServer().handle(post({ input: [{ id: 'no_type' }] }));
+    const body = (await response.json()) as {
+      error: { code: string; message: string; details: Array<{ code: string; param: string; type: string }> };
+    };
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe('invalid_request');
+    expect(body.error.message).toBe('request body failed schema validation');
+    expect(body.error.details.map((d) => d.param)).toEqual(['$.input[0].role', '$.input[0].content']);
+    for (const detail of body.error.details) {
+      expect(detail.code).toBe('invalid_value');
+      expect(detail.type).toBe('invalid_request_error');
+    }
+  });
+
+  it('rejects a null type rather than treating it as absent', async () => {
+    const response = await makeServer().handle(
+      post({ input: [{ type: null, role: 'user', content: 'hi' }] }),
+    );
     const body = (await response.json()) as { error: { details: Array<{ param: string }> } };
 
     expect(response.status).toBe(400);
-    expect(body.error.details.map((d) => d.param)).toContain('$.input[0]');
+    expect(body.error.details.map((d) => d.param)).toEqual(['$.input[0]']);
   });
 
   it('rejects a conversation id that cannot be a storage key', async () => {

--- a/packages/agentserver/src/validation.test.ts
+++ b/packages/agentserver/src/validation.test.ts
@@ -146,6 +146,22 @@ describe('input items without an explicit type', () => {
     expect(detailParams({ input: [{ id: 'x' }] })).toEqual(['$.input[0].role', '$.input[0].content']);
   });
 
+  it('holds an item that names message to the same rules as one that omits the type', () => {
+    // Writing the discriminator out must not buy a laxer check than leaving it off, or the message
+    // rules could be skipped by naming the very shape they belong to.
+    expect(detailParams({ input: [{ type: 'message', id: 'x' }] })).toEqual([
+      '$.input[0].role',
+      '$.input[0].content',
+    ]);
+    expect(detailParams({ input: [{ type: 'message', role: 'user' }] })).toEqual(['$.input[0].content']);
+  });
+
+  it('leaves an item of another type to its own shape', () => {
+    expect(detailParams({ input: [{ type: 'function_call_output', call_id: 'c1', output: 'x' }] })).toEqual(
+      [],
+    );
+  });
+
   it.each([
     [{ content: 'hi' }, ['$.input[0].role']],
     [{ role: 42, content: 'hi' }, ['$.input[0].role']],

--- a/packages/agentserver/src/validation.test.ts
+++ b/packages/agentserver/src/validation.test.ts
@@ -31,7 +31,8 @@ describe('schema validation paths', () => {
     [{ text: 'plain' }, '$.text'],
     [{ input: 42 }, '$.input'],
     [{ input: [42] }, '$.input[0]'],
-    [{ input: [{ role: 'user' }] }, '$.input[0]'],
+    // No `type` means the item is held to the message shape, so the missing field is named.
+    [{ input: [{ role: 'user' }] }, '$.input[0].content'],
     [{ conversation: 42 }, '$.conversation'],
     [{ conversation: { id: 42 } }, '$.conversation.id'],
     [{ metadata: [] }, '$.metadata'],
@@ -51,7 +52,8 @@ describe('schema validation paths', () => {
     expect(detailParams({ stream: 'yes', model: 42, input: [{}] })).toEqual([
       '$.stream',
       '$.model',
-      '$.input[0]',
+      '$.input[0].role',
+      '$.input[0].content',
     ]);
   });
 
@@ -69,6 +71,88 @@ describe('schema validation paths', () => {
       agent_reference: { name: 'assistant', version: '1' },
     });
     expect(request.model).toBe('gpt-4o');
+  });
+});
+
+describe('input items without an explicit type', () => {
+  it('defaults a missing discriminator to message and normalizes the item', () => {
+    const request = parseCreateRequest({ input: [{ role: 'user', content: 'hello' }] });
+
+    expect(request.input).toEqual([{ type: 'message', role: 'user', content: 'hello' }]);
+  });
+
+  it('keeps every caller-supplied field on the normalized item', () => {
+    const request = parseCreateRequest({
+      input: [
+        { role: 'user', content: [{ type: 'input_text', text: 'hi' }], id: 'msg_x', phase: 'commentary' },
+      ],
+    });
+
+    expect(request.input).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'hi' }],
+        id: 'msg_x',
+        phase: 'commentary',
+      },
+    ]);
+  });
+
+  it('leaves the caller-owned request and item objects untouched', () => {
+    const item = { role: 'user', content: 'hello' };
+    const body = { input: [item] };
+
+    const request = parseCreateRequest(body);
+
+    expect(Object.hasOwn(item, 'type')).toBe(false);
+    expect(item).toEqual({ role: 'user', content: 'hello' });
+    expect(body.input[0]).toBe(item);
+    expect(request.input).not.toBe(body.input);
+  });
+
+  it('preserves an explicit valid discriminator', () => {
+    // `item_reference` is how a caller points at a stored item; it must survive untouched, and an
+    // explicit `message` must not be rewritten either.
+    const request = parseCreateRequest({
+      input: [
+        { type: 'item_reference', id: 'x' },
+        { type: 'message', role: 'user', content: 'hi' },
+      ],
+    });
+
+    expect(request.input).toEqual([
+      { type: 'item_reference', id: 'x' },
+      { type: 'message', role: 'user', content: 'hi' },
+    ]);
+  });
+
+  it('returns the very same request when no item needed the default', () => {
+    const body = { input: [{ type: 'item_reference', id: 'x' }] };
+
+    expect(parseCreateRequest(body).input).toBe(body.input);
+  });
+
+  it.each<[string, unknown]>([
+    ['null', null],
+    ['a number', 42],
+    ['an object', {}],
+    ['an array', ['message']],
+  ])('rejects a type of %s rather than taking the default for it', (_label, type) => {
+    expect(detailParams({ input: [{ type, role: 'user', content: 'hi' }] })).toEqual(['$.input[0]']);
+  });
+
+  it('still refuses an id-only object, which needs an explicit item_reference', () => {
+    expect(detailParams({ input: [{ id: 'x' }] })).toEqual(['$.input[0].role', '$.input[0].content']);
+  });
+
+  it.each([
+    [{ content: 'hi' }, ['$.input[0].role']],
+    [{ role: 42, content: 'hi' }, ['$.input[0].role']],
+    [{ role: 'user' }, ['$.input[0].content']],
+    [{ role: 'user', content: 42 }, ['$.input[0].content']],
+  ])('reports field-level paths for the defaulted message %j', (item, params) => {
+    expect(detailParams({ input: [item] })).toEqual(params);
   });
 });
 

--- a/packages/agentserver/src/validation.ts
+++ b/packages/agentserver/src/validation.ts
@@ -89,6 +89,17 @@ function isPlainObject(value: unknown): value is JsonObject {
 }
 
 /**
+ * The discriminator an input item that names none is validated and normalized as.
+ *
+ * `{ role: "user", content: "hello" }` is a valid Responses input item, and both reference servers
+ * resolve its absent `type` to `message` before dispatching — .NET's item validator supplies the
+ * default from its custom `ResolveDefaultDiscriminator`, Python's reads `value.get("type",
+ * "message")`. The default is what makes the item *dispatch* to the message rules; it does not
+ * excuse them, so `role` and `content` are still required and an id-only object is still refused.
+ */
+const DEFAULT_ITEM_TYPE = 'message';
+
+/**
  * Structural validation of a `POST /responses` body.
  *
  * Mirrors what Python gets from its generated `validate_create_response_payload`: every field the
@@ -123,8 +134,23 @@ function schemaDetails(request: JsonObject): ApiErrorDetail[] {
   }
   if (Array.isArray(input)) {
     input.forEach((item, index) => {
-      if (!isPlainObject(item) || typeof item.type !== 'string') {
-        wrong(`$.input[${index}]`, "an object with a string 'type'");
+      const path = `$.input[${index}]`;
+      if (!isPlainObject(item)) {
+        wrong(path, "an object with a string 'type'");
+        return;
+      }
+      if (Object.hasOwn(item, 'type')) {
+        // Present but not a string — `null` included — is a broken discriminator, not an absent
+        // one, and taking the default for it would silently reinterpret the item.
+        if (typeof item.type !== 'string') wrong(path, "an object with a string 'type'");
+        return;
+      }
+      // Absent: the item is a message, so it answers for the two fields a message must carry.
+      // Reported per field, the way the reference validators name them, so a caller learns which
+      // half of `{ role, content }` is missing rather than only that the item was refused.
+      if (typeof item.role !== 'string') wrong(`${path}.role`, 'a string');
+      if (typeof item.content !== 'string' && !Array.isArray(item.content)) {
+        wrong(`${path}.content`, 'a string or an array');
       }
     });
   }
@@ -182,6 +208,32 @@ function schemaDetails(request: JsonObject): ApiErrorDetail[] {
   return details;
 }
 
+/**
+ * Writes the resolved discriminator onto every input item that named none, so that the handler,
+ * the id minting and the stored transcript all read the same `type` the validation above judged
+ * the item by. Left implicit, such an item reaches the handler untyped and has no known id prefix,
+ * which quietly drops it out of persistence — the next turn would replay a conversation missing
+ * what the caller actually said.
+ *
+ * The request and its items belong to the caller, so nothing is written in place: only the items
+ * that need the default are rebuilt, and when none does the request is handed back unchanged.
+ */
+function withResolvedItemTypes(request: CreateResponseRequest): CreateResponseRequest {
+  const input = request.input;
+  if (!Array.isArray(input)) {
+    return request;
+  }
+  let defaulted = false;
+  const items = input.map((item: unknown): unknown => {
+    if (!isPlainObject(item) || Object.hasOwn(item, 'type')) {
+      return item;
+    }
+    defaulted = true;
+    return { type: DEFAULT_ITEM_TYPE, ...item };
+  });
+  return defaulted ? { ...request, input: items } : request;
+}
+
 /** Optional limits for {@link parseCreateRequest}. */
 export interface ParseCreateRequestLimits {
   /** Maximum number of items an `input` array may carry. */
@@ -195,6 +247,9 @@ export interface ParseCreateRequestLimits {
  * a 400 with the offending `param` rather than something a handler has to re-check. Structural
  * problems are reported first (the counterpart of Python's generated schema-validation pass, as
  * field-level `details[]` with JSON paths), then the semantic constraints.
+ *
+ * The returned request is normalized: an input item that omitted its `type` carries the resolved
+ * `message` discriminator. The body handed in is never written to.
  *
  * @throws {ProtocolError} 400 when the body is not an object or breaks a documented constraint.
  */
@@ -211,7 +266,7 @@ export function parseCreateRequest(
     throw badRequest('request body failed schema validation', { code: 'invalid_request', details });
   }
 
-  const request = payload as CreateResponseRequest;
+  const request = withResolvedItemTypes(payload as CreateResponseRequest);
 
   // After the schema pass `store` is a boolean or absent, so `!== false` here and the
   // `=== false` persistence check in the server agree — there is no third, falsy-but-not-false

--- a/packages/agentserver/src/validation.ts
+++ b/packages/agentserver/src/validation.ts
@@ -96,6 +96,8 @@ function isPlainObject(value: unknown): value is JsonObject {
  * default from its custom `ResolveDefaultDiscriminator`, Python's reads `value.get("type",
  * "message")`. The default is what makes the item *dispatch* to the message rules; it does not
  * excuse them, so `role` and `content` are still required and an id-only object is still refused.
+ * An item that names `message` itself dispatches to exactly the same rules — one shape, one set of
+ * requirements, whether the caller wrote the discriminator or left it out.
  */
 const DEFAULT_ITEM_TYPE = 'message';
 
@@ -142,12 +144,18 @@ function schemaDetails(request: JsonObject): ApiErrorDetail[] {
       if (Object.hasOwn(item, 'type')) {
         // Present but not a string — `null` included — is a broken discriminator, not an absent
         // one, and taking the default for it would silently reinterpret the item.
-        if (typeof item.type !== 'string') wrong(path, "an object with a string 'type'");
-        return;
+        if (typeof item.type !== 'string') {
+          wrong(path, "an object with a string 'type'");
+          return;
+        }
+        // Any other discriminator names a shape this pass does not model.
+        if (item.type !== DEFAULT_ITEM_TYPE) return;
       }
-      // Absent: the item is a message, so it answers for the two fields a message must carry.
-      // Reported per field, the way the reference validators name them, so a caller learns which
-      // half of `{ role, content }` is missing rather than only that the item was refused.
+      // A message, whether it said so or was resolved to one, answers for the two fields a message
+      // must carry. Both spellings reach the same rules, the way the reference validators dispatch
+      // them, so naming the discriminator explicitly cannot buy a laxer check than omitting it.
+      // Reported per field so a caller learns which half of `{ role, content }` is missing rather
+      // than only that the item was refused.
       if (typeof item.role !== 'string') wrong(`${path}.role`, 'a string');
       if (typeof item.content !== 'string' && !Array.isArray(item.content)) {
         wrong(`${path}.content`, 'a string or an array');


### PR DESCRIPTION
## What this changes

Fixes #100. `POST /responses` required every input item to name a string `type`, so a plain OpenAI
Responses `EasyInputMessage` — `{ "role": "user", "content": "hello" }` — was answered with a 400
that neither reference server gives. An item whose `type` property is absent is now judged by the
message rules and normalized to `type: "message"` in `parseCreateRequest`, which is what puts the
resolved discriminator in front of every later reader at once: the handler receives the parsed
request, and the same `input` array feeds the id minting and the stored transcript, where an
untyped item had no known id prefix and dropped silently out of persistence.

The default applies only to an absent property — `type: null` and any other non-string `type` stay
a 400 — and neither the caller's request object nor its items are written to.

An item that names `type: "message"` is held to the same message rules. Defaulting the absent
discriminator would otherwise have given one shape two validators, letting a caller skip the
`role` / `content` checks by writing out the discriminator those checks belong to.

## Parity

- Reference checked: .NET `ItemValidatorCustom.ResolveDefaultDiscriminator`, which supplies
  `"message"`, and Python `_request_validators.py`, whose `_validate_OpenAI_Item` reads
  `value.get("type", "message")` and hands both the defaulted and the written-out `message` to the
  single `_validate_OpenAI_ItemMessage`, which requires `role` and `content`. Both refuse an id-only
  object, which needs the explicit `item_reference` discriminator; that stays refused here.
  Deliberate divergence: .NET also defaults a non-string `type`, and this follows Python in treating
  one as a broken discriminator instead.
- Wire format affected: yes — an input item may now omit its `type`. A malformed message item is
  reported at `$.input[i].role` and `$.input[i].content` rather than only at `$.input[i]`; the HTTP
  status and error envelope are unchanged.
- Public API affected: no
- Breaking change: yes

What breaks: `{ "type": "message", "id": "x" }` was accepted and is now a 400. Point at a stored item with `{ "type": "item_reference", "id": "x" }`, or give the message a `role` and `content`. Items of every other type are unaffected.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
