### PR TITLE
Execute tool calls whose arguments are missing or null with empty arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,20 @@ contain breaking changes**; patch releases are fixes only.
   `{ "type": "item_reference", "id": "x" }`; to send a message, give it a `role` and `content`.
   Items of every other type are unaffected.
 
+- **`@polymind-inc/agent-framework-core`** — a tool call that carries no arguments at all now runs
+  with an empty argument object instead of coming back as an `Invalid arguments` result. A
+  `function_call` whose `arguments` field is absent or a native `null` reached schema validation as
+  `undefined` / `null` and was refused there, so a tool whose parameters are all optional never
+  executed — the shape a transcript written by another implementation has, since Python omits
+  `arguments` when it is `None`. All three reference implementations invoke the tool in that case
+  (Python `dict(parse_arguments() or {})`, .NET's nullable `FunctionCallContent.Arguments`, Go's
+  `{}` encoding of empty arguments). Both the ordinary loop and an approval resumed from a
+  serialized session take the same view, which is built fresh per invocation and never written back
+  to the call: `FunctionCallContent.arguments` is unchanged in the transcript and in the serialized
+  session. Empty and whitespace-only argument strings behave exactly as before, malformed non-empty
+  JSON is still an `Invalid JSON arguments` result, and the JSON text `null`, non-null scalars and
+  arrays are not treated as absent — they go on to schema validation as they always did.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/packages/core/src/client/function-execution.ts
+++ b/packages/core/src/client/function-execution.ts
@@ -140,9 +140,27 @@ export class FunctionInvocationLimitError extends ToolInvocationError {
   }
 }
 
+/**
+ * Turns the model's `arguments` field into the value the tool's schema is validated against.
+ *
+ * A call that carries no arguments is a call with *empty* arguments, not a malformed one. That
+ * absence is spelled several ways — the field omitted (Python drops `arguments` when it is `None`,
+ * so a transcript it wrote arrives without one), a native `null`, or an empty string — and each
+ * stands for the same empty argument object. All three reference implementations invoke the tool
+ * in that case rather than refusing the call, so a tool whose parameters are all optional runs.
+ *
+ * The normalization is a fresh object built for this invocation. Nothing is written back to the
+ * call, which stays exactly as the transcript recorded it.
+ *
+ * Only the *unparsed* field is read as absent. The JSON text `null` is a value the model sent, so
+ * it — like any other non-object JSON — goes on to schema validation and is refused there.
+ */
 function parseArguments(
   call: FunctionCallContent,
 ): { ok: true; value: unknown } | { ok: false; message: string } {
+  if (call.arguments === undefined || call.arguments === null) {
+    return { ok: true, value: {} };
+  }
   if (typeof call.arguments !== 'string') {
     return { ok: true, value: call.arguments };
   }

--- a/packages/core/src/client/function-invocation.test.ts
+++ b/packages/core/src/client/function-invocation.test.ts
@@ -11,7 +11,9 @@ import type {
   UserInputRequestContent,
 } from '../types/content.js';
 import { textContent } from '../types/content.js';
+import type { Message } from '../types/message.js';
 import { chatResponseUpdate, mergeChatUpdates } from '../types/response.js';
+import { deserializeContent } from '../types/serialization.js';
 import type { ChatClient, ChatClientMetadata, ChatOptions } from './chat-client.js';
 import { FunctionInvocationLimitError } from './function-execution.js';
 import { withFunctionInvocation } from './function-invocation.js';
@@ -1464,5 +1466,154 @@ describe('conversation chaining between rounds', () => {
     const secondRequest = requests[1];
     assert.exists(secondRequest);
     expect(secondRequest.conversationId).toBe('resp_r1');
+  });
+});
+
+describe('calls whose arguments are missing or null', () => {
+  /**
+   * A `function_call` exactly as it arrives from the wire.
+   *
+   * Deserialization casts a known content `type` without filling in fields, so a call written by
+   * another implementation reaches the loop with `arguments` absent — Python omits the field when
+   * it is `None` — or carrying a literal `null`.
+   */
+  function wireCall(fields: Record<string, unknown>): FunctionCallContent {
+    return deserializeContent({ type: 'function_call', callId: 'c1', ...fields }) as FunctionCallContent;
+  }
+
+  /** The two wire shapes that carry no arguments at all, as opposed to empty ones. */
+  const nullish: Array<[label: string, fields: Record<string, unknown>]> = [
+    ['omitted', {}],
+    ['native null', { arguments: null }],
+  ];
+
+  const optionalParameters = {
+    type: 'object',
+    properties: { note: { type: 'string' } },
+    additionalProperties: false,
+  } as const;
+
+  const requiredParameters = {
+    type: 'object' as const,
+    properties: { resource: { type: 'string' } },
+    required: ['resource'],
+    additionalProperties: false,
+  };
+
+  function scriptedClient(...calls: FunctionCallContent[]): MockChatClient {
+    return new MockChatClient([
+      { contents: calls, finishReason: 'tool_calls' },
+      { contents: [textContent('done')], finishReason: 'stop' },
+    ]);
+  }
+
+  function exceptionOf(response: { messages: Message[] }): string | undefined {
+    return resultsOf(response.messages.flatMap((m) => m.contents))[0]?.exception;
+  }
+
+  it.each(nullish)('executes an all-optional tool once with {} when arguments are %s', async (_l, fields) => {
+    const execute = vi.fn(async () => 'pong');
+    const ping = tool({ name: 'ping', description: 'd', parameters: optionalParameters, execute });
+    const inner = scriptedClient(wireCall({ name: 'ping', ...fields }));
+
+    const response = await withFunctionInvocation(inner).getResponse([], { tools: [ping] } as ChatOptions);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledWith({}, expect.anything());
+    expect(resultsOf(response.messages.flatMap((m) => m.contents)).map((r) => r.result)).toEqual(['pong']);
+  });
+
+  it('hands every call its own arguments object', async () => {
+    const seen: Record<string, unknown>[] = [];
+    const ping = tool({
+      name: 'ping',
+      description: 'd',
+      parameters: optionalParameters,
+      execute: async (input: Record<string, unknown>) => {
+        seen.push(input);
+        // A tool that writes into what it was handed must not be able to reach the next call.
+        input.note = 'mutated';
+        return 'pong';
+      },
+    });
+    const inner = scriptedClient(
+      wireCall({ callId: 'c1', name: 'ping' }),
+      wireCall({ callId: 'c2', name: 'ping', arguments: null }),
+    );
+
+    await withFunctionInvocation(inner).getResponse([], { tools: [ping] } as ChatOptions);
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).not.toBe(seen[1]);
+    expect(seen[1]).toEqual({ note: 'mutated' });
+  });
+
+  it.each(['', '   ', '\n\t'])('keeps an empty argument string %j executing with {}', async (args) => {
+    const execute = vi.fn(async () => 'pong');
+    const ping = tool({ name: 'ping', description: 'd', parameters: optionalParameters, execute });
+    const inner = scriptedClient(wireCall({ name: 'ping', arguments: args }));
+
+    await withFunctionInvocation(inner).getResponse([], { tools: [ping] } as ChatOptions);
+
+    expect(execute).toHaveBeenCalledWith({}, expect.anything());
+  });
+
+  it.each(nullish)('still refuses a required parameter when arguments are %s', async (_label, fields) => {
+    const execute = vi.fn(async () => 'never');
+    const strict = tool({ name: 'strict', description: 'd', parameters: requiredParameters, execute });
+    const inner = scriptedClient(wireCall({ name: 'strict', ...fields }));
+
+    const response = await withFunctionInvocation(inner).getResponse([], { tools: [strict] } as ChatOptions);
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(exceptionOf(response)).toBe('Invalid arguments: $.resource: required property is missing');
+  });
+
+  it('still reports malformed non-empty JSON as an invalid-JSON result', async () => {
+    const execute = vi.fn(async () => 'never');
+    const ping = tool({ name: 'ping', description: 'd', parameters: optionalParameters, execute });
+    const inner = scriptedClient(wireCall({ name: 'ping', arguments: '{"note":' }));
+
+    const response = await withFunctionInvocation(inner).getResponse([], { tools: [ping] } as ChatOptions);
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(exceptionOf(response)).toContain('Invalid JSON arguments');
+  });
+
+  it.each(['null', '42', '"note"', '[]'])(
+    'validates the parsed value of %j instead of reading it as missing arguments',
+    async (args) => {
+      const execute = vi.fn(async () => 'never');
+      const ping = tool({ name: 'ping', description: 'd', parameters: optionalParameters, execute });
+      const inner = scriptedClient(wireCall({ name: 'ping', arguments: args }));
+
+      const response = await withFunctionInvocation(inner).getResponse([], { tools: [ping] } as ChatOptions);
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(exceptionOf(response)).toBe('Invalid arguments: $: expected object');
+    },
+  );
+
+  it.each(nullish)('leaves the %s arguments of the transcript call untouched', async (_label, fields) => {
+    const ping = tool({
+      name: 'ping',
+      description: 'd',
+      parameters: optionalParameters,
+      execute: async () => 'pong',
+    });
+    const original = wireCall({ name: 'ping', ...fields });
+    const inner = scriptedClient(original);
+
+    const response = await withFunctionInvocation(inner).getResponse([], { tools: [ping] } as ChatOptions);
+
+    // The normalization is a view taken for this invocation; nothing writes it back.
+    expect(original.arguments).toBe(fields.arguments as undefined);
+    expect(Object.hasOwn(original, 'arguments')).toBe('arguments' in fields);
+    const transcriptCall = response.messages
+      .flatMap((m) => m.contents)
+      .find((content): content is FunctionCallContent => content.type === 'function_call');
+    assert.exists(transcriptCall);
+    expect(transcriptCall.arguments).toBe(fields.arguments as undefined);
+    expect(Object.hasOwn(transcriptCall, 'arguments')).toBe('arguments' in fields);
   });
 });

--- a/packages/core/src/client/tool-approval.test.ts
+++ b/packages/core/src/client/tool-approval.test.ts
@@ -17,6 +17,7 @@ import type {
 } from '../types/content.js';
 import { textContent } from '../types/content.js';
 import type { Message } from '../types/message.js';
+import { deserializeContent } from '../types/serialization.js';
 import type { ChatClient, ChatOptions } from './chat-client.js';
 import { withFunctionInvocation } from './function-invocation.js';
 import { MockChatClient } from './test-support.js';
@@ -1024,4 +1025,75 @@ describe('approval occurrences of a reused call id', () => {
     expect(executed).toEqual(['only']);
     expect(session.state._toolApproval).toBeUndefined();
   });
+});
+
+describe('approval resume for a call carrying no arguments', () => {
+  /**
+   * A `function_call` as another implementation serialized it: `arguments` omitted — Python drops
+   * the field when it is `None` — or written out as a literal `null`.
+   */
+  function wireCall(fields: Record<string, unknown>): FunctionCallContent {
+    return deserializeContent({
+      type: 'function_call',
+      callId: 'c1',
+      name: 'sweep',
+      ...fields,
+    }) as FunctionCallContent;
+  }
+
+  const nullish: Array<[label: string, fields: Record<string, unknown>]> = [
+    ['omitted', {}],
+    ['native null', { arguments: null }],
+  ];
+
+  /** The `function_call` of the single pending approval inside a serialized session. */
+  function storedCall(wire: unknown): Record<string, unknown> {
+    const state = (wire as { state: Record<string, unknown> }).state;
+    const partition = state._toolApproval as { pending: Array<{ functionCall: Record<string, unknown> }> };
+    const first = partition.pending[0];
+    assert.exists(first);
+    return first.functionCall;
+  }
+
+  it.each(nullish)(
+    'executes a call whose arguments are %s after suspend, serialize, restore and resume',
+    async (_label, fields) => {
+      const seen: unknown[] = [];
+      const sweep = tool({
+        name: 'sweep',
+        description: 'Sweep everything',
+        parameters: { type: 'object', properties: { scope: { type: 'string' } } },
+        approvalMode: 'always_require',
+        execute: async (input) => {
+          seen.push(input);
+          return 'swept';
+        },
+      });
+      const mock = new MockChatClient([
+        { contents: [wireCall(fields)], finishReason: 'tool_calls' },
+        { contents: [textContent('done')], finishReason: 'stop' },
+      ]);
+      const agent = new Agent({ client: mock, tools: [sweep] });
+      const session = agent.createSession();
+
+      const request = approvals(await agent.run('sweep', { session }))[0];
+      assert.exists(request);
+      expect(seen).toEqual([]);
+
+      // The human answers in another process, so only the serialized session bridges the turns.
+      const wire = JSON.parse(JSON.stringify(session)) as unknown;
+      // What the session persisted is the wire shape the provider reported, not a normalized copy.
+      expect(Object.hasOwn(storedCall(wire), 'arguments')).toBe('arguments' in fields);
+      expect(storedCall(wire).arguments).toBe(fields.arguments as undefined);
+
+      const resumed = await agent.run(approvalResponse(request, true), {
+        session: AgentSession.fromJSON(wire),
+      });
+
+      expect(seen).toEqual([{}]);
+      expect(results(resumed.messages)).toEqual([['c1', 'swept']]);
+      // The request the caller still holds was never rewritten either.
+      expect(request.functionCall.arguments).toBe(fields.arguments as undefined);
+    },
+  );
 });


### PR DESCRIPTION
## What this changes

Fixes #101. `parseArguments` passed an absent or natively `null` `FunctionCallContent.arguments`
straight through to schema validation, where `resolveArguments` refused it, so a tool whose
parameters are all optional came back as an `Invalid arguments` result instead of running. Python
omits `arguments` when it is `None`, so any transcript it wrote reaches this path on resume.

Only the *unparsed* nullish field is normalized to a fresh `{}` before validation. The JSON text
`null`, non-null scalars and arrays are values the model sent and continue through schema
validation as before; empty and whitespace-only argument strings keep their existing behaviour.
Nothing is written back, so `FunctionCallContent.arguments` is unchanged in the transcript and in
the serialized session.

## Parity

- Reference checked: all three invoke rather than refuse. .NET's `FunctionCallContent.Arguments` is
  nullable and becomes an empty `AIFunctionArguments` at invocation — and its
  `ItemResourceConversions.ParseArguments` returns null for missing arguments, so .NET itself
  produces such calls when rehydrating a Responses conversation. Python calls with
  `dict(function_call_content.parse_arguments() or {})`, where `parse_arguments()` returns `None`
  only when `arguments is None`; `json.loads("null")` yields `{"raw": None}` and still fails
  validation, which is the same split this change makes. Go encodes nil/empty as `{}` before
  dispatch.
- Wire format affected: no
- Public API affected: no
- Breaking change: no

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
