### PR TITLE
Transform strict structured-output schemas on the OpenAI request path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,27 @@ contain breaking changes**; patch releases are fixes only.
   `{ "type": "item_reference", "id": "x" }`; to send a message, give it a `role` and `content`.
   Items of every other type are unaffected.
 
+- **[BREAKING] `@polymind-inc/agent-framework-openai`** — a strict structured-output schema is now
+  transformed into the closed form the Responses API requires before it is sent. `strict` has always
+  defaulted to `true`, but the JSON Schema went out untouched, so a perfectly valid framework input
+  — a raw object schema without `additionalProperties: false`, or with a `required` list that does
+  not name every property — reached the service as a combination it rejects. The request path now
+  rewrites a deep clone of the schema, mirroring the contract Go's `strictSchemaToMap` applies:
+  `properties`, `items`, `anyOf`, `oneOf`, `$defs` and `definitions` are walked recursively, every
+  object with declared properties gains `additionalProperties: false` and a `required` list naming
+  all of them in a deterministic order, and `default` moves into the node's description. The
+  caller's schema object is never modified. A schema strict mode cannot express now fails locally
+  with the offending path — an explicitly open object (`additionalProperties: true` or a schema
+  value), a non-object root, a root `anyOf`, a boolean subschema, an object that declares nothing,
+  a `required` entry that is not a declared property, or a keyword outside the strict subset
+  (`allOf`, `not`, `if`/`then`/`else`, `patternProperties`, `prefixItems`, `uniqueItems`,
+  `minProperties`/`maxProperties`, the `$dynamic*`/`$recursive*` family and the rest) — instead of
+  producing an opaque service 400. Schemas that already satisfied strict mode, including everything
+  zod emits, are unchanged on the wire. Pass `strict: false` to send a schema through untouched, as
+  before. A `responseFormat` given without a name now takes its name from a string root `title` on
+  the schema, matching Python; an explicit `name` still wins, and the `title` keyword stays on the
+  schema.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/packages/core/src/client/structured-output.test.ts
+++ b/packages/core/src/client/structured-output.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { ChatClientError } from '../errors.js';
 import { textContent } from '../types/content.js';
 import { chatResponse } from '../types/response.js';
-import { applyStructuredOutput, withStructuredOutput } from './structured-output.js';
+import { applyStructuredOutput, resolveResponseFormat, withStructuredOutput } from './structured-output.js';
 import { MockChatClient } from './test-support.js';
 
 /** A minimal responseFormat with a Standard Schema validator. */
@@ -209,5 +209,38 @@ describe('withStructuredOutput', () => {
     const response = await client.getResponse([{ role: 'user', contents: [textContent('hi')] }]);
     expect(response.text).toBe('plain');
     expect(response.value).toBeUndefined();
+  });
+});
+
+describe('resolveResponseFormat', () => {
+  it('defaults to strict for every accepted form', () => {
+    expect(resolveResponseFormat(schema as never).strict).toBe(true);
+    expect(resolveResponseFormat(rawFormat as never).strict).toBe(true);
+    expect(resolveResponseFormat({ name: 'person', schema: { type: 'object', properties: {} } }).strict).toBe(
+      true,
+    );
+    expect(resolveResponseFormat({ name: 'person', schema: { type: 'object' }, strict: false }).strict).toBe(
+      false,
+    );
+  });
+
+  it('names an unnamed format after the schema root title', () => {
+    const titled = { type: 'object', title: 'Person', properties: { name: { type: 'string' } } };
+    expect(resolveResponseFormat(titled).name).toBe('Person');
+    expect(resolveResponseFormat({ schema: titled }).name).toBe('Person');
+    expect(resolveResponseFormat({ name: 'explicit', schema: titled }).name).toBe('explicit');
+  });
+
+  it('falls back to "response" when there is no usable title', () => {
+    expect(resolveResponseFormat({ type: 'object', properties: {} }).name).toBe('response');
+    expect(resolveResponseFormat({ type: 'object', title: '', properties: {} }).name).toBe('response');
+    expect(resolveResponseFormat({ type: 'object', title: 7, properties: {} }).name).toBe('response');
+  });
+
+  it('keeps the schema object it was handed', () => {
+    // Providers own whatever rewriting their wire format needs; resolution itself copies nothing.
+    const raw = { type: 'object', properties: { name: { type: 'string' } } };
+    expect(resolveResponseFormat(raw).schema).toBe(raw);
+    expect(resolveResponseFormat({ name: 'person', schema: raw }).schema).toBe(raw);
   });
 });

--- a/packages/core/src/client/structured-output.ts
+++ b/packages/core/src/client/structured-output.ts
@@ -32,15 +32,29 @@ function isNamedFormat(value: object): value is JsonSchemaResponseFormat {
 }
 
 /**
+ * The name to send when the caller did not supply one.
+ *
+ * A schema written by hand or produced by a schema library usually names itself with a root
+ * `title`, and that name is far more useful to a provider — and to anyone reading a trace — than a
+ * generic placeholder. Python does the same for the OpenAI response format. The keyword stays on
+ * the schema: it is a legal annotation, and removing it would change what the caller declared.
+ */
+function defaultFormatName(schema: JsonSchema): string {
+  const title = schema.title;
+  return typeof title === 'string' && title !== '' ? title : 'response';
+}
+
+/**
  * Normalizes a {@link ResponseFormat} into a JSON Schema plus the metadata providers require.
  *
  * @throws {SchemaResolutionError} When the schema cannot be converted to JSON Schema.
  */
 export function resolveResponseFormat(format: ResponseFormat): ResolvedResponseFormat {
   if (typeof format === 'object' && format !== null && !isStandardSchema(format) && isNamedFormat(format)) {
+    const schema = resolveJsonSchema(format.schema);
     const resolved: ResolvedResponseFormat = {
-      name: format.name ?? 'response',
-      schema: resolveJsonSchema(format.schema),
+      name: format.name ?? defaultFormatName(schema),
+      schema,
       strict: format.strict ?? true,
     };
     if (format.description !== undefined) {
@@ -49,9 +63,10 @@ export function resolveResponseFormat(format: ResponseFormat): ResolvedResponseF
     return resolved;
   }
 
+  const schema = resolveJsonSchema(format);
   const resolved: ResolvedResponseFormat = {
-    name: 'response',
-    schema: resolveJsonSchema(format),
+    name: defaultFormatName(schema),
+    schema,
     strict: true,
   };
   if (isStandardSchema(format)) {

--- a/packages/openai/src/chat-client.test.ts
+++ b/packages/openai/src/chat-client.test.ts
@@ -274,16 +274,110 @@ describe('OpenAIChatClient request mapping', () => {
 
   it('maps responseFormat to text.format', () => {
     const request = client.buildRequest(HI, {
-      responseFormat: { name: 'person', schema: { type: 'object', properties: {} }, strict: true },
+      responseFormat: {
+        name: 'person',
+        schema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+          additionalProperties: false,
+        },
+        strict: true,
+      },
     });
     expect(request.text).toEqual({
       format: {
         type: 'json_schema',
         name: 'person',
-        schema: { type: 'object', properties: {} },
+        schema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+          additionalProperties: false,
+        },
         strict: true,
       },
     });
+  });
+
+  it('closes a strict responseFormat schema the caller left open-ended', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        address: { type: 'object', properties: { city: { type: 'string' } } },
+      },
+    };
+    const before = structuredClone(schema);
+
+    const request = client.buildRequest(HI, { responseFormat: schema });
+
+    expect(request.text).toEqual({
+      format: {
+        type: 'json_schema',
+        name: 'response',
+        schema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            address: {
+              type: 'object',
+              properties: { city: { type: 'string' } },
+              required: ['city'],
+              additionalProperties: false,
+            },
+          },
+          required: ['address', 'name'],
+          additionalProperties: false,
+        },
+        strict: true,
+      },
+    });
+    // Building the request must not write anything back into the caller's schema.
+    expect(schema).toEqual(before);
+  });
+
+  it('leaves a non-strict responseFormat schema alone', () => {
+    // An explicitly open map is a shape strict mode rejects, so this passes only while the
+    // transform stays off the `strict: false` path.
+    const schema = {
+      type: 'object',
+      properties: { tags: { type: 'object', additionalProperties: { type: 'string' } } },
+    };
+    const request = client.buildRequest(HI, {
+      responseFormat: { name: 'loose', schema, strict: false },
+    });
+    expect(request.text).toEqual({
+      format: { type: 'json_schema', name: 'loose', schema, strict: false },
+    });
+  });
+
+  it('refuses a strict responseFormat schema strict mode cannot express', () => {
+    expect(() =>
+      client.buildRequest(HI, {
+        responseFormat: {
+          name: 'loose',
+          schema: {
+            type: 'object',
+            properties: { tags: { type: 'object', additionalProperties: { type: 'string' } } },
+          },
+        },
+      }),
+    ).toThrow(/strict JSON schema at properties\/tags: additionalProperties must be false/);
+  });
+
+  it('names the format from a raw schema title unless the caller names it', () => {
+    const schema = { type: 'object', title: 'Person', properties: { name: { type: 'string' } } };
+    expect(
+      (client.buildRequest(HI, { responseFormat: schema }).text as { format: { name: string } }).format.name,
+    ).toBe('Person');
+    expect(
+      (
+        client.buildRequest(HI, { responseFormat: { name: 'explicit', schema } }).text as {
+          format: { name: string };
+        }
+      ).format.name,
+    ).toBe('explicit');
   });
 
   it('routes conversationId to previous_response_id or conversation', () => {

--- a/packages/openai/src/strict-schema.test.ts
+++ b/packages/openai/src/strict-schema.test.ts
@@ -1,0 +1,504 @@
+import type { JsonSchema } from '@polymind-inc/agent-framework-core';
+import { describe, expect, it } from 'vitest';
+import { toStrictJsonSchema } from './strict-schema.js';
+import { toResponsesTextFormat } from './to-openai.js';
+
+/** A Standard Schema that also exposes a JSON Schema, as a schema library would. */
+const standardSchema = {
+  '~standard': {
+    version: 1 as const,
+    vendor: 'test',
+    validate: (value: unknown) => ({ value }),
+  },
+  toJsonSchema: () => ({ type: 'object', properties: { name: { type: 'string' } } }),
+};
+
+/**
+ * What a zod 4 object schema converts to, verbatim, minus the `$schema` keyword the framework
+ * strips before a provider sees it: closed objects and a complete `required` list at every level.
+ * Such a schema already satisfies strict mode, so the transform must be a no-op on it.
+ */
+const zodDerivedSchema: JsonSchema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    age: { type: 'integer', minimum: -9007199254740991, maximum: 9007199254740991 },
+    hobbies: { type: 'array', items: { type: 'string' } },
+    nested: {
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      required: ['a'],
+      additionalProperties: false,
+    },
+  },
+  required: ['name', 'age', 'hobbies', 'nested'],
+  additionalProperties: false,
+};
+
+/**
+ * Every keyword the strict subset excludes, as `[keyword, node type, value]`. A list rather than an
+ * object because one of the keywords is `then`, and an object literal carrying it is a thenable.
+ */
+const UNSUPPORTED: Array<[string, string, unknown]> = [
+  ['$anchor', 'string', 'here'],
+  ['$dynamicAnchor', 'string', 'here'],
+  ['$dynamicRef', 'string', '#here'],
+  ['$recursiveAnchor', 'string', true],
+  ['$recursiveRef', 'string', '#'],
+  ['allOf', 'string', [{ type: 'string' }]],
+  ['contains', 'array', { type: 'string' }],
+  ['contentEncoding', 'string', 'base64'],
+  ['contentMediaType', 'string', 'text/plain'],
+  ['contentSchema', 'string', { type: 'string' }],
+  ['dependentRequired', 'object', { value: ['other'] }],
+  ['dependentSchemas', 'object', { value: { type: 'string' } }],
+  ['dependencies', 'object', { value: ['other'] }],
+  ['else', 'string', { type: 'string' }],
+  ['if', 'string', { type: 'string' }],
+  ['maxContains', 'array', 2],
+  ['maxProperties', 'object', 2],
+  ['minContains', 'array', 1],
+  ['minProperties', 'object', 1],
+  ['not', 'string', { type: 'string' }],
+  ['patternProperties', 'object', { '^x-': { type: 'string' } }],
+  ['prefixItems', 'array', [{ type: 'string' }]],
+  ['propertyNames', 'object', { type: 'string' }],
+  ['then', 'string', { type: 'string' }],
+  ['unevaluatedItems', 'array', false],
+  ['unevaluatedProperties', 'object', false],
+  ['uniqueItems', 'array', true],
+];
+
+describe('toStrictJsonSchema', () => {
+  it('closes every object and completes required, recursing through the whole document', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        name: { type: ['string', 'null'] },
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+          },
+        },
+        choice: {
+          anyOf: [
+            { type: 'object', properties: { a: { type: 'string' } } },
+            { type: 'object', properties: { b: { type: 'string' } } },
+          ],
+        },
+        either: {
+          oneOf: [{ type: 'object', properties: { c: { type: 'string' } } }],
+        },
+      },
+      required: ['name'],
+      $defs: {
+        details: { type: 'object', properties: { enabled: { type: 'boolean' } } },
+      },
+      definitions: {
+        legacy: { type: 'object', properties: { old: { type: 'string' } } },
+      },
+    };
+
+    expect(toStrictJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        name: { type: ['string', 'null'] },
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+          },
+        },
+        choice: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: { a: { type: 'string' } },
+              required: ['a'],
+              additionalProperties: false,
+            },
+            {
+              type: 'object',
+              properties: { b: { type: 'string' } },
+              required: ['b'],
+              additionalProperties: false,
+            },
+          ],
+        },
+        either: {
+          oneOf: [
+            {
+              type: 'object',
+              properties: { c: { type: 'string' } },
+              required: ['c'],
+              additionalProperties: false,
+            },
+          ],
+        },
+      },
+      // The caller's own entry keeps its position; the rest follow in sorted order.
+      required: ['name', 'choice', 'either', 'items'],
+      additionalProperties: false,
+      $defs: {
+        details: {
+          type: 'object',
+          properties: { enabled: { type: 'boolean' } },
+          required: ['enabled'],
+          additionalProperties: false,
+        },
+      },
+      definitions: {
+        legacy: {
+          type: 'object',
+          properties: { old: { type: 'string' } },
+          required: ['old'],
+          additionalProperties: false,
+        },
+      },
+    });
+  });
+
+  it('leaves the caller schema untouched and returns a fresh document every call', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        nested: { type: 'object', properties: { value: { type: 'string' } } },
+      },
+    };
+    const before = structuredClone(schema);
+
+    const first = toStrictJsonSchema(schema);
+    expect(schema).toEqual(before);
+
+    // Mutating a previous result must not leak into the next one.
+    first.required = ['corrupted'];
+    expect(toStrictJsonSchema(schema).required).toEqual(['name', 'nested']);
+    expect(schema).toEqual(before);
+  });
+
+  it('normalises a single-element object type array at the root', () => {
+    expect(toStrictJsonSchema({ type: ['object'], properties: { a: { type: 'string' } } }).type).toBe(
+      'object',
+    );
+  });
+
+  it('preserves the keywords strict mode supports', () => {
+    const properties = {
+      text: { type: 'string', minLength: 1, maxLength: 10, pattern: '^[a-z]+$', format: 'email' },
+      number: { type: 'number', minimum: 1, maximum: 10, multipleOf: 2 },
+      list: { type: 'array', items: { type: 'string' }, minItems: 1, maxItems: 10 },
+      choice: { type: 'string', enum: ['a', 'b'] },
+      fixed: { const: 'x' },
+      reference: { $ref: '#/$defs/details' },
+    };
+    const strict = toStrictJsonSchema({
+      type: 'object',
+      title: 'Payload',
+      description: 'A payload',
+      properties,
+      $defs: { details: { type: 'object', properties: { enabled: { type: 'boolean' } } } },
+    });
+
+    expect(strict.properties).toEqual(properties);
+    expect(strict.title).toBe('Payload');
+    expect(strict.description).toBe('A payload');
+  });
+
+  it('moves default into the description', () => {
+    const strict = toStrictJsonSchema({
+      type: 'object',
+      properties: {
+        described: { type: 'string', description: 'A value', default: 'fallback' },
+        bare: { type: 'integer', default: 7 },
+        nulled: { type: 'string', description: null, default: 'x' },
+      },
+    });
+
+    expect(strict.properties).toEqual({
+      described: { type: 'string', description: 'A value (Default value: "fallback")' },
+      bare: { type: 'integer', description: 'Default value: 7' },
+      nulled: { type: 'string', description: 'Default value: "x"' },
+    });
+  });
+
+  it('rejects a default whose description is not a string', () => {
+    expect(() =>
+      toStrictJsonSchema({
+        type: 'object',
+        properties: { value: { type: 'string', description: 42, default: 'x' } },
+      }),
+    ).toThrow('strict JSON schema at properties/value: description must be a string');
+  });
+
+  describe('rejects the keywords strict mode does not support', () => {
+    // The framework refuses locally instead of letting the service answer with an opaque 400, and
+    // never drops the keyword: silently ignoring it would change what the caller declared.
+    for (const [keyword, type, value] of UNSUPPORTED) {
+      it(keyword, () => {
+        expect(() =>
+          toStrictJsonSchema({
+            type: 'object',
+            properties: { value: { type, [keyword]: value } },
+          }),
+        ).toThrow(`strict JSON schema at properties/value: unsupported keyword "${keyword}"`);
+      });
+    }
+
+    it('covers every excluded keyword', () => {
+      expect(UNSUPPORTED).toHaveLength(27);
+    });
+  });
+
+  for (const value of [true, false]) {
+    it(`rejects a boolean subschema (${value})`, () => {
+      expect(() => toStrictJsonSchema({ type: 'object', properties: { value } })).toThrow(
+        'strict JSON schema at properties/value: boolean schemas are not supported',
+      );
+    });
+  }
+
+  it('rejects a non-schema subschema value', () => {
+    expect(() => toStrictJsonSchema({ type: 'object', properties: { value: 'string' } })).toThrow(
+      'strict JSON schema at properties/value: schema must be an object or boolean',
+    );
+  });
+
+  it('rejects an explicitly open object with its path', () => {
+    expect(() =>
+      toStrictJsonSchema({
+        type: 'object',
+        properties: {
+          tags: { type: 'object', additionalProperties: { type: 'string' } },
+        },
+      }),
+    ).toThrow('strict JSON schema at properties/tags: additionalProperties must be false');
+
+    expect(() =>
+      toStrictJsonSchema({
+        type: 'object',
+        properties: {
+          extras: { type: 'object', properties: { a: { type: 'string' } }, additionalProperties: true },
+        },
+      }),
+    ).toThrow('strict JSON schema at properties/extras: additionalProperties must be false');
+  });
+
+  it('rejects an implicitly open object', () => {
+    expect(() => toStrictJsonSchema({ type: 'object' })).toThrow(
+      'strict JSON schema at <root>: object schema must declare properties or set additionalProperties to false',
+    );
+    expect(() => toStrictJsonSchema({ type: 'object', properties: { nested: { type: 'object' } } })).toThrow(
+      'strict JSON schema at properties/nested: object schema must declare properties or set additionalProperties to false',
+    );
+  });
+
+  it('rejects an object whose declared properties are empty', () => {
+    expect(() => toStrictJsonSchema({ type: 'object', properties: {} })).toThrow(
+      'strict JSON schema at <root>: object schema must declare properties or set additionalProperties to false',
+    );
+  });
+
+  it('accepts an empty object that closed itself explicitly', () => {
+    expect(toStrictJsonSchema({ type: 'object', properties: {}, additionalProperties: false })).toEqual({
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+      required: [],
+    });
+  });
+
+  for (const [label, schema] of Object.entries({
+    string: { type: 'string' },
+    array: { type: 'array', items: { type: 'string' } },
+    unconstrained: { properties: { a: { type: 'string' } } },
+    union: { type: ['object', 'null'], properties: { a: { type: 'string' } } },
+  })) {
+    it(`rejects a non-object root: ${label}`, () => {
+      expect(() => toStrictJsonSchema(schema as JsonSchema)).toThrow(
+        'strict JSON schema at <root>: root schema must have type object',
+      );
+    });
+  }
+
+  it('rejects a root that is not an object at all', () => {
+    expect(() => toStrictJsonSchema([{ type: 'object' }] as unknown as JsonSchema)).toThrow(
+      'strict JSON schema at <root>: root schema must have type object',
+    );
+  });
+
+  it('rejects a union at the root', () => {
+    expect(() =>
+      toStrictJsonSchema({
+        type: 'object',
+        properties: { a: { type: 'string' } },
+        anyOf: [{ type: 'object', properties: { b: { type: 'string' } } }],
+      }),
+    ).toThrow('strict JSON schema at <root>: root schema must not use anyOf');
+  });
+
+  it('rejects a required property that is not declared', () => {
+    expect(() =>
+      toStrictJsonSchema({
+        type: 'object',
+        properties: { name: { type: 'string' } },
+        required: ['name', 'ghost'],
+      }),
+    ).toThrow('strict JSON schema at <root>: required property "ghost" is not declared in properties');
+  });
+
+  it('rejects a malformed properties, required, union or definition container', () => {
+    expect(() => toStrictJsonSchema({ type: 'object', properties: [] as never })).toThrow(
+      'strict JSON schema at <root>: properties must be an object',
+    );
+    expect(() =>
+      toStrictJsonSchema({ type: 'object', properties: { a: { type: 'string' } }, required: 'a' as never }),
+    ).toThrow('strict JSON schema at <root>: required must be an array of property names');
+    expect(() =>
+      toStrictJsonSchema({ type: 'object', properties: { a: { type: 'string' } }, required: [1] as never }),
+    ).toThrow('strict JSON schema at <root>: required must contain only property names');
+    expect(() => toStrictJsonSchema({ type: 'object', properties: { a: { anyOf: {} } } })).toThrow(
+      'strict JSON schema at properties/a/anyOf: must be an array of schemas',
+    );
+    expect(() =>
+      toStrictJsonSchema({ type: 'object', properties: { a: { type: 'string' } }, $defs: [] }),
+    ).toThrow('strict JSON schema at $defs: must be an object of schemas');
+  });
+
+  it('names the failing union branch by index', () => {
+    expect(() =>
+      toStrictJsonSchema({
+        type: 'object',
+        properties: {
+          choice: {
+            anyOf: [{ type: 'object', properties: { a: { type: 'string' } } }, { type: 'object' }],
+          },
+        },
+      }),
+    ).toThrow(
+      'strict JSON schema at properties/choice/anyOf/[1]: object schema must declare properties or set additionalProperties to false',
+    );
+  });
+
+  it('rejects a schema JSON cannot serialize', () => {
+    const schema: JsonSchema = { type: 'object', properties: { a: { type: 'string' } } };
+    schema.self = schema;
+    expect(() => toStrictJsonSchema(schema)).toThrow(
+      /strict JSON schema at <root>: schema is not JSON-serializable/,
+    );
+  });
+
+  it('keeps an optional nullable property required, as strict mode demands', () => {
+    // Strict mode has no notion of an optional property: "absent" is expressed by a nullable type,
+    // and the name still has to appear in `required`.
+    expect(
+      toStrictJsonSchema({
+        type: 'object',
+        properties: { name: { type: ['string', 'null'] }, email: { type: ['string', 'null'] } },
+        required: ['name'],
+      }).required,
+    ).toEqual(['name', 'email']);
+  });
+
+  it('leaves a zod-derived schema that already satisfies strict mode unchanged', () => {
+    expect(toStrictJsonSchema(zodDerivedSchema)).toEqual(zodDerivedSchema);
+  });
+});
+
+describe('toResponsesTextFormat strict handling', () => {
+  it('transforms a default-strict raw schema', () => {
+    expect(toResponsesTextFormat({ type: 'object', properties: { name: { type: 'string' } } })).toEqual({
+      type: 'json_schema',
+      name: 'response',
+      schema: {
+        type: 'object',
+        properties: { name: { type: 'string' } },
+        required: ['name'],
+        additionalProperties: false,
+      },
+      strict: true,
+    });
+  });
+
+  it('takes the same path for an explicit strict named format and a Standard Schema', () => {
+    const expected = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+      additionalProperties: false,
+    };
+    expect(
+      toResponsesTextFormat({
+        name: 'person',
+        schema: { type: 'object', properties: { name: { type: 'string' } } },
+        strict: true,
+      }),
+    ).toEqual({ type: 'json_schema', name: 'person', schema: expected, strict: true });
+    expect(toResponsesTextFormat(standardSchema as never)).toEqual({
+      type: 'json_schema',
+      name: 'response',
+      schema: expected,
+      strict: true,
+    });
+  });
+
+  it('passes a non-strict schema through structurally unchanged', () => {
+    // Deliberately a shape the strict transform would rewrite *and* one it would reject, so the
+    // assertion fails if the transform ever runs here.
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { tags: { type: 'object', additionalProperties: { type: 'string' } } },
+    };
+    expect(toResponsesTextFormat({ name: 'loose', schema, strict: false })).toEqual({
+      type: 'json_schema',
+      name: 'loose',
+      schema,
+      strict: false,
+    });
+  });
+
+  it('keeps a zod-derived schema at its original wire meaning', () => {
+    const before = structuredClone(zodDerivedSchema);
+    expect(toResponsesTextFormat({ name: 'person', schema: zodDerivedSchema }).schema).toEqual(before);
+    expect(zodDerivedSchema).toEqual(before);
+  });
+
+  it('uses a string root title as the format name, and an explicit name wins', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      title: 'Person',
+      properties: { name: { type: 'string' } },
+    };
+    expect(toResponsesTextFormat(schema).name).toBe('Person');
+    expect(toResponsesTextFormat({ schema }).name).toBe('Person');
+    expect(toResponsesTextFormat({ name: 'explicit', schema }).name).toBe('explicit');
+    // The title stays on the schema: it is a legal annotation, not a framework-only field.
+    expect((toResponsesTextFormat(schema).schema as JsonSchema).title).toBe('Person');
+  });
+
+  it('falls back to "response" when the title is missing or not a string', () => {
+    expect(toResponsesTextFormat({ type: 'object', properties: { a: { type: 'string' } } }).name).toBe(
+      'response',
+    );
+    expect(
+      toResponsesTextFormat({ type: 'object', title: 7, properties: { a: { type: 'string' } } }).name,
+    ).toBe('response');
+    expect(
+      toResponsesTextFormat({ type: 'object', title: '', properties: { a: { type: 'string' } } }).name,
+    ).toBe('response');
+  });
+
+  it('reports an untransformable strict schema with its path', () => {
+    expect(() =>
+      toResponsesTextFormat({
+        type: 'object',
+        properties: { tags: { type: 'object', additionalProperties: { type: 'string' } } },
+      }),
+    ).toThrow('strict JSON schema at properties/tags: additionalProperties must be false');
+  });
+});

--- a/packages/openai/src/strict-schema.ts
+++ b/packages/openai/src/strict-schema.ts
@@ -1,0 +1,310 @@
+import type { JsonSchema } from '@polymind-inc/agent-framework-core';
+import { ChatClientError } from '@polymind-inc/agent-framework-core';
+import { isRecord } from '@polymind-inc/agent-framework-core/internal';
+
+/**
+ * JSON Schema keywords the OpenAI strict structured-output decoder does not accept.
+ *
+ * A schema using any of them cannot be represented in strict mode, and the service rejects the
+ * whole request. Dropping the keyword would silently widen or narrow what the caller declared, so
+ * the transform refuses instead and names the offending path.
+ */
+const UNSUPPORTED_KEYWORDS = [
+  '$anchor',
+  '$dynamicAnchor',
+  '$dynamicRef',
+  '$recursiveAnchor',
+  '$recursiveRef',
+  'allOf',
+  'contains',
+  'contentEncoding',
+  'contentMediaType',
+  'contentSchema',
+  'dependentRequired',
+  'dependentSchemas',
+  'dependencies',
+  'else',
+  'if',
+  'maxContains',
+  'maxProperties',
+  'minContains',
+  'minProperties',
+  'not',
+  'patternProperties',
+  'prefixItems',
+  'propertyNames',
+  'then',
+  'unevaluatedItems',
+  'unevaluatedProperties',
+  'uniqueItems',
+] as const;
+
+/** Keywords holding an array of subschemas. */
+const SUBSCHEMA_LISTS = ['anyOf', 'oneOf'] as const;
+
+/** Keywords holding a named map of subschemas. */
+const DEFINITION_MAPS = ['$defs', 'definitions'] as const;
+
+function strictSchemaError(path: readonly string[], message: string): ChatClientError {
+  const location = path.length > 0 ? path.join('/') : '<root>';
+  return new ChatClientError(`strict JSON schema at ${location}: ${message}`);
+}
+
+function childPath(path: readonly string[], ...elements: string[]): string[] {
+  return [...path, ...elements];
+}
+
+function hasType(schema: Record<string, unknown>, want: string): boolean {
+  const type = schema.type;
+  if (typeof type === 'string') {
+    return type === want;
+  }
+  return Array.isArray(type) && type.includes(want);
+}
+
+/**
+ * Reads a node's `properties`, distinguishing "absent" from "declared but empty".
+ *
+ * @throws {ChatClientError} When `properties` is present but not an object.
+ */
+function readProperties(
+  schema: Record<string, unknown>,
+  path: readonly string[],
+): Record<string, unknown> | undefined {
+  if (!Object.hasOwn(schema, 'properties')) {
+    return undefined;
+  }
+  const properties = schema.properties;
+  if (!isRecord(properties)) {
+    throw strictSchemaError(path, 'properties must be an object');
+  }
+  return properties;
+}
+
+/**
+ * Checks `required` against the declared properties before anything is rewritten.
+ *
+ * A name that is required but never declared cannot be satisfied once the object is closed, so the
+ * transform reports it instead of emitting a schema the service would reject.
+ *
+ * @throws {ChatClientError} When `required` is malformed or names an undeclared property.
+ */
+function validateRequired(
+  schema: Record<string, unknown>,
+  properties: Record<string, unknown> | undefined,
+  path: readonly string[],
+): void {
+  if (!Object.hasOwn(schema, 'required')) {
+    return;
+  }
+  const required = schema.required;
+  if (!Array.isArray(required)) {
+    throw strictSchemaError(path, 'required must be an array of property names');
+  }
+  for (const name of required) {
+    if (typeof name !== 'string') {
+      throw strictSchemaError(path, 'required must contain only property names');
+    }
+    if (properties === undefined || !Object.hasOwn(properties, name)) {
+      throw strictSchemaError(path, `required property "${name}" is not declared in properties`);
+    }
+  }
+}
+
+/**
+ * Fills `required` with every declared property.
+ *
+ * Names the caller already listed keep their order and the rest follow sorted, so the same input
+ * always produces the same wire payload.
+ */
+function completeRequired(existing: unknown, properties: Record<string, unknown>): string[] {
+  const required: string[] = [];
+  const seen = new Set<string>();
+  if (Array.isArray(existing)) {
+    // `validateRequired` already established that every entry is a declared property name.
+    for (const name of existing as string[]) {
+      if (!seen.has(name)) {
+        required.push(name);
+        seen.add(name);
+      }
+    }
+  }
+  const missing = Object.keys(properties).filter((name) => !seen.has(name));
+  missing.sort();
+  required.push(...missing);
+  return required;
+}
+
+/**
+ * Rewrites `default` into the node's description.
+ *
+ * Strict mode has no `default`, and a model that never sees the fallback cannot honour it, so the
+ * value is preserved as prose rather than dropped. Every value here has already been through the
+ * JSON clone, so re-encoding it always succeeds.
+ *
+ * @throws {ChatClientError} When the node's `description` is present but not a string.
+ */
+function moveDefaultIntoDescription(schema: Record<string, unknown>, path: readonly string[]): void {
+  if (!Object.hasOwn(schema, 'default')) {
+    return;
+  }
+  const defaultDescription = `Default value: ${JSON.stringify(schema.default)}`;
+  const description = schema.description;
+  if (description !== undefined && description !== null) {
+    if (typeof description !== 'string') {
+      throw strictSchemaError(path, 'description must be a string');
+    }
+    schema.description = `${description} (${defaultDescription})`;
+  } else {
+    schema.description = defaultDescription;
+  }
+  delete schema.default;
+}
+
+/**
+ * Transforms one subschema value in place.
+ *
+ * @throws {ChatClientError} When the value is not a strict-compatible schema object.
+ */
+function transformNode(value: unknown, path: readonly string[]): void {
+  if (typeof value === 'boolean') {
+    // `true` / `false` as a schema has no `properties` to close and no way to spell the closure.
+    throw strictSchemaError(path, 'boolean schemas are not supported');
+  }
+  if (!isRecord(value)) {
+    throw strictSchemaError(path, 'schema must be an object or boolean');
+  }
+  transformObject(value, path);
+}
+
+/**
+ * Applies the strict contract to one schema node and recurses into every subschema it carries.
+ *
+ * @throws {ChatClientError} When the node cannot be represented in strict mode.
+ */
+function transformObject(schema: Record<string, unknown>, path: readonly string[]): void {
+  for (const keyword of UNSUPPORTED_KEYWORDS) {
+    if (Object.hasOwn(schema, keyword)) {
+      throw strictSchemaError(path, `unsupported keyword "${keyword}"`);
+    }
+  }
+
+  const properties = readProperties(schema, path);
+  validateRequired(schema, properties, path);
+
+  const hasAdditionalProperties = Object.hasOwn(schema, 'additionalProperties');
+  if (hasAdditionalProperties && schema.additionalProperties !== false) {
+    // An explicitly open object — `true`, or a schema describing the extra keys — is a shape strict
+    // mode cannot express. Forcing it closed would drop data the caller asked for, so it fails.
+    throw strictSchemaError(path, 'additionalProperties must be false');
+  }
+  if (
+    hasType(schema, 'object') &&
+    (properties === undefined || Object.keys(properties).length === 0) &&
+    !hasAdditionalProperties
+  ) {
+    // An object that declares nothing is only meaningful if it accepts arbitrary keys, which strict
+    // mode forbids; closing it would send a schema that can never match anything.
+    throw strictSchemaError(
+      path,
+      'object schema must declare properties or set additionalProperties to false',
+    );
+  }
+
+  for (const [name, property] of Object.entries(properties ?? {})) {
+    transformNode(property, childPath(path, 'properties', name));
+  }
+  if (Object.hasOwn(schema, 'items')) {
+    transformNode(schema.items, childPath(path, 'items'));
+  }
+  for (const keyword of SUBSCHEMA_LISTS) {
+    if (!Object.hasOwn(schema, keyword)) {
+      continue;
+    }
+    const subschemas = schema[keyword];
+    if (!Array.isArray(subschemas)) {
+      throw strictSchemaError(childPath(path, keyword), 'must be an array of schemas');
+    }
+    subschemas.forEach((subschema, index) => {
+      transformNode(subschema, childPath(path, keyword, `[${index}]`));
+    });
+  }
+  for (const keyword of DEFINITION_MAPS) {
+    if (!Object.hasOwn(schema, keyword)) {
+      continue;
+    }
+    const definitions = schema[keyword];
+    if (!isRecord(definitions)) {
+      throw strictSchemaError(childPath(path, keyword), 'must be an object of schemas');
+    }
+    for (const [name, definition] of Object.entries(definitions)) {
+      transformNode(definition, childPath(path, keyword, name));
+    }
+  }
+
+  if (properties !== undefined) {
+    if (!hasAdditionalProperties) {
+      schema.additionalProperties = false;
+    }
+    schema.required = completeRequired(schema.required, properties);
+  }
+
+  moveDefaultIntoDescription(schema, path);
+}
+
+/**
+ * Validates the root of a strict schema and normalises a single-element `type` array.
+ *
+ * @throws {ChatClientError} When the root is not a plain object schema.
+ */
+function validateRoot(schema: Record<string, unknown>): void {
+  const type = schema.type;
+  if (typeof type === 'string') {
+    if (type !== 'object') {
+      throw strictSchemaError([], 'root schema must have type object');
+    }
+  } else if (Array.isArray(type)) {
+    if (type.length !== 1 || type[0] !== 'object') {
+      throw strictSchemaError([], 'root schema must have type object');
+    }
+    schema.type = 'object';
+  } else {
+    throw strictSchemaError([], 'root schema must have type object');
+  }
+  if (Object.hasOwn(schema, 'anyOf')) {
+    // A root union contradicts the required object root, and the service reports the combination
+    // only as an opaque 400.
+    throw strictSchemaError([], 'root schema must not use anyOf');
+  }
+}
+
+/**
+ * Rewrites a JSON Schema into the closed form the OpenAI strict structured-output decoder accepts.
+ *
+ * Strict mode requires an object root, `additionalProperties: false` on every object with declared
+ * properties, and a `required` list naming all of them; a schema that merely omits those keywords
+ * is rejected by the service with an opaque error. The transform therefore adds what is missing and
+ * refuses — naming the schema path — anything it cannot express, such as an explicitly open object
+ * or a keyword outside the strict subset. Adding the keywords is safe because a model that must
+ * emit every property can still express "absent" through a nullable type; silently closing an
+ * object the caller deliberately opened would not be.
+ *
+ * Works on a deep clone, so the caller's schema object is never modified. The clone goes through
+ * JSON, which also drops anything the wire could not carry.
+ *
+ * @throws {ChatClientError} When the schema cannot be represented in strict mode.
+ */
+export function toStrictJsonSchema(schema: JsonSchema): JsonSchema {
+  let clone: unknown;
+  try {
+    clone = JSON.parse(JSON.stringify(schema)) as unknown;
+  } catch (error) {
+    throw strictSchemaError([], `schema is not JSON-serializable: ${String(error)}`);
+  }
+  if (!isRecord(clone)) {
+    throw strictSchemaError([], 'root schema must have type object');
+  }
+  validateRoot(clone);
+  transformObject(clone, []);
+  return clone as JsonSchema;
+}

--- a/packages/openai/src/to-openai.ts
+++ b/packages/openai/src/to-openai.ts
@@ -21,6 +21,7 @@ import {
   safeStringify,
   topLevelMediaType,
 } from '@polymind-inc/agent-framework-core/internal';
+import { toStrictJsonSchema } from './strict-schema.js';
 
 /** A Responses API input item, kept loose so unmodelled item types pass through. */
 export type ResponsesInputItem = Record<string, unknown>;
@@ -720,13 +721,23 @@ export function toResponsesToolChoice(choice: ToolChoice | undefined): unknown {
   };
 }
 
-/** Converts a {@link ResponseFormat} into the Responses API `text.format` value. */
+/**
+ * Converts a {@link ResponseFormat} into the Responses API `text.format` value.
+ *
+ * A strict format's schema goes through {@link toStrictJsonSchema} first: `strict: true` and an
+ * untransformed schema is a combination the service rejects, and the caller's schema is a plain
+ * JSON Schema that need not already carry the closure keywords strict mode requires. A
+ * `strict: false` format is passed through structurally unchanged — the transform's rules do not
+ * apply there, and applying them would change what the caller asked for.
+ *
+ * @throws {ChatClientError} When a strict schema cannot be represented in strict mode.
+ */
 export function toResponsesTextFormat(format: ResponseFormat): Record<string, unknown> {
   const resolved = resolveResponseFormat(format);
   const config: Record<string, unknown> = {
     type: 'json_schema',
     name: resolved.name,
-    schema: resolved.schema,
+    schema: resolved.strict ? toStrictJsonSchema(resolved.schema) : resolved.schema,
     strict: resolved.strict,
   };
   if (resolved.description !== undefined) {

--- a/packages/openai/src/to-openai.wire-fallbacks.test.ts
+++ b/packages/openai/src/to-openai.wire-fallbacks.test.ts
@@ -412,7 +412,11 @@ describe('tool declarations and choices', () => {
 
   it('carries a response-format description onto the wire', () => {
     expect(
-      toResponsesTextFormat({ name: 'answer', description: 'the shape', schema: { type: 'object' } }),
+      toResponsesTextFormat({
+        name: 'answer',
+        description: 'the shape',
+        schema: { type: 'object', properties: { a: { type: 'string' } } },
+      }),
     ).toMatchObject({ type: 'json_schema', name: 'answer', description: 'the shape' });
   });
 });


### PR DESCRIPTION
## What this changes

Fixes #102. Structured output defaults `strict` to `true`, but the OpenAI request path sent the
JSON Schema unchanged, so a raw schema that is a valid framework input could reach the Responses
API in a form strict mode rejects — commonly an object node without `additionalProperties: false`
or without a complete `required`.

A strict format's schema now goes through a recursive transform on a deep clone before it is sent.
Object nodes gain `additionalProperties: false` and a completed `required`, `default` moves into
the description, and a schema strict mode cannot express fails locally with its path instead of as
a service 400. A `strict: false` format is passed through structurally unchanged, and the caller's
schema object is never written to. An unnamed raw schema takes its format name from a string root
`title`; an explicit name wins.

## Parity

- Reference checked: Go's `provider/openaiprovider/strict_schema.go`, branch for branch — the root
  validation, the 27 unsupported keywords, the container-shape errors, the `required` ordering
  (caller's order, then the remaining names sorted), the `default`-into-description rule and the
  `strict JSON schema at <path>: …` message shape. Python's `_chat_client.py` supplies the
  `title`-as-format-name behaviour, which Go lacks. Python's raw-schema path patches
  `additionalProperties` at the root only, which is the shallow form this deliberately does not
  follow.
- Wire format affected: yes
- Public API affected: no
- Breaking change: yes

A strict request now carries `additionalProperties: false` and a completed `required` on object
nodes, `default` becomes description text, and `text.format.name` may come from a schema `title`.
Requests that worked before are unchanged in shape, since the ones this affects were rejected by
the service. What breaks: `strict: true` with a schema strict mode cannot express now fails locally
with a `ChatClientError` naming the path, where it previously reached the service and returned a
400.

The transform is package-internal — exported from neither the root entry nor `./internal` — so
there is no public API addition.

Two deliberate divergences: Go's transform cache is not ported, because the clone here is a
plain-object round trip and a content-keyed cache would only reintroduce the shared-mutable-result
hazard Go spends three of its tests guarding. And unlike Python, `title` is not popped off the
schema: Go's 27-keyword unsupported list does not include it, so Go preserves it, and popping would
change what the caller declared.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
