### PR TITLE
Normalize MCP tool names and input schemas before they reach a provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,25 @@ contain breaking changes**; patch releases are fixes only.
   `{ "type": "item_reference", "id": "x" }`; to send a message, give it a `role` and `content`.
   Items of every other type are unaffected.
 
+- **`@polymind-inc/agent-framework-mcp`** — an MCP server's tool names and input schemas are
+  normalized before they reach a provider, and `McpClientConfig.toolNamePrefix` is new. MCP puts no
+  restriction on a tool name while providers accept only `[A-Za-z0-9_.-]` in a function name, and a
+  zero-argument tool declared as a bare `{ "type": "object" }` is rejected by OpenAI for having no
+  `properties` — both were passed through unchanged, so a valid server could produce a request the
+  provider refused or a tool the model could not name. The exposed name now replaces every other
+  character with `-` (`search docs!` becomes `search-docs-`), the reference implementations' rule
+  in Python's `_normalize_mcp_name` and Go's `normalizeMCPName`; an object schema gains
+  `properties: {}` when it has none, and a missing schema becomes
+  `{ "type": "object", "properties": {} }` — on a copy, so the server's own declaration is never
+  modified. The remote name is what still goes out on `tools/call`, and what `allowedTools`, the
+  `approvalMode` callback and error messages speak in. `toolNamePrefix` exposes tools as
+  `<prefix>_<name>`, so two servers that both advertise `search` can be told apart; the prefix is
+  normalized the same way, loses trailing `_.-`, and is ignored when nothing is left of it, as
+  Python's `tool_name_prefix` does. Prefixes are the only thing that separates clients — none
+  infers another's namespace. When two of one server's tools would be exposed under the same name,
+  `getTools()` now rejects and names both remote tools and the name they collide on, rather than
+  silently shadowing one of them.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -56,6 +56,43 @@ A tool result's `_meta` envelope is preserved: it is copied onto every content i
 that result under `additionalProperties._meta`, matching the reference implementation, so a layer
 above can read per-item labels a server attached.
 
+## Tool names and schemas
+
+MCP puts no restriction on what a server calls a tool or on how it declares one; providers do. Two
+things are therefore normalized on the way out, and only on the way out:
+
+- **The exposed name.** Every character outside `[A-Za-z0-9_.-]` becomes `-`, so a server's
+  `search docs!` reaches the model as `search-docs-`. This is the reference implementations' rule
+  (Python's `_normalize_mcp_name`, Go's `normalizeMCPName`), so the same remote tool surfaces under
+  the same name across the SDKs.
+- **The input schema.** A tool that takes no arguments is commonly declared as a bare
+  `{ "type": "object" }`, which OpenAI rejects with a 400; it gains `properties: {}`. A missing
+  schema becomes `{ "type": "object", "properties": {} }`. Any other schema is passed through, and
+  the change is made on a copy — the server's own declaration is never modified.
+
+The server's own name is what still goes out on `tools/call`, and it is the name `allowedTools`
+matches, the name the `approvalMode` callback receives, and the name error messages use. Only what
+the model sees changes.
+
+`toolNamePrefix` namespaces the exposed names as `<prefix>_<name>`, which is how two servers that
+both advertise `search` are told apart:
+
+```ts
+const github = new McpClient({ url: githubUrl, toolNamePrefix: 'github' }); // github_search
+const jira = new McpClient({ url: jiraUrl, toolNamePrefix: 'jira' }); // jira_search
+```
+
+The prefix is normalized the same way, then loses any trailing `_`, `.` or `-`; one that
+normalizes away to nothing is ignored, as are leading separators on the tool name where the two
+join. Prefixes are the *only* way clients are separated: no client guesses at another's names, so
+two servers with a colliding tool name and no prefix stay colliding.
+
+If two of **one** server's tools would be exposed under the same name — `a b` and `a-b` both
+normalize to `a-b` — `getTools()` rejects and names both remote tools and the name they collide on.
+Keeping one silently would make the other unreachable, and which one survived would depend on the
+order the server happened to list them in. Narrow `allowedTools` to one of them, or ask the server
+to rename.
+
 ## Connection sources
 
 `McpClient` accepts exactly one connection source:

--- a/packages/mcp/src/client.test.ts
+++ b/packages/mcp/src/client.test.ts
@@ -188,10 +188,12 @@ describe('tool schema normalization', () => {
       .mockResolvedValue({ tools: [{ name: 'ping' }] } as unknown as Awaited<
         ReturnType<McpConnection['listTools']>
       >);
+    const mcp = new McpClient({ transport: server() });
     try {
-      const [ping] = await new McpClient({ transport: server() }).getTools();
+      const [ping] = await mcp.getTools();
       expect(ping?.jsonSchema).toEqual({ type: 'object', properties: {} });
     } finally {
+      await mcp.close();
       listTools.mockRestore();
     }
   });
@@ -200,10 +202,12 @@ describe('tool schema normalization', () => {
     const listTools = vi.spyOn(McpConnection.prototype, 'listTools').mockResolvedValue({
       tools: [{ name: 'ping', inputSchema: { type: 'string', description: 'raw' } }],
     } as unknown as Awaited<ReturnType<McpConnection['listTools']>>);
+    const mcp = new McpClient({ transport: server() });
     try {
-      const [ping] = await new McpClient({ transport: server() }).getTools();
+      const [ping] = await mcp.getTools();
       expect(ping?.jsonSchema).toEqual({ type: 'string', description: 'raw' });
     } finally {
+      await mcp.close();
       listTools.mockRestore();
     }
   });
@@ -215,13 +219,15 @@ describe('tool schema normalization', () => {
       .mockResolvedValue({ tools: [{ name: 'ping', inputSchema: declaredSchema }] } as unknown as Awaited<
         ReturnType<McpConnection['listTools']>
       >);
+    const mcp = new McpClient({ transport: server() });
     try {
-      const [ping] = await new McpClient({ transport: server() }).getTools();
+      const [ping] = await mcp.getTools();
 
       expect(declaredSchema).toEqual({ type: 'object' });
       expect(Object.hasOwn(declaredSchema, 'properties')).toBe(false);
       expect(ping?.jsonSchema).not.toBe(declaredSchema);
     } finally {
+      await mcp.close();
       listTools.mockRestore();
     }
   });

--- a/packages/mcp/src/client.test.ts
+++ b/packages/mcp/src/client.test.ts
@@ -17,6 +17,7 @@ import {
 import { MockChatClient } from '@polymind-inc/agent-framework-core/testing';
 import { describe, expect, it, vi } from 'vitest';
 import { McpClient } from './client.js';
+import { McpConnection } from './connection.js';
 import { fromMcpContent } from './content.js';
 import type { TestTool } from './test-server.js';
 import { SlowStartServer, TestMcpServer } from './test-server.js';
@@ -158,6 +159,162 @@ describe('tool enumeration', () => {
     expect(() => new McpClient({ transportFactory: server, headers: { authorization: 'secret' } })).toThrow(
       ConfigurationError,
     );
+  });
+});
+
+describe('tool schema normalization', () => {
+  it('gives a zero-argument object schema an empty properties map', async () => {
+    // The shape a real server sends for a tool that takes no arguments. OpenAI rejects an object
+    // schema without `properties` with a 400, so the declaration cannot be passed through as is.
+    const mcp = new McpClient({
+      transport: new TestMcpServer([
+        { name: 'ping', inputSchema: { type: 'object' }, call: () => ({ content: [] }) },
+      ]),
+    });
+
+    const [ping] = await mcp.getTools();
+
+    expect(ping?.jsonSchema).toEqual({ type: 'object', properties: {} });
+    await mcp.close();
+  });
+
+  it('supplies an object schema when the server declares none', async () => {
+    // `listTools` is stubbed on purpose: the MCP SDK validates a `tools/list` response and rejects
+    // a tool whose `inputSchema` is absent or is not `type: "object"`, so the two guards below
+    // cannot be reached through a transport. They exist for the same reason Python's do — a
+    // non-conforming server, or a caller driving McpClient over its own McpConnection.
+    const listTools = vi
+      .spyOn(McpConnection.prototype, 'listTools')
+      .mockResolvedValue({ tools: [{ name: 'ping' }] } as unknown as Awaited<
+        ReturnType<McpConnection['listTools']>
+      >);
+    try {
+      const [ping] = await new McpClient({ transport: server() }).getTools();
+      expect(ping?.jsonSchema).toEqual({ type: 'object', properties: {} });
+    } finally {
+      listTools.mockRestore();
+    }
+  });
+
+  it('leaves a non-object schema unchanged', async () => {
+    const listTools = vi.spyOn(McpConnection.prototype, 'listTools').mockResolvedValue({
+      tools: [{ name: 'ping', inputSchema: { type: 'string', description: 'raw' } }],
+    } as unknown as Awaited<ReturnType<McpConnection['listTools']>>);
+    try {
+      const [ping] = await new McpClient({ transport: server() }).getTools();
+      expect(ping?.jsonSchema).toEqual({ type: 'string', description: 'raw' });
+    } finally {
+      listTools.mockRestore();
+    }
+  });
+
+  it('does not mutate the schema object it was handed', async () => {
+    const declaredSchema: Record<string, unknown> = { type: 'object' };
+    const listTools = vi
+      .spyOn(McpConnection.prototype, 'listTools')
+      .mockResolvedValue({ tools: [{ name: 'ping', inputSchema: declaredSchema }] } as unknown as Awaited<
+        ReturnType<McpConnection['listTools']>
+      >);
+    try {
+      const [ping] = await new McpClient({ transport: server() }).getTools();
+
+      expect(declaredSchema).toEqual({ type: 'object' });
+      expect(Object.hasOwn(declaredSchema, 'properties')).toBe(false);
+      expect(ping?.jsonSchema).not.toBe(declaredSchema);
+    } finally {
+      listTools.mockRestore();
+    }
+  });
+});
+
+describe('tool name normalization', () => {
+  function namedServer(...names: string[]): TestMcpServer {
+    return new TestMcpServer(
+      names.map((name) => ({
+        name,
+        inputSchema: { type: 'object' },
+        call: () => ({ content: [{ type: 'text', text: `called:${name}` }] }),
+      })),
+    );
+  }
+
+  it('exposes a provider-safe name and calls the server with the remote one', async () => {
+    const transport = namedServer('search docs!');
+    const mcp = new McpClient({ transport });
+
+    const [search] = await mcp.getTools();
+
+    expect(search?.name).toBe('search-docs-');
+    await search?.execute?.({}, { callId: 'call_1' });
+    expect(transport.calls).toEqual([{ name: 'search docs!', arguments: {} }]);
+    await mcp.close();
+  });
+
+  it('rejects when two remote names collide on one exposed name', async () => {
+    const mcp = new McpClient({ transport: namedServer('a b', 'a-b') });
+
+    // Deterministic rather than a silent shadowing or a list-order-dependent suffix: both remote
+    // names and the exposed name they collide on are in the message.
+    await expect(mcp.getTools()).rejects.toThrow(/"a b".*"a-b"|"a-b".*"a b"/);
+    await expect(mcp.getTools()).rejects.toThrow('a-b');
+    await mcp.close();
+  });
+
+  it('keeps the allowlist and the approval policy on the remote names', async () => {
+    const seen: string[] = [];
+    const mcp = new McpClient({
+      transport: namedServer('search docs!', 'other tool'),
+      allowedTools: ['search docs!'],
+      approvalMode: (name) => {
+        seen.push(name);
+        return name === 'search docs!' ? 'always_require' : 'never_require';
+      },
+    });
+
+    const tools = await mcp.getTools();
+
+    expect(tools.map((entry) => entry.name)).toEqual(['search-docs-']);
+    expect(tools[0]?.approvalMode).toBe('always_require');
+    expect(seen).toEqual(['search docs!']);
+    await mcp.close();
+  });
+
+  it('namespaces two servers with toolNamePrefix and routes each call to its own server', async () => {
+    const githubTransport = namedServer('search');
+    const jiraTransport = namedServer('search');
+    const github = new McpClient({ transport: githubTransport, toolNamePrefix: 'github' });
+    const jira = new McpClient({ transport: jiraTransport, toolNamePrefix: 'jira' });
+
+    const [githubSearch] = await github.getTools();
+    const [jiraSearch] = await jira.getTools();
+
+    expect(githubSearch?.name).toBe('github_search');
+    expect(jiraSearch?.name).toBe('jira_search');
+    await githubSearch?.execute?.({}, { callId: 'call_1' });
+    await jiraSearch?.execute?.({}, { callId: 'call_2' });
+    expect(githubTransport.calls).toEqual([{ name: 'search', arguments: {} }]);
+    expect(jiraTransport.calls).toEqual([{ name: 'search', arguments: {} }]);
+    await github.close();
+    await jira.close();
+  });
+
+  it('normalizes the prefix and trims the separators around the join', async () => {
+    const exposed = async (toolNamePrefix: string, remoteName: string): Promise<string | undefined> => {
+      const mcp = new McpClient({ transport: namedServer(remoteName), toolNamePrefix });
+      const [only] = await mcp.getTools();
+      await mcp.close();
+      return only?.name;
+    };
+
+    expect(await exposed('git hub!', 'search')).toBe('git-hub_search');
+    expect(await exposed('github__', 'search')).toBe('github_search');
+    expect(await exposed('github', '__search')).toBe('github_search');
+    // A prefix that normalizes away entirely leaves the name as it was.
+    expect(await exposed('', 'search docs!')).toBe('search-docs-');
+    expect(await exposed('_.-', 'search docs!')).toBe('search-docs-');
+    expect(await exposed('!!!', 'search docs!')).toBe('search-docs-');
+    // A name that trims away entirely leaves the prefix standing on its own.
+    expect(await exposed('github', '___')).toBe('github');
   });
 });
 

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -7,6 +7,7 @@ import type {
   ToolContext,
 } from '@polymind-inc/agent-framework-core';
 import {
+  AgentFrameworkError,
   ConfigurationError,
   ToolInvocationError,
   textOfContents,
@@ -82,6 +83,80 @@ export interface McpClientConfig {
   headers?: Record<string, string> | McpHeaderProvider;
   /** Replaces the transport's `fetch`, for proxies and tests. */
   fetch?: typeof globalThis.fetch;
+  /**
+   * Namespaces the tool names this client exposes to the model, as `<prefix>_<name>`.
+   *
+   * Two servers that both advertise `search` collide the moment their tools reach one agent, and
+   * nothing in MCP tells them apart — a client cannot know what another client called its tools.
+   * A prefix is how the caller separates them: `toolNamePrefix: 'github'` and
+   * `toolNamePrefix: 'jira'` expose `github_search` and `jira_search`, each still calling its own
+   * server's `search`.
+   *
+   * The prefix goes through the same normalization as a tool name, then loses any trailing `_`,
+   * `.` or `-`; a prefix that normalizes away to nothing is ignored. Leading separators are
+   * trimmed off the tool name where the two are joined, and a name that trims away entirely leaves
+   * the prefix standing alone.
+   *
+   * Only the exposed name changes. `tools/call`, {@link McpClientConfig.allowedTools},
+   * {@link McpClientConfig.approvalMode} and error messages all keep using the server's own name.
+   */
+  toolNamePrefix?: string;
+}
+
+/** Characters a provider accepts in a function name; everything else normalizes to `-`. */
+const DISALLOWED_NAME_CHARACTERS = /[^A-Za-z0-9_.-]/g;
+/** The separators trimmed off each side of the `<prefix>_<name>` join. */
+const LEADING_SEPARATORS = /^[_.-]+/;
+const TRAILING_SEPARATORS = /[_.-]+$/;
+
+/**
+ * Rewrites a server-chosen name into the identifier pattern providers accept.
+ *
+ * MCP puts no restriction on a tool name, while OpenAI and the other providers only accept
+ * `[A-Za-z0-9_.-]` in a function name — so a server offering `search docs!` would otherwise turn
+ * into a request the provider rejects. The rule is the reference implementations': Python's
+ * `_normalize_mcp_name` and Go's `normalizeMCPName` both replace every other character with `-`,
+ * so the same remote tool surfaces under the same name across the SDKs.
+ */
+function normalizeToolName(name: string): string {
+  return name.replace(DISALLOWED_NAME_CHARACTERS, '-');
+}
+
+/** The name a tool is exposed to the model under, given the configured prefix. */
+function localToolName(remoteName: string, toolNamePrefix: string | undefined): string {
+  const normalized = normalizeToolName(remoteName);
+  if (toolNamePrefix === undefined) {
+    return normalized;
+  }
+  const prefix = normalizeToolName(toolNamePrefix).replace(TRAILING_SEPARATORS, '');
+  if (prefix === '') {
+    return normalized;
+  }
+  const trimmed = normalized.replace(LEADING_SEPARATORS, '');
+  return trimmed === '' ? prefix : `${prefix}_${trimmed}`;
+}
+
+/**
+ * Copies a declared input schema into one every provider accepts.
+ *
+ * A tool that takes no arguments is commonly declared as a bare `{ "type": "object" }`, which
+ * OpenAI answers with a 400 because the object form requires `properties`. Adding the empty map is
+ * what Python's MCP loader does, and it says exactly what the server meant. A schema that is
+ * absent altogether is treated as that same zero-argument declaration; Python leaves it as an
+ * empty schema, which says nothing about the arguments at all. Any other schema is passed through.
+ *
+ * The copy is shallow — only the top-level `properties` key is ever written — so the schema the
+ * server owns is left as it was; nothing nested is modified.
+ */
+function normalizeInputSchema(schema: Record<string, unknown> | null | undefined): Record<string, unknown> {
+  if (schema === undefined || schema === null) {
+    return { type: 'object', properties: {} };
+  }
+  const normalized = { ...schema };
+  if (normalized.type === 'object' && !Object.hasOwn(normalized, 'properties')) {
+    normalized.properties = {};
+  }
+  return normalized;
 }
 
 function approvalModeFor(policy: ApprovalPolicy | undefined, toolName: string): ApprovalMode {
@@ -91,11 +166,17 @@ function approvalModeFor(policy: ApprovalPolicy | undefined, toolName: string): 
   return typeof policy === 'function' ? policy(toolName) : policy;
 }
 
-/** A declared MCP tool, as `tools/list` reports it. */
+/**
+ * A declared MCP tool, as `tools/list` reports it.
+ *
+ * `inputSchema` is required by the protocol and by the SDK's own response validation, so the
+ * absent and null forms only arise for a non-conforming server reached some other way; they are
+ * accepted here rather than turned into a crash, as Python's loader does.
+ */
 interface DeclaredTool {
   name: string;
   description?: string;
-  inputSchema?: Record<string, unknown>;
+  inputSchema?: Record<string, unknown> | null;
 }
 
 /**
@@ -122,6 +203,17 @@ interface DeclaredTool {
  * framework has no home for yet (Python guards it with a deny-by-default callback and per-session
  * caps; .NET has none); elicitation is supported by *no* reference implementation; prompts are
  * message templates rather than callables. See the package README for the full table.
+ *
+ * ## Names and schemas
+ *
+ * MCP lets a server name a tool anything and declare a zero-argument tool as a bare
+ * `{ "type": "object" }`; providers accept neither. So the exposed name replaces every character
+ * outside `[A-Za-z0-9_.-]` with `-`, an object schema gains `properties: {}` when it has none, and
+ * a copy of the schema is what carries the change. The server's own name is what still goes out on
+ * `tools/call`, and what {@link McpClientConfig.allowedTools},
+ * {@link McpClientConfig.approvalMode} and error messages speak in.
+ * {@link McpClientConfig.toolNamePrefix} adds a namespace when several servers advertise the same
+ * tool; without it, one client never guesses at another's names.
  *
  * ## Security considerations
  *
@@ -183,14 +275,42 @@ export class McpClient {
    *
    * Called on demand rather than at startup, so a server that is briefly unreachable fails the one
    * run that needed it instead of the whole process.
+   *
+   * Each tool is exposed under a provider-safe name (see {@link McpClientConfig.toolNamePrefix}).
+   *
+   * @throws {AgentFrameworkError} When two of the server's tools would be exposed under the same
+   *   name. Silently keeping one of them would make the other unreachable, and which one survived
+   *   would depend on the order the server happened to list them in.
    */
   async getTools(): Promise<Array<FunctionTool<Record<string, unknown>, unknown>>> {
     const { tools } = await this.#connection.listTools();
     const declared = tools as unknown as DeclaredTool[];
 
-    return declared
-      .filter((entry) => this.#allowedTools?.has(entry.name) ?? true)
-      .map((entry) => this.#toFunctionTool(entry));
+    const remoteByLocalName = new Map<string, string>();
+    const exposed: Array<FunctionTool<Record<string, unknown>, unknown>> = [];
+    for (const entry of declared) {
+      if (!(this.#allowedTools?.has(entry.name) ?? true)) {
+        continue;
+      }
+      const localName = localToolName(entry.name, this.#config.toolNamePrefix);
+      const claimedBy = remoteByLocalName.get(localName);
+      if (claimedBy !== undefined) {
+        if (claimedBy !== entry.name) {
+          throw new AgentFrameworkError(
+            `MCP server ${this.#target} advertises two tools whose exposed name is the same ` +
+              `"${localName}": "${claimedBy}" and "${entry.name}". Both cannot be offered to the ` +
+              'model, so neither is: restrict `allowedTools` to one of them, or have the server ' +
+              'rename one.',
+          );
+        }
+        // The same tool listed twice names the same target, so the first entry stands. Offering it
+        // twice would be the duplicate-name rejection this normalization exists to avoid.
+        continue;
+      }
+      remoteByLocalName.set(localName, entry.name);
+      exposed.push(this.#toFunctionTool(entry, localName));
+    }
+    return exposed;
   }
 
   /**
@@ -207,14 +327,17 @@ export class McpClient {
     return mcpSkillsSource(this.#connection, config);
   }
 
-  #toFunctionTool(declared: DeclaredTool): FunctionTool<Record<string, unknown>, unknown> {
+  #toFunctionTool(declared: DeclaredTool, localName: string): FunctionTool<Record<string, unknown>, unknown> {
     return tool({
-      name: declared.name,
+      // The provider-facing name. Everything else below — the call, the approval decision, the
+      // error text — stays on the server's own name, which is what identifies the tool remotely.
+      name: localName,
       // Python parity (`_mcp.py`: `tool.description or ""`): a missing description stays empty
       // rather than the name doubling as prose.
       description: declared.description ?? '',
-      // The server's JSON Schema is the contract; the framework does not re-derive it.
-      parameters: declared.inputSchema ?? { type: 'object' },
+      // The server's JSON Schema is the contract; the framework does not re-derive it, it only
+      // fills in what a provider requires but the server left implicit.
+      parameters: normalizeInputSchema(declared.inputSchema),
       approvalMode: approvalModeFor(this.#config.approvalMode, declared.name),
       execute: async (input: unknown, ctx: ToolContext): Promise<Content[]> => {
         try {

--- a/packages/meta/src/mcp-openai-tools.test.ts
+++ b/packages/meta/src/mcp-openai-tools.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Cross-package check: what `McpClient` exposes is what the OpenAI request conversion accepts.
+ *
+ * The MCP and OpenAI packages never depend on each other, so this lives in the umbrella package,
+ * the one that depends on both. `packages/mcp` covers separately that a real `tools/list` over the
+ * MCP SDK yields exactly the declaration asserted here; this test carries that declaration the
+ * rest of the way, into the Responses request body a provider would receive.
+ */
+import { textContent } from '@polymind-inc/agent-framework-core';
+import { McpClient, McpConnection } from '@polymind-inc/agent-framework-mcp';
+import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
+import { describe, expect, it, vi } from 'vitest';
+
+/** A Responses tool declaration, as far as these assertions read it. */
+interface ToolDeclaration {
+  type?: string;
+  name?: string;
+  parameters?: Record<string, unknown>;
+}
+
+type ListToolsResult = Awaited<ReturnType<McpConnection['listTools']>>;
+
+describe('MCP tools through the OpenAI request conversion', () => {
+  it('declares a zero-argument MCP tool in the shape the Responses API accepts', async () => {
+    // What a zero-argument tool looks like as MCP declares it: `properties` omitted, and a name
+    // no provider accepts as a function name. Either one passed through is a 400.
+    const listTools = vi.spyOn(McpConnection.prototype, 'listTools').mockResolvedValue({
+      tools: [{ name: 'search docs!', description: 'Search the docs', inputSchema: { type: 'object' } }],
+    } as unknown as ListToolsResult);
+    try {
+      const mcp = new McpClient({ url: 'https://mcp.example.com/mcp' });
+      const tools = await mcp.getTools();
+      const client = new OpenAIChatClient({ apiKey: 'test-key', model: 'gpt-4o' });
+
+      const request = client.buildRequest([{ role: 'user', contents: [textContent('hi')] }], { tools });
+
+      const declared = (request.tools as ToolDeclaration[]).find((entry) => entry.type === 'function');
+      expect(declared?.name).toBe('search-docs-');
+      // `{ "type": "object" }` on its own is what the API rejects; the empty map is what makes the
+      // zero-argument declaration legal.
+      expect(declared?.parameters).toEqual({
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      });
+    } finally {
+      listTools.mockRestore();
+    }
+  });
+});

--- a/packages/meta/src/mcp-openai-tools.test.ts
+++ b/packages/meta/src/mcp-openai-tools.test.ts
@@ -27,8 +27,8 @@ describe('MCP tools through the OpenAI request conversion', () => {
     const listTools = vi.spyOn(McpConnection.prototype, 'listTools').mockResolvedValue({
       tools: [{ name: 'search docs!', description: 'Search the docs', inputSchema: { type: 'object' } }],
     } as unknown as ListToolsResult);
+    const mcp = new McpClient({ url: 'https://mcp.example.com/mcp' });
     try {
-      const mcp = new McpClient({ url: 'https://mcp.example.com/mcp' });
       const tools = await mcp.getTools();
       const client = new OpenAIChatClient({ apiKey: 'test-key', model: 'gpt-4o' });
 
@@ -44,6 +44,7 @@ describe('MCP tools through the OpenAI request conversion', () => {
         additionalProperties: false,
       });
     } finally {
+      await mcp.close();
       listTools.mockRestore();
     }
   });


### PR DESCRIPTION
## What this changes

Fixes #103. MCP puts no restriction on what a server calls a tool, and a zero-argument tool is
commonly declared as a bare `{ "type": "object" }`. Providers accept neither, and both were
forwarded unchanged, so a valid server could produce a request the provider refused or a tool the
model could not name.

The exposed name now replaces every character outside `[A-Za-z0-9_.-]` with `-`, and an object
schema gains `properties: {}` when it has none — written onto a copy, so the server's schema is
never modified. Only the model-facing name changes: `tools/call`, `allowedTools`, the
`approvalMode` callback and error text all keep speaking the server's own name.

`McpClientConfig.toolNamePrefix` is new: it exposes tools as `<prefix>_<name>` so two servers that
both advertise `search` can be told apart. When two of one server's tools would be exposed under
the same name, `getTools()` rejects and names both — keeping one silently would make the other
unreachable, and which one survived would depend on the order the server listed them in.

## Parity

- Reference checked: Python `_mcp.py` — `_normalize_mcp_name` (the same character class),
  `_build_prefixed_mcp_name` (branch for branch, including the trailing/leading separator trims and
  the empty-prefix and empty-name cases), the `dict(tool.inputSchema or {})` + missing-`properties`
  rule, and the collision raise. `MCPTool.tool_name_prefix` is the grounding for the new config
  field. Go's `tool/mcptool/mcp.go` `normalizeMCPName` is a second witness for the character rule,
  and its `mcpWrapper` splits remote and local names exactly this way. .NET does no normalization —
  it wraps the MCP library's `McpClientTool` directly — so Python is the authority here.
- Wire format affected: no
- Public API affected: yes
- Breaking change: no

`McpClientConfig.toolNamePrefix` is added, and `getTools()` can now reject on a name collision.

MCP `tools/call` is unchanged — it still sends the server's own name. The provider request changes
by design, and only for servers whose names contained illegal characters or whose object schema
lacked `properties`; those requests were rejected before, so nothing that worked changes shape.

One deliberate divergence: a *missing* schema becomes `{ "type": "object", "properties": {} }`
rather than Python's `{}`. An empty schema says nothing about the arguments; the zero-argument
declaration is what the issue asks for, and it continues this package's previous default.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`
