### PR TITLE
Withhold unexecutable local calls at the function-invocation limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,22 @@ contain breaking changes**; patch releases are fixes only.
   `getTools()` now rejects and names both remote tools and the name they collide on, rather than
   silently shadowing one of them.
 
+- **`@polymind-inc/agent-framework-core`** — a run that exhausts `maxIterations` no longer ends on
+  a tool call nobody will make. The final, over-budget request already withdrew the local function
+  declarations; it now also sends `toolChoice: 'none'` (previously `'auto'`), and a local
+  `function_call` or local `function_approval_request` the provider emits anyway is removed from
+  that round instead of being returned unexecuted — in both awaited and streamed form, which fold
+  to the same messages. Filtering is per update, so everything an update keeps is still forwarded
+  the moment it arrives; text, reasoning, response metadata, raw representation, hosted content,
+  provider-hosted approvals and `informationalOnly` call/result pairs are untouched, and an update
+  left with metadata but no content stays visible. When finalization leaves no non-blank
+  user-visible answer and no hosted approval, the run ends on the fixed sentence
+  `Function invocation limit reached before a final answer could be produced.`, matching Python's
+  `_ensure_function_invocation_limit_fallback_response`; content that survived is never displaced
+  to make room for it. Requesting structured output from a run that ends this way now raises the
+  ordinary "not valid JSON" error rather than silently returning `value: undefined`, because the
+  response is no longer a suspended one.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/packages/core/src/client/function-invocation.test.ts
+++ b/packages/core/src/client/function-invocation.test.ts
@@ -1,7 +1,13 @@
 import { assert, describe, expect, expectTypeOf, it, vi } from 'vitest';
-import { ConfigurationError, SchemaResolutionError, UserInputRequiredError } from '../errors.js';
+import {
+  ChatClientError,
+  ConfigurationError,
+  SchemaResolutionError,
+  UserInputRequiredError,
+} from '../errors.js';
 import { functionMiddleware } from '../middleware/middleware.js';
 import { createResponseStream } from '../streaming/response-stream.js';
+import { hostedTool } from '../tools/hosted.js';
 import { invocationCountOf, resetInvocationCount, tool } from '../tools/tool.js';
 import type {
   Content,
@@ -12,11 +18,13 @@ import type {
 } from '../types/content.js';
 import { textContent } from '../types/content.js';
 import type { Message } from '../types/message.js';
+import type { ChatResponseUpdate } from '../types/response.js';
 import { chatResponseUpdate, mergeChatUpdates } from '../types/response.js';
 import { deserializeContent } from '../types/serialization.js';
 import type { ChatClient, ChatClientMetadata, ChatOptions } from './chat-client.js';
 import { FunctionInvocationLimitError } from './function-execution.js';
 import { withFunctionInvocation } from './function-invocation.js';
+import { withStructuredOutput } from './structured-output.js';
 import { MockChatClient } from './test-support.js';
 
 function call(
@@ -353,7 +361,7 @@ describe('withFunctionInvocation', () => {
     expect(inner.callCount).toBe(3);
     expect(inner.calls[0]?.options?.tools).toHaveLength(1);
     expect(inner.calls[2]?.options?.tools).toBeUndefined();
-    expect(inner.calls[2]?.options?.toolChoice).toBe('auto');
+    expect(inner.calls[2]?.options?.toolChoice).toBe('none');
   });
 
   it.each([0, -1, 0.5, Number.NaN, Number.POSITIVE_INFINITY])(
@@ -1615,5 +1623,507 @@ describe('calls whose arguments are missing or null', () => {
     assert.exists(transcriptCall);
     expect(transcriptCall.arguments).toBe(fields.arguments as undefined);
     expect(Object.hasOwn(transcriptCall, 'arguments')).toBe('arguments' in fields);
+  });
+});
+
+describe('withFunctionInvocation at the iteration limit', () => {
+  const FALLBACK_TEXT = 'Function invocation limit reached before a final answer could be produced.';
+
+  const loopTool = (execute: () => Promise<string> = async () => 'again') =>
+    tool({ name: 'loop', description: 'd', parameters: echoSchema, execute });
+
+  function localApproval(callId: string): FunctionApprovalRequestContent {
+    return {
+      type: 'function_approval_request',
+      id: `ficc_${callId}`,
+      functionCall: call(callId, 'loop'),
+      userInputRequest: true,
+    };
+  }
+
+  function hostedApproval(callId: string): FunctionApprovalRequestContent {
+    return {
+      type: 'function_approval_request',
+      id: `ficc_${callId}`,
+      functionCall: { ...call(callId, 'remote'), additionalProperties: { server_label: 'srv' } },
+      userInputRequest: true,
+    };
+  }
+
+  const informationalCall = (callId: string): FunctionCallContent => ({
+    ...call(callId, 'web_search'),
+    informationalOnly: true,
+  });
+  const informationalResult = (callId: string): FunctionResultContent => ({
+    type: 'function_result',
+    callId,
+    result: 'searched',
+  });
+
+  /**
+   * A provider scripted at *update* granularity, so a test can put metadata on an individual
+   * update rather than on a whole turn. Each entry answers one round in order; the last entry
+   * repeats once the script runs out, like {@link MockChatClient}.
+   */
+  function updateScript(turns: () => ChatResponseUpdate[][]): {
+    client: ChatClient<ChatOptions>;
+    requests: Array<ChatOptions | undefined>;
+  } {
+    const scripted = turns();
+    let index = 0;
+    const requests: Array<ChatOptions | undefined> = [];
+    const client: ChatClient<ChatOptions> = {
+      metadata: { providerName: 'mock' },
+      getResponse: (_messages, options) => {
+        requests.push(options);
+        const turn = scripted[Math.min(index++, scripted.length - 1)] ?? [];
+        return createResponseStream({
+          start: () =>
+            (async function* () {
+              yield* turn;
+            })(),
+          finalize: (updates) => mergeChatUpdates(updates),
+        });
+      },
+    };
+    return { client, requests };
+  }
+
+  /** Message ids the framework generates are random; everything else has to match exactly. */
+  function normalizeMessages(messages: Message[]): unknown {
+    return messages.map((msg) => ({
+      ...msg,
+      messageId:
+        msg.messageId !== undefined && /^[0-9a-f]{8}-[0-9a-f]{4}-/.test(msg.messageId)
+          ? '<generated>'
+          : msg.messageId,
+    }));
+  }
+
+  const contentsOf = (messages: Message[]): Content[] => messages.flatMap((msg) => msg.contents);
+
+  it('sends the final request without local declarations and with toolChoice none', async () => {
+    const inner = new MockChatClient([
+      { contents: [call('c1', 'loop')], finishReason: 'tool_calls' },
+      { contents: [textContent('done')], finishReason: 'stop' },
+    ]);
+    const search = hostedTool('web_search', { type: 'web_search' });
+
+    await withFunctionInvocation(inner, { maxIterations: 1 }).getResponse([], {
+      tools: [loopTool(), search],
+      toolChoice: 'auto',
+    } as ChatOptions);
+
+    expect(inner.callCount).toBe(2);
+    expect(inner.calls[0]?.options?.tools).toHaveLength(2);
+    // The hosted tool is the provider's own; only the local declaration is withdrawn.
+    expect(inner.calls[1]?.options?.tools).toEqual([search]);
+    expect(inner.calls[1]?.options?.toolChoice).toBe('none');
+  });
+
+  it('drops a local call and a local approval the provider emits on the final round', async () => {
+    const execute = vi.fn(async () => 'again');
+    const inner = new MockChatClient([
+      { contents: [call('c1', 'loop')], finishReason: 'tool_calls' },
+      {
+        contents: [textContent('here it is'), call('c2', 'loop'), localApproval('c3')],
+        finishReason: 'tool_calls',
+      },
+    ]);
+
+    const response = await withFunctionInvocation(inner, { maxIterations: 1 }).getResponse([], {
+      tools: [loopTool(execute)],
+    } as ChatOptions);
+
+    // Only round 0 ran a tool; the final round's call is never executed.
+    expect(execute).toHaveBeenCalledTimes(1);
+    const contents = contentsOf(response.messages);
+    expect(contents.filter((c) => c.type === 'function_call' && c.callId === 'c2')).toEqual([]);
+    expect(contents.filter((c) => c.type === 'function_approval_request')).toEqual([]);
+    expect(response.text).toBe('here it is');
+  });
+
+  it('drops the same content from the yielded updates when streaming', async () => {
+    const execute = vi.fn(async () => 'again');
+    const inner = new MockChatClient([
+      { contents: [call('c1', 'loop')], finishReason: 'tool_calls' },
+      {
+        contents: [textContent('here it is'), call('c2', 'loop'), localApproval('c3')],
+        finishReason: 'tool_calls',
+      },
+    ]);
+
+    const stream = withFunctionInvocation(inner, { maxIterations: 1 }).getResponse([], {
+      tools: [loopTool(execute)],
+    } as ChatOptions);
+    const yielded: ChatResponseUpdate[] = [];
+    for await (const update of stream) {
+      yielded.push(update);
+    }
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    const streamedContents = yielded.flatMap((update) => update.contents);
+    expect(streamedContents.filter((c) => c.type === 'function_call' && c.callId === 'c2')).toEqual([]);
+    expect(streamedContents.filter((c) => c.type === 'function_approval_request')).toEqual([]);
+    const folded = await stream.finalResponse();
+    expect(folded.text).toBe('here it is');
+  });
+
+  it('yields retained content before the final round stream completes', async () => {
+    // Filtering is per update: a retained update reaches the caller while the provider is still
+    // producing, rather than after the whole round has been buffered.
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let index = 0;
+    const client: ChatClient<ChatOptions> = {
+      metadata: { providerName: 'mock' },
+      getResponse: () => {
+        const round = index++;
+        return createResponseStream({
+          start: () =>
+            (async function* () {
+              if (round === 0) {
+                yield chatResponseUpdate({
+                  contents: [call('c1', 'loop')],
+                  role: 'assistant',
+                  messageId: 'm0',
+                  finishReason: 'tool_calls',
+                });
+                return;
+              }
+              yield chatResponseUpdate({
+                contents: [textContent('early')],
+                role: 'assistant',
+                messageId: 'm1',
+              });
+              await gate;
+              yield chatResponseUpdate({
+                contents: [call('c2', 'loop')],
+                role: 'assistant',
+                messageId: 'm1',
+                finishReason: 'tool_calls',
+              });
+            })(),
+          finalize: (updates) => mergeChatUpdates(updates),
+        });
+      },
+    };
+
+    const stream = withFunctionInvocation(client, { maxIterations: 1 }).getResponse([], {
+      tools: [loopTool()],
+    } as ChatOptions);
+    const iterator = stream[Symbol.asyncIterator]();
+    let next = await iterator.next();
+    while (!next.done && next.value.text !== 'early') {
+      next = await iterator.next();
+    }
+    // Reached while the provider's own stream is still parked on the gate.
+    assert.isFalse(next.done);
+    expect(next.value.text).toBe('early');
+    release();
+    const rest: ChatResponseUpdate[] = [];
+    for (next = await iterator.next(); !next.done; next = await iterator.next()) {
+      rest.push(next.value);
+    }
+    expect(rest.flatMap((update) => update.contents).filter((c) => c.type === 'function_call')).toEqual([]);
+  });
+
+  it('keeps text, reasoning and metadata while removing only the local call', async () => {
+    const { client } = updateScript(() => [
+      [
+        chatResponseUpdate({
+          contents: [call('c1', 'loop')],
+          role: 'assistant',
+          finishReason: 'tool_calls',
+        }),
+      ],
+      [
+        chatResponseUpdate({
+          contents: [
+            textContent('partial'),
+            { type: 'text_reasoning', text: 'thinking' },
+            call('c2', 'loop'),
+          ],
+          role: 'assistant',
+          messageId: 'm1',
+          responseId: 'resp_final',
+          additionalProperties: { trace: 'abc' },
+          finishReason: 'tool_calls',
+        }),
+      ],
+    ]);
+
+    const stream = withFunctionInvocation(client, { maxIterations: 1 }).getResponse([], {
+      tools: [loopTool()],
+    } as ChatOptions);
+    const yielded: ChatResponseUpdate[] = [];
+    for await (const update of stream) {
+      yielded.push(update);
+    }
+    const mixed = yielded.find((update) => update.messageId === 'm1');
+    assert.exists(mixed);
+    expect(mixed.contents.map((c) => c.type)).toEqual(['text', 'text_reasoning']);
+    expect(mixed.responseId).toBe('resp_final');
+    expect(mixed.additionalProperties).toEqual({ trace: 'abc' });
+    expect(mixed.finishReason).toBe('tool_calls');
+  });
+
+  it('keeps a metadata-only update after its local call is removed', async () => {
+    const { client } = updateScript(() => [
+      [
+        chatResponseUpdate({
+          contents: [call('c1', 'loop')],
+          role: 'assistant',
+          finishReason: 'tool_calls',
+        }),
+      ],
+      [
+        chatResponseUpdate({ contents: [textContent('answer')], role: 'assistant', messageId: 'm1' }),
+        chatResponseUpdate({
+          contents: [call('c2', 'loop')],
+          role: 'assistant',
+          messageId: 'm1',
+          responseId: 'resp_final',
+          finishReason: 'tool_calls',
+        }),
+        // Nothing but a local call, and no metadata at all: this one goes away entirely.
+        chatResponseUpdate({ contents: [call('c3', 'loop')] }),
+      ],
+    ]);
+
+    const stream = withFunctionInvocation(client, { maxIterations: 1 }).getResponse([], {
+      tools: [loopTool()],
+    } as ChatOptions);
+    const yielded: ChatResponseUpdate[] = [];
+    for await (const update of stream) {
+      yielded.push(update);
+    }
+    const metadataOnly = yielded.filter((update) => update.responseId === 'resp_final');
+    expect(metadataOnly).toHaveLength(1);
+    expect(metadataOnly[0]?.contents).toEqual([]);
+    expect(metadataOnly[0]?.finishReason).toBe('tool_calls');
+    // The bare call update carried nothing else, so nothing is forwarded in its place.
+    expect(yielded.filter((update) => update.contents.length === 0)).toHaveLength(1);
+  });
+
+  it.each([true, false])(
+    'preserves provider-executed calls and hosted approvals on the final round (streamed=%s)',
+    async (streamed) => {
+      const script = (): ChatResponseUpdate[][] => [
+        [
+          chatResponseUpdate({
+            contents: [call('c1', 'loop')],
+            role: 'assistant',
+            finishReason: 'tool_calls',
+          }),
+        ],
+        [
+          chatResponseUpdate({
+            contents: [
+              informationalCall('i1'),
+              informationalResult('i1'),
+              hostedApproval('h1'),
+              call('c2', 'loop'),
+              localApproval('c3'),
+            ],
+            role: 'assistant',
+            messageId: 'm1',
+            finishReason: 'tool_calls',
+          }),
+        ],
+      ];
+      const { client } = updateScript(script);
+      const invoked = withFunctionInvocation(client, { maxIterations: 1 }).getResponse([], {
+        tools: [loopTool()],
+      } as ChatOptions);
+      if (streamed) {
+        for await (const _update of invoked) {
+          // drain
+        }
+      }
+      const response = streamed ? await invoked.finalResponse() : await invoked;
+
+      const contents = contentsOf(response.messages);
+      expect(contents.filter((c) => c.type === 'function_call' && c.informationalOnly === true)).toHaveLength(
+        1,
+      );
+      expect(contents.filter((c) => c.type === 'function_result' && c.callId === 'i1')).toHaveLength(1);
+      expect(contents.filter((c) => c.type === 'function_approval_request')).toEqual([hostedApproval('h1')]);
+      expect(contents.filter((c) => c.type === 'function_call' && c.callId === 'c2')).toEqual([]);
+      // A hosted approval is an answer the caller can act on, so no fallback is manufactured.
+      expect(response.text).not.toContain(FALLBACK_TEXT);
+    },
+  );
+
+  it.each([true, false])(
+    'appends the fallback after a provider-executed pair that answers nobody (streamed=%s)',
+    async (streamed) => {
+      const script = (): ChatResponseUpdate[][] => [
+        [
+          chatResponseUpdate({
+            contents: [call('c1', 'loop')],
+            role: 'assistant',
+            finishReason: 'tool_calls',
+          }),
+        ],
+        [
+          chatResponseUpdate({
+            contents: [informationalCall('i1'), informationalResult('i1'), call('c2', 'loop')],
+            role: 'assistant',
+            messageId: 'm1',
+            finishReason: 'tool_calls',
+          }),
+        ],
+      ];
+      const { client } = updateScript(script);
+      const invoked = withFunctionInvocation(client, { maxIterations: 1 }).getResponse([], {
+        tools: [loopTool()],
+      } as ChatOptions);
+      if (streamed) {
+        for await (const _update of invoked) {
+          // drain
+        }
+      }
+      const response = streamed ? await invoked.finalResponse() : await invoked;
+
+      const contents = contentsOf(response.messages);
+      // The pair survives — but a report of work the provider already did is not an answer, so
+      // the run still ends on the fallback.
+      expect(contents.filter((c) => c.type === 'function_call' && c.informationalOnly === true)).toHaveLength(
+        1,
+      );
+      expect(contents.filter((c) => c.type === 'function_result' && c.callId === 'i1')).toHaveLength(1);
+      expect(response.text).toBe(FALLBACK_TEXT);
+    },
+  );
+
+  it.each([true, false])(
+    'appends the deterministic fallback when nothing user-visible remains (streamed=%s)',
+    async (streamed) => {
+      const inner = new MockChatClient([
+        { contents: [call('c1', 'loop')], finishReason: 'tool_calls' },
+        { contents: [textContent('   '), call('c2', 'loop')], finishReason: 'tool_calls' },
+      ]);
+      const invoked = withFunctionInvocation(inner, { maxIterations: 1 }).getResponse([], {
+        tools: [loopTool()],
+      } as ChatOptions);
+      if (streamed) {
+        for await (const _update of invoked) {
+          // drain
+        }
+      }
+      const response = streamed ? await invoked.finalResponse() : await invoked;
+
+      const texts = contentsOf(response.messages)
+        .filter((c) => c.type === 'text')
+        .map((c) => c.text);
+      expect(texts).toContain(FALLBACK_TEXT);
+      // Retained content is not displaced to make room for the fallback.
+      expect(texts).toContain('   ');
+    },
+  );
+
+  it('reports a limit-terminated run as an answer rather than a suspension', async () => {
+    // The withheld call used to make the response look suspended, so structured output silently
+    // left `value` undefined. With nothing pending, the fallback is read as the model's answer
+    // and fails to parse like any other non-JSON reply.
+    const inner = new MockChatClient([
+      { contents: [call('c1', 'loop')], finishReason: 'tool_calls' },
+      { contents: [call('c2', 'loop')], finishReason: 'tool_calls' },
+    ]);
+    const client = withStructuredOutput(withFunctionInvocation(inner, { maxIterations: 1 }));
+    await expect(
+      client.getResponse([], {
+        tools: [loopTool()],
+        responseFormat: { schema: { type: 'object' } },
+      } as ChatOptions),
+    ).rejects.toThrow(ChatClientError);
+  });
+
+  it('adds no fallback when a visible answer remains', async () => {
+    const inner = new MockChatClient([
+      { contents: [call('c1', 'loop')], finishReason: 'tool_calls' },
+      { contents: [textContent('the answer'), call('c2', 'loop')], finishReason: 'tool_calls' },
+    ]);
+    const response = await withFunctionInvocation(inner, { maxIterations: 1 }).getResponse([], {
+      tools: [loopTool()],
+    } as ChatOptions);
+    expect(response.text).toBe('the answer');
+  });
+
+  it('adds no fallback when a non-text answer remains', async () => {
+    const chart: Content = { type: 'uri', uri: 'https://example.test/chart.png', mediaType: 'image/png' };
+    const inner = new MockChatClient([
+      { contents: [call('c1', 'loop')], finishReason: 'tool_calls' },
+      { contents: [chart, call('c2', 'loop')], finishReason: 'tool_calls' },
+    ]);
+    const response = await withFunctionInvocation(inner, { maxIterations: 1 }).getResponse([], {
+      tools: [loopTool()],
+    } as ChatOptions);
+    expect(contentsOf(response.messages)).toContainEqual(chart);
+    expect(response.text).toBe('');
+  });
+
+  it('appends the fallback when the final round produced only reasoning', async () => {
+    const reasoning: Content = { type: 'text_reasoning', text: 'the tool would say...' };
+    const inner = new MockChatClient([
+      { contents: [call('c1', 'loop')], finishReason: 'tool_calls' },
+      { contents: [reasoning, call('c2', 'loop')], finishReason: 'tool_calls' },
+    ]);
+    const response = await withFunctionInvocation(inner, { maxIterations: 1 }).getResponse([], {
+      tools: [loopTool()],
+    } as ChatOptions);
+    // Reasoning explains an answer instead of being one, so it is kept and still counted as none.
+    expect(contentsOf(response.messages)).toContainEqual(reasoning);
+    expect(response.text).toBe(FALLBACK_TEXT);
+  });
+
+  it('produces the same folded messages awaited and streamed', async () => {
+    const script = (): ChatResponseUpdate[][] => [
+      [
+        chatResponseUpdate({
+          contents: [call('c1', 'loop', '{"value":"x"}')],
+          role: 'assistant',
+          messageId: 'm0',
+          responseId: 'resp_0',
+          finishReason: 'tool_calls',
+        }),
+      ],
+      [
+        chatResponseUpdate({
+          contents: [textContent(' '), informationalCall('i1'), informationalResult('i1')],
+          role: 'assistant',
+          messageId: 'm1',
+          responseId: 'resp_1',
+        }),
+        chatResponseUpdate({
+          contents: [call('c2', 'loop'), localApproval('c3')],
+          role: 'assistant',
+          messageId: 'm1',
+          responseId: 'resp_1',
+          finishReason: 'tool_calls',
+        }),
+      ],
+    ];
+
+    const awaitedClient = updateScript(script);
+    const awaited = await withFunctionInvocation(awaitedClient.client, { maxIterations: 1 }).getResponse([], {
+      tools: [loopTool()],
+    } as ChatOptions);
+
+    const streamedClient = updateScript(script);
+    const stream = withFunctionInvocation(streamedClient.client, { maxIterations: 1 }).getResponse([], {
+      tools: [loopTool()],
+    } as ChatOptions);
+    const yielded: ChatResponseUpdate[] = [];
+    for await (const update of stream) {
+      yielded.push(update);
+    }
+
+    expect(normalizeMessages(mergeChatUpdates(yielded).messages)).toEqual(
+      normalizeMessages(awaited.messages),
+    );
   });
 });

--- a/packages/core/src/client/function-invocation.ts
+++ b/packages/core/src/client/function-invocation.ts
@@ -13,12 +13,14 @@ import type { AnyFunctionTool, Tool, ToolContext } from '../tools/tool.js';
 import { isFunctionTool } from '../tools/tool.js';
 import type {
   Content,
+  ContentType,
   FunctionApprovalRequestContent,
   FunctionApprovalResponseContent,
   FunctionCallContent,
 } from '../types/content.js';
+import { textContent } from '../types/content.js';
 import type { Message } from '../types/message.js';
-import type { ChatResponseUpdate } from '../types/response.js';
+import type { ChatResponse, ChatResponseUpdate } from '../types/response.js';
 import { chatResponseToUpdates, chatResponseUpdate, mergeChatUpdates } from '../types/response.js';
 import type { ChatClient, ChatOptions, ChatResponseStream } from './chat-client.js';
 import type { InvocationEnv, InvocationRoundConfig, RoundOutcome } from './function-execution.js';
@@ -32,8 +34,11 @@ export interface FunctionInvocationConfig {
    * Maximum number of tool rounds per run. Must be a positive safe integer. Default `40`,
    * matching .NET and Go.
    *
-   * On hitting the limit the loop makes one final model call with the function tools removed, so
-   * the run always ends with an assistant message rather than an unanswered tool call.
+   * On hitting the limit the loop makes one final model call with the function tools removed and
+   * `toolChoice: 'none'`. Should the model still answer with a local call or a local approval
+   * request, it is removed from that round rather than handed to the caller, and a run left with
+   * no answer at all ends on a fixed sentence — so the run always ends with an assistant message
+   * rather than an unanswered tool call.
    */
   maxIterations?: number;
   /**
@@ -97,22 +102,138 @@ function buildToolMap(
 }
 
 /**
- * Drops function tools for the final, over-budget model call.
+ * Prepares the final, over-budget model call.
  *
- * Mirrors Go `prepareOptionsForLastIteration`: without declarations the model cannot request more
- * local calls, so the run terminates with prose.
+ * Local function declarations are withdrawn (Go `prepareOptionsForLastIteration`) and the tool
+ * choice is pinned to `'none'` (Python's last phase), so the model is asked for prose rather than
+ * for calls nobody will run. Provider-hosted declarations stay: the provider executes those
+ * itself, and removing them would change what it can report about work it already did.
  */
 function withoutFunctionTools<TOptions extends ChatOptions>(options: TOptions): TOptions {
   const remaining = (options.tools ?? []).filter((candidate) => !isFunctionTool(candidate));
-  if (remaining.length === (options.tools ?? []).length) {
-    return options;
-  }
-  const next = { ...options, tools: remaining } as TOptions;
+  const next = { ...options, toolChoice: 'none' } as TOptions;
   if (remaining.length === 0) {
     delete next.tools;
-    next.toolChoice = 'auto';
+  } else {
+    next.tools = remaining;
   }
   return next;
+}
+
+/** The answer a run ends with when the iteration budget ran out before the model produced one. */
+const FUNCTION_INVOCATION_LIMIT_FALLBACK_TEXT =
+  'Function invocation limit reached before a final answer could be produced.';
+
+/**
+ * Content types that are an answer in themselves, alongside non-blank text.
+ *
+ * Reasoning is deliberately absent: it explains an answer rather than being one, so a round that
+ * produced nothing but reasoning still needs the fallback below.
+ */
+const USER_VISIBLE_CONTENT_TYPES: ReadonlySet<ContentType> = new Set<ContentType>([
+  'data',
+  'uri',
+  'error',
+  'hosted_file',
+  'hosted_vector_store',
+]);
+
+/**
+ * Local tool content the final request can neither execute nor answer.
+ *
+ * Two things qualify: a call this layer would have run (a provider-executed `informationalOnly`
+ * call is a report, not a request), and an approval request for a local tool. An approval a
+ * provider raised for its own hosted tool is *its* to settle — see {@link isHostedApproval} — so
+ * it survives and reaches the caller.
+ */
+function isUnexecutableLocalContent(content: Content): boolean {
+  if (isPendingCall(content)) {
+    return true;
+  }
+  return content.type === 'function_approval_request' && !isHostedApproval(content);
+}
+
+/**
+ * Whether an update still says something once its contents are gone.
+ *
+ * `role` is excluded on purpose: every update carries one, so counting it would keep every empty
+ * husk. The rest — ids, model, finish reason, continuation token, raw representation — is what a
+ * consumer folds into the response, and dropping it would lose response-level facts.
+ */
+function hasMeaningfulMetadata(update: ChatResponseUpdate): boolean {
+  return (
+    update.authorName !== undefined ||
+    update.responseId !== undefined ||
+    update.messageId !== undefined ||
+    update.conversationId !== undefined ||
+    update.model !== undefined ||
+    update.createdAt !== undefined ||
+    update.finishReason !== undefined ||
+    update.continuationToken !== undefined ||
+    (update.additionalProperties !== undefined && Object.keys(update.additionalProperties).length > 0) ||
+    update.rawRepresentation !== undefined
+  );
+}
+
+/**
+ * Removes unexecutable local content from one update, returning `undefined` for an update that is
+ * left with nothing at all.
+ *
+ * Applied per update rather than to a buffered round, so everything the update kept keeps flowing
+ * at the moment it arrived. The update is never mutated: the same objects are also what the
+ * provider's own stream and any layer beneath observe.
+ */
+function dropUnexecutableLocalContent(update: ChatResponseUpdate): ChatResponseUpdate | undefined {
+  if (!update.contents.some(isUnexecutableLocalContent)) {
+    return update;
+  }
+  const kept = update.contents.filter((content) => !isUnexecutableLocalContent(content));
+  if (kept.length === 0 && !hasMeaningfulMetadata(update)) {
+    return undefined;
+  }
+  return chatResponseUpdate({ ...update, contents: kept });
+}
+
+/** Whether the round left the caller something to read. */
+function hasUserVisibleAnswer(response: ChatResponse<unknown>): boolean {
+  for (const msg of response.messages) {
+    for (const content of msg.contents) {
+      if (content.type === 'text') {
+        if (content.text.trim() !== '') {
+          return true;
+        }
+      } else if (USER_VISIBLE_CONTENT_TYPES.has(content.type)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** Whether the round left a provider-owned approval for the caller to settle. */
+function hasHostedApprovalRequest(response: ChatResponse<unknown>): boolean {
+  return response.messages.some((msg) =>
+    msg.contents.some((content) => content.type === 'function_approval_request' && isHostedApproval(content)),
+  );
+}
+
+/**
+ * The answer emitted when the final round produced nothing the caller can use.
+ *
+ * A round left with an empty message — everything it carried was withheld — takes the sentence
+ * into that message, which is what the id-less update folds into. Otherwise the sentence opens a
+ * message of its own: appending it to a message that kept content would coalesce the two texts
+ * into one run of prose, and the fallback is meant to be recognizable verbatim.
+ */
+function limitFallbackUpdate(response: ChatResponse<unknown>): ChatResponseUpdate {
+  const last = response.messages.at(-1);
+  const emptiedMessage = last !== undefined && last.contents.length === 0;
+  return chatResponseUpdate({
+    contents: [textContent(FUNCTION_INVOCATION_LIMIT_FALLBACK_TEXT)],
+    role: 'assistant',
+    finishReason: 'stop',
+    ...(emptiedMessage ? {} : { messageId: crypto.randomUUID() }),
+  });
 }
 
 /**
@@ -214,7 +335,9 @@ function collectExecutableCalls(messages: Message[]): FunctionCallContent[] {
  * - a tool declared without `execute` stops the loop so the caller can handle the call;
  * - a tool's `maxInvocations` budget is claimed here, and a spent budget is reported to the model as
  *   a result rather than failing the run;
- * - after `maxIterations` rounds, one final call is made with the function tools removed;
+ * - after `maxIterations` rounds, one final call is made with the function tools removed and
+ *   `toolChoice: 'none'`, and anything local the model still asks for on that round is dropped
+ *   instead of being returned unexecuted;
  * - `maxConsecutiveErrors` failing rounds in a row abort the run with the aggregated error.
  *
  * Streaming behaves identically: every inner update is forwarded as it arrives and the generated
@@ -630,12 +753,24 @@ export function createFunctionInvocationClientFactory<TOptions extends ChatOptio
         (candidate) => candidate.approvalMode === 'always_require',
       );
 
+      // The final request carries no local function declarations, so a call or approval the
+      // provider emits anyway is content this layer will neither execute nor remove later —
+      // exactly the unanswered tool call the run promises not to end on. Each update is filtered
+      // as it arrives, before it is accumulated or forwarded, so whatever the update kept still
+      // reaches the caller at the moment the provider sent it.
+      const retained = (update: ChatResponseUpdate): ChatResponseUpdate | undefined =>
+        isFinalIteration ? dropUnexecutableLocalContent(update) : update;
+
       const inner = client.getResponse(history, roundOptions);
       const updates: ChatResponseUpdate[] = [];
       let flushed = 0;
       let buffering = false;
       if (stream) {
-        for await (const update of inner) {
+        for await (const raw of inner) {
+          const update = retained(raw);
+          if (update === undefined) {
+            continue;
+          }
           updates.push(update);
           buffering ||= mayRequireApproval && update.contents.some(isPendingCall);
           if (!buffering) {
@@ -644,7 +779,12 @@ export function createFunctionInvocationClientFactory<TOptions extends ChatOptio
           }
         }
       } else {
-        updates.push(...chatResponseToUpdates(await inner));
+        for (const raw of chatResponseToUpdates(await inner)) {
+          const update = retained(raw);
+          if (update !== undefined) {
+            updates.push(update);
+          }
+        }
         if (!mayRequireApproval) {
           for (const update of updates) {
             flushed++;
@@ -668,7 +808,16 @@ export function createFunctionInvocationClientFactory<TOptions extends ChatOptio
         yield update;
       }
 
-      if (isFinalIteration || shouldStop(calls, tools)) {
+      if (isFinalIteration) {
+        // Only once the round is complete is it known whether anything usable survived. The
+        // fallback is appended, never substituted: retained content keeps its place and the
+        // sentence is added after it.
+        if (!hasUserVisibleAnswer(roundResponse) && !hasHostedApprovalRequest(roundResponse)) {
+          yield limitFallbackUpdate(roundResponse);
+        }
+        return;
+      }
+      if (shouldStop(calls, tools)) {
         return;
       }
 


### PR DESCRIPTION
## What this changes

Fixes #108. A run that exhausts `maxIterations` could end on a tool call nobody would make: the
final, over-budget request already withdrew the local function declarations, but a provider that
answered with a local call or a local approval anyway had that content handed straight to the
caller — unexecuted and unremovable, against a contract promising a final answer with no unanswered
local tool calls.

The final request now also sends `toolChoice: 'none'`, and an actionable local `function_call` or
local `function_approval_request` on that round is withheld instead of returned. Filtering happens
per update, before accumulation, so everything an update keeps still reaches the caller the moment
the provider sent it — no full-round buffering was introduced. When finalization leaves no non-blank
user-visible answer and no hosted approval, the run ends on a fixed sentence, appended after any
content that survived rather than in place of it.

Awaited and streamed runs share one generator here, so a single filter serves both and their
equality is structural. Python needs the rule in two places for the same reason it is one here.

## Parity

- Reference checked: Python `_tools.py` — `_is_unexecutable_local_tool_content`,
  `_update_has_meaningful_metadata` (the same ten fields, `role` excluded),
  `_drop_unexecutable_tool_contents_from_update`, `_USER_VISIBLE_CONTENT_TYPES` (the same set), and
  `_ensure_function_invocation_limit_fallback_response` for the exact fallback text. Withdrawing the
  declarations follows Go's `prepareOptionsForLastIteration`, which is unchanged. Go has neither the
  filter nor the fallback; .NET's `FunctionInvokingChatClient` ships in a NuGet package outside the
  local mirror, so Python is the authority, as the issue states.
- Deliberate divergences: updates are copied rather than mutated — this layer does not modify
  content it did not create. Python's second gate, `max_function_calls`, has no counterpart here;
  `maxInvocations` is per tool and reports a result instead.
- Wire format affected: yes
- Public API affected: no
- Breaking change: no

The only wire change is on the final request, whose `toolChoice` becomes `'none'` where it was
`'auto'`. Content shapes and discriminators are untouched.

One consequence outside the loop, pinned by a test and called out in the changelog: a
limit-terminated run is no longer a suspended one, so asking for structured output from it raises
the ordinary "not valid JSON" error instead of silently returning `value: undefined`. That matches
Python, whose parse is lazy and would raise on access.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
