### PR TITLE
Default the non-hosted agentserver response store to the file-backed provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,34 @@ contain breaking changes**; patch releases are fixes only.
   `getTools()` now rejects and names both remote tools and the name they collide on, rather than
   silently shadowing one of them.
 
+- **[BREAKING] `@polymind-inc/agent-framework-agentserver`, `@polymind-inc/agent-framework-foundry`**
+  — a server built without an explicit `store` now persists responses to the **filesystem** rather
+  than to memory. `new ResponsesServer({ handler })` and a non-hosted `ResponsesHostServer` both
+  default to `FileResponseProvider` under `${AGENTSERVER_STATE_ROOT}/responses`
+  (`~/.agentserver/responses` when that variable is unset), so a `previous_response_id` chain
+  survives a restart instead of answering 404 — the local default both reference servers already
+  make (.NET registers `FileResponsesProvider` for a non-hosted host; Python's
+  `ResponsesAgentServerHost` falls through to `FileResponseStore`, under the same state root).
+  A hosted `ResponsesHostServer` is unchanged: the Foundry storage service when the platform
+  injects the project endpoint, the sandbox filesystem when it does not.
+
+  **Migration.** Nothing to do to keep the new behaviour, but two consequences are worth a
+  decision. First, the process now writes to disk where it previously did not: it needs write
+  access to the state root, and a read-only or ephemeral filesystem wants
+  `AGENTSERVER_STATE_ROOT` pointed somewhere writable. Second, **transcripts are persisted in the
+  clear** — each file is plain JSON holding a whole conversation, readable by anything running as
+  the same account, and nothing in this package expires, rotates or bounds them. Retention,
+  cleanup and the directory's permissions are the operator's responsibility. To keep the previous
+  process-local behaviour, pass the store explicitly:
+
+  ```ts
+  new ResponsesServer({ handler, store: new InMemoryResponseProvider() });
+  ```
+
+  Tests are the other place this shows up: a suite that builds a server without naming a store now
+  writes into `~/.agentserver` unless it pins `AGENTSERVER_STATE_ROOT` to a temporary directory —
+  this repository's own suites pass an in-memory store explicitly and pin the root regardless.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/examples/02-foundry/02-hosted-agent/README.md
+++ b/examples/02-foundry/02-hosted-agent/README.md
@@ -136,6 +136,13 @@ keep a deployment on its sandbox filesystem instead, pass the store explicitly:
 new ResponsesHostServer({ agent, store: new FileResponseProvider() });
 ```
 
+Running the same file locally stores responses on **your own filesystem**, under
+`${AGENTSERVER_STATE_ROOT}/responses` — `~/.agentserver/responses` unless you set that variable —
+so restarting the process does not break a `previous_response_id` chain. They are plain JSON
+holding whole conversations: nothing expires them, so clearing them out is your job, and the
+directory needs the protection the conversations do. `store: new InMemoryResponseProvider()` opts
+out and keeps everything in the process.
+
 Two service behaviours worth knowing, both measured against a live project: storage writes are
 gated on the **hosted-agent credential**, so `FoundryResponseStore` works from inside a deployed
 container and answers an opaque `500` from a workstation login; and every write must carry an

--- a/examples/02-foundry/02-hosted-agent/main.ts
+++ b/examples/02-foundry/02-hosted-agent/main.ts
@@ -53,7 +53,9 @@ const agent = new Agent({
 });
 
 // In a container the store defaults to the Foundry storage service, so responses survive sandbox
-// recycling; pass `store: new FileResponseProvider()` to keep a deployment off it — see README.md.
+// recycling; pass `store: new FileResponseProvider()` to keep a deployment off it. Run locally,
+// the default writes transcripts as plain JSON under `${AGENTSERVER_STATE_ROOT}/responses`
+// (`~/.agentserver/responses`), which nothing cleans up for you — see README.md.
 const server = new ResponsesHostServer({ agent });
 
 const { port } = await serve(server);

--- a/packages/agentserver/README.md
+++ b/packages/agentserver/README.md
@@ -27,6 +27,37 @@ with a Node adapter on the `./node` subpath:
 npm install @polymind-inc/agent-framework-agentserver
 ```
 
+## Response store
+
+`new ResponsesServer({ handler })` stores responses on the **filesystem** by default, so a
+`previous_response_id` chain survives a restart. Both reference servers make the same local
+choice — .NET registers `FileResponsesProvider` for a non-hosted host, Python's
+`ResponsesAgentServerHost` falls through to `FileResponseStore`.
+
+| Variable                 | Effect                                                                                    |
+| ------------------------ | ----------------------------------------------------------------------------------------- |
+| `AGENTSERVER_STATE_ROOT` | Root for local persistence. Defaults to `~/.agentserver`; responses live in `responses/`. |
+
+**Security and retention.** A response holds a whole conversation, and it is written as plain
+JSON: anything the user or the model said is readable by anyone who can read that directory, and
+by anything else running as the same account. Nothing here expires, rotates or bounds those
+files — retention and cleanup belong to whoever runs the process. Give the directory the
+protection the conversations deserve, or move it somewhere that has it:
+
+```sh
+AGENTSERVER_STATE_ROOT=/var/lib/my-agent node server.js
+```
+
+To opt out and keep every conversation in the process, pass the in-memory store explicitly:
+
+```ts
+new ResponsesServer({ handler, store: new InMemoryResponseProvider() });
+```
+
+That is also what a test wants: a suite that lets the default apply must point
+`AGENTSERVER_STATE_ROOT` at a temporary directory it cleans up, or it will write into the
+developer's home.
+
 ## Trust model
 
 This server is designed to run **behind the Microsoft Foundry gateway**. It trusts the

--- a/packages/agentserver/src/background.test.ts
+++ b/packages/agentserver/src/background.test.ts
@@ -453,6 +453,7 @@ describe('streamed replay', () => {
     const hold1 = Promise.withResolvers<void>();
     const hold2 = Promise.withResolvers<void>();
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       handler: async function* (_request: CreateResponseRequest, context: HandlerContext) {
         const response = (status: ResponseObject['status']): ResponseObject => ({
           ...context.response,
@@ -1084,6 +1085,7 @@ describe('the background registry survives a reused id', () => {
     // during its own setup, before there is a run to hand the id to.
     let attempts = 0;
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       handler: (request, context) => {
         attempts += 1;
         if (attempts === 1) {
@@ -1254,6 +1256,7 @@ describe('draining background runs', () => {
 
   it('settles the wait when the handler throws before its first event', async () => {
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       handler: async function* () {
         throw new Error('exploded before created');
         // biome-ignore lint/correctness/noUnreachable: never runs; the yield only makes this function a generator

--- a/packages/agentserver/src/config.ts
+++ b/packages/agentserver/src/config.ts
@@ -112,7 +112,14 @@ export function gracefulShutdownSeconds(): number {
   return intEnv('AGENTSERVER_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS', 30);
 }
 
-/** Root for local persistence when the platform's storage is not available. */
+/**
+ * Root for local persistence when the platform's storage is not available.
+ *
+ * `AGENTSERVER_STATE_ROOT`, defaulting to `~/.agentserver` — the same variable and default the
+ * reference servers resolve their durable state under. The default response store writes whole
+ * transcripts here in the clear and never removes them, so an operator who cares where that is,
+ * or who wants it on a volume they can wipe, sets this.
+ */
 export function stateRoot(): string {
   return (
     env('AGENTSERVER_STATE_ROOT') ?? `${process.env.HOME ?? process.env.USERPROFILE ?? '.'}/.agentserver`

--- a/packages/agentserver/src/node.test.ts
+++ b/packages/agentserver/src/node.test.ts
@@ -7,6 +7,7 @@ import { serve } from './node.js';
 import { writeWebResponse } from './node-internals.js';
 import type { HandlerContext } from './server.js';
 import { ResponsesServer } from './server.js';
+import { InMemoryResponseProvider } from './store/memory.js';
 import type { CreateResponseRequest, ResponseEvent, ResponseObject } from './wire.js';
 
 /** A minimal echo agent, over a real socket. */
@@ -34,7 +35,7 @@ let running: RunningServer;
 let base: string;
 
 beforeAll(async () => {
-  running = await serve(new ResponsesServer({ handler: echo }), {
+  running = await serve(new ResponsesServer({ handler: echo, store: new InMemoryResponseProvider() }), {
     port: 0,
     host: '127.0.0.1',
     handleSignals: false,
@@ -168,11 +169,14 @@ describe('node adapter', () => {
       sigterm: process.listenerCount('SIGTERM'),
       sigint: process.listenerCount('SIGINT'),
     };
-    const signalled = await serve(new ResponsesServer({ handler: echo }), {
-      port: 0,
-      host: '127.0.0.1',
-      observability: false,
-    });
+    const signalled = await serve(
+      new ResponsesServer({ handler: echo, store: new InMemoryResponseProvider() }),
+      {
+        port: 0,
+        host: '127.0.0.1',
+        observability: false,
+      },
+    );
     try {
       expect(process.listenerCount('SIGTERM')).toBe(before.sigterm + 1);
       expect(process.listenerCount('SIGINT')).toBe(before.sigint + 1);

--- a/packages/agentserver/src/observability.test.ts
+++ b/packages/agentserver/src/observability.test.ts
@@ -358,7 +358,7 @@ describe('setupHostObservability', () => {
     vi.resetModules();
     const { serve } = await import('./node.js');
     const { ResponsesServer } = await import('./server.js');
-    const server = new ResponsesServer({ handler: minimalHandler() });
+    const server = new ResponsesServer({ handler: minimalHandler(), store: new InMemoryResponseProvider() });
 
     // The message, not the class: the fresh generation has its own class identity.
     await expect(serve(server, { port: 0, host: '127.0.0.1', handleSignals: false })).rejects.toThrow(

--- a/packages/agentserver/src/server.test.ts
+++ b/packages/agentserver/src/server.test.ts
@@ -522,7 +522,11 @@ describe('route-level errors', () => {
   });
 
   it('does not claim a path that merely starts with the prefix', async () => {
-    const server = new ResponsesServer({ handler: lifecycleHandler({ echo: true }), prefix: '/api' });
+    const server = new ResponsesServer({
+      handler: lifecycleHandler({ echo: true }),
+      store: new InMemoryResponseProvider(),
+      prefix: '/api',
+    });
 
     expect((await server.handle(post({ input: 'x' }))).status).toBe(404);
     expect(
@@ -734,6 +738,7 @@ describe('request limits', () => {
     expect(
       () =>
         new ResponsesServer({
+          store: new InMemoryResponseProvider(),
           handler: lifecycleHandler({ echo: true }),
           limits: { [name]: value },
         }),
@@ -743,6 +748,7 @@ describe('request limits', () => {
   it('answers 413 for a body over the configured bound, before the handler runs', async () => {
     let ran = false;
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       handler: async function* (_request, context) {
         ran = true;
         yield { type: 'response.completed', response: context.response };
@@ -759,6 +765,7 @@ describe('request limits', () => {
 
   it('bounds the number of input items', async () => {
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       handler: lifecycleHandler({ echo: true }),
       limits: { maxInputItems: 2 },
     });
@@ -819,6 +826,7 @@ describe('lifecycle enforcement', () => {
   it('supplies created and in_progress for a handler that skips them', async () => {
     const violations: string[] = [];
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       handler: async function* (_request, context) {
         yield { type: 'response.completed', response: { ...context.response, status: 'completed' } };
       },
@@ -838,6 +846,7 @@ describe('lifecycle enforcement', () => {
   it('fails a response whose handler ends without a terminal event', async () => {
     const violations: string[] = [];
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       handler: async function* (_request, context) {
         yield { type: 'response.created', response: context.response };
         yield { type: 'response.in_progress', response: { ...context.response, status: 'in_progress' } };
@@ -854,6 +863,7 @@ describe('lifecycle enforcement', () => {
   it('emits exactly one terminal event', async () => {
     const violations: string[] = [];
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       handler: async function* (_request, context) {
         yield { type: 'response.created', response: context.response };
         yield { type: 'response.in_progress', response: context.response };
@@ -874,6 +884,7 @@ describe('lifecycle enforcement', () => {
   it('turns a handler exception into response.failed carrying the real message', async () => {
     const violations: Array<{ kind: string; detail?: string }> = [];
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       handler: async function* (_request, context) {
         yield { type: 'response.created', response: context.response };
         yield { type: 'response.in_progress', response: context.response };
@@ -900,6 +911,7 @@ describe('lifecycle enforcement', () => {
 
   it('falls back to the error name when the thrown message is empty', async () => {
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       handler: async function* (_request, context) {
         yield { type: 'response.created', response: context.response };
         yield { type: 'response.in_progress', response: context.response };
@@ -918,6 +930,7 @@ describe('lifecycle enforcement', () => {
   it('ends a cancelled turn as incomplete rather than failed', async () => {
     const violations: string[] = [];
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       handler: async function* (_request, context) {
         yield { type: 'response.created', response: context.response };
         yield { type: 'response.in_progress', response: context.response };
@@ -1126,6 +1139,7 @@ describe('protocol version fail-close', () => {
 describe('handler exceptions before streaming starts', () => {
   it('answers 500 with a fixed message, classified as an upstream failure', async () => {
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       // Throws synchronously, before any event, so the response is still a plain HTTP error.
       handler: () => {
         throw new Error('Internal connection string: sk-secret');
@@ -1147,6 +1161,7 @@ describe('handler exceptions before streaming starts', () => {
 
   it('classifies an async handler failure before the first event as upstream too', async () => {
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       handler: async function* () {
         throw new Error('agent setup failed');
         // biome-ignore lint/correctness/noUnreachable: never runs; the yield only makes this function a generator
@@ -1162,6 +1177,7 @@ describe('handler exceptions before streaming starts', () => {
 
   it('keeps a ProtocolError thrown by the handler, including its own source', async () => {
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       handler: async function* () {
         throw new ProtocolError(400, 'the platform did not identify the user', {
           code: 'missing_user_id',
@@ -1261,6 +1277,7 @@ describe('resource hygiene', () => {
 
   it('removes its abort listeners when the handler fails before streaming starts', async () => {
     const server = new ResponsesServer({
+      store: new InMemoryResponseProvider(),
       handler: () => {
         throw new Error('setup failed');
       },

--- a/packages/agentserver/src/server.ts
+++ b/packages/agentserver/src/server.ts
@@ -39,7 +39,7 @@ import {
   type ResourceRouteState,
 } from './resource-routes.js';
 import { resolveAgentReference, resolveAgentSessionId } from './session-id.js';
-import { InMemoryResponseProvider } from './store/memory.js';
+import { FileResponseProvider } from './store/file.js';
 import type { ResponseGeneration, ResponseProvider } from './store/provider.js';
 import { sameOwner } from './store/provider.js';
 import { conversationIdOf, parseCreateRequest, positiveLimit, validateResponseId } from './validation.js';
@@ -107,7 +107,15 @@ export interface ResponsesServerLimits {
 /** Construction options for {@link ResponsesServer}. */
 export interface ResponsesServerConfig {
   handler: ResponseHandler;
-  /** Defaults to {@link InMemoryResponseProvider}. */
+  /**
+   * Where responses live. Defaults to a {@link FileResponseProvider} under
+   * `${AGENTSERVER_STATE_ROOT}/responses` (`~/.agentserver/responses` when that variable is
+   * unset), so a `previous_response_id` chain survives a restart.
+   *
+   * That default writes transcripts to disk **in the clear**, and nothing expires them: see the
+   * class's security notes on {@link ResponsesServer}. Pass `new InMemoryResponseProvider()` to
+   * opt out and keep every conversation process-local.
+   */
   store?: ResponseProvider;
   /** Mounted under this path prefix. Foundry serves at the root, which is the default. */
   prefix?: string;
@@ -155,6 +163,11 @@ interface TurnTelemetry {
  * - **Handler exceptions are opaque to the caller.** A 500 body says only `internal server error`.
  *   They are classified `upstream` on `x-platform-error-source`; the `x-platform-error-detail`
  *   diagnostics header is reserved for `platform`-source failures of this layer itself.
+ * - **Transcripts are persisted to disk by default, in the clear.** With no `store`, responses go
+ *   to `${AGENTSERVER_STATE_ROOT}/responses` (`~/.agentserver/responses` by default) as JSON
+ *   holding whole conversations. Nothing here expires or rotates them, so retention and cleanup
+ *   belong to whoever runs the process, and the directory needs the protection the conversations
+ *   do. `new InMemoryResponseProvider()` opts out.
  */
 export class ResponsesServer {
   readonly #handler: ResponseHandler;
@@ -176,7 +189,11 @@ export class ResponsesServer {
 
   constructor(options: ResponsesServerConfig) {
     this.#handler = options.handler;
-    this.#store = options.store ?? new InMemoryResponseProvider();
+    // File-backed by default, so a `previous_response_id` chain outlives the process the way both
+    // reference servers make it: .NET registers `FileResponsesProvider` for a non-hosted host and
+    // Python's `ResponsesAgentServerHost` falls through to `FileResponseStore`, both under the
+    // shared `AGENTSERVER_STATE_ROOT`. An in-memory store is the explicit opt-out.
+    this.#store = options.store ?? new FileResponseProvider();
     this.#prefix = trimTrailingSlashes(options.prefix ?? '');
     this.#onViolation = options.onViolation;
     this.#hosted = options.hosted ?? isHosted();

--- a/packages/agentserver/src/store/default-store.test.ts
+++ b/packages/agentserver/src/store/default-store.test.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { stateRoot } from '../config.js';
+import type { HandlerContext, ResponseHandler } from '../server.js';
+import { ResponsesServer } from '../server.js';
+import { lifecycleHandler, post } from '../test-helpers.js';
+import type { CreateResponseRequest, ResponseObject } from '../wire.js';
+import { InMemoryResponseProvider } from './memory.js';
+
+describe('the test harness', () => {
+  it('keeps every suite off the developer’s own state root', () => {
+    // The store defaults to the filesystem, so a suite that builds a server without naming one
+    // writes transcripts somewhere. `scripts/test-state-root.ts` decides where; this is the
+    // assertion that notices if that setup file ever stops being applied.
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? '.';
+
+    expect(stateRoot()).not.toBe(`${home}/.agentserver`);
+    expect(stateRoot()).toContain('afjs-state-root-');
+  });
+});
+
+/**
+ * What a restart looks like from a test: a state root that only this test can see, so the default
+ * store resolves under it instead of the developer's `~/.agentserver`, and two server instances
+ * that share nothing but that directory.
+ */
+let root: string;
+
+/** Records the history each turn was handed, and answers with one identifiable output item. */
+function recordingHandler(seenHistory: string[][]): ResponseHandler {
+  return async function* (_request: CreateResponseRequest, context: HandlerContext) {
+    seenHistory.push(context.history.map((item) => String(item.id)));
+    yield { type: 'response.created', response: context.response };
+    yield { type: 'response.in_progress', response: { ...context.response, status: 'in_progress' } };
+    yield {
+      type: 'response.output_item.done',
+      item: { type: 'message', id: `out_${seenHistory.length}`, role: 'assistant' },
+    };
+    yield { type: 'response.completed', response: { ...context.response, status: 'completed' } };
+  };
+}
+
+describe('the default response store', () => {
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'afjs-default-store-'));
+    vi.stubEnv('AGENTSERVER_STATE_ROOT', root);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('continues a conversation across two server instances sharing one state root', async () => {
+    const seenHistory: string[][] = [];
+    const handler = recordingHandler(seenHistory);
+
+    // The instance a first process builds.
+    const before = new ResponsesServer({ handler, hosted: false });
+    const first = (await (
+      await before.handle(post({ input: [{ type: 'message', id: 'in_1', role: 'user', content: 'one' }] }))
+    ).json()) as ResponseObject;
+
+    // The instance the *next* process builds: same configuration, same state root, no shared memory.
+    const after = new ResponsesServer({ handler, hosted: false });
+    const continued = await after.handle(
+      post({
+        input: [{ type: 'message', id: 'in_2', role: 'user', content: 'two' }],
+        previous_response_id: first.id,
+      }),
+    );
+    const second = (await continued.json()) as ResponseObject;
+
+    expect(continued.status).toBe(200);
+    expect(seenHistory).toEqual([[], ['in_1', 'out_1']]);
+    expect(second.output[0]?.id).toBe('out_2');
+  });
+
+  it('persists the transcript as clear text under the state root', async () => {
+    const server = new ResponsesServer({ handler: lifecycleHandler({ echo: true }), hosted: false });
+
+    const created = (await (await server.handle(post({ input: 'Hi' }))).json()) as ResponseObject;
+
+    // Nothing encrypts or redacts what a turn said: the directory needs the protection the
+    // conversation does, and clearing it out is the operator's job.
+    const stored = await readFile(join(root, 'responses', `${created.id}.json`), 'utf8');
+    expect(stored).toContain('Echo: Hi');
+  });
+
+  it('keeps an explicit in-memory store process-local, and off the filesystem', async () => {
+    const seenHistory: string[][] = [];
+    const handler = recordingHandler(seenHistory);
+
+    const before = new ResponsesServer({
+      handler,
+      store: new InMemoryResponseProvider(),
+      hosted: false,
+    });
+    const first = (await (
+      await before.handle(post({ input: [{ type: 'message', id: 'in_1', role: 'user', content: 'one' }] }))
+    ).json()) as ResponseObject;
+
+    const after = new ResponsesServer({
+      handler,
+      store: new InMemoryResponseProvider(),
+      hosted: false,
+    });
+    const continued = await after.handle(post({ input: 'two', previous_response_id: first.id }));
+
+    // The documented opt-out: the second instance has never heard of the first turn.
+    expect(continued.status).toBe(404);
+    // And the opt-out is real — nothing reached the state root.
+    await expect(readdir(join(root, 'responses'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/packages/agentserver/src/store/file.ts
+++ b/packages/agentserver/src/store/file.ts
@@ -24,14 +24,18 @@ import {
 /**
  * Persists responses as JSON files under a root directory.
  *
- * For local runs that need to survive a restart — `azd ai agent run`, a debugger, a test that
- * exercises `previous_response_id` across processes.
+ * The default store, so a local run survives a restart — `azd ai agent run`, a debugger, a test
+ * that exercises `previous_response_id` across processes. `root` defaults to
+ * `${AGENTSERVER_STATE_ROOT}/responses`, and `AGENTSERVER_STATE_ROOT` itself to
+ * `~/.agentserver`.
  *
  * ## Security considerations
  *
  * Response ids come from the request, so they are treated as untrusted path segments and rejected
  * rather than sanitized (see {@link resolveUnder}). Contents are stored in the clear: a response
  * holds the whole conversation, so the directory needs the same protection the conversation does.
+ * Nothing here expires, rotates or bounds what it has written — retention and cleanup belong to
+ * whoever runs the process. `InMemoryResponseProvider` opts out of the filesystem entirely.
  *
  * The owner is stored *inside* the file rather than used as a directory, because an id is
  * addressable on its own: a caller asks for `caresp_…`, not for `alice/caresp_…`. Reads therefore

--- a/packages/agentserver/src/store/memory.ts
+++ b/packages/agentserver/src/store/memory.ts
@@ -34,8 +34,10 @@ export interface InMemoryResponseProviderConfig {
 /**
  * Keeps responses in process memory.
  *
- * The default for local development. Everything is lost when the process exits, so a hosted
- * container must not use it — a restart between turns would drop the conversation.
+ * The opt-out from the file-backed default: nothing reaches the filesystem, which is what a test
+ * or a short-lived process wants. Everything is lost when the process exits, so a hosted
+ * container must not use it — a restart between turns would drop the conversation, and a local
+ * run loses a `previous_response_id` chain the same way.
  *
  * Cross-user isolation still applies: one process serves every caller, so the owner check is the
  * only thing keeping their conversations apart.

--- a/packages/agentserver/src/test-setup.ts
+++ b/packages/agentserver/src/test-setup.ts
@@ -5,6 +5,10 @@
  * variable leaking in from the machine running the tests would silently change what the suite
  * asserts. A test that exercises an environment-driven path sets — and restores — the variable
  * itself.
+ *
+ * `AGENTSERVER_STATE_ROOT` goes with the rest, but does not stay unset: `scripts/test-state-root.ts`
+ * runs after this file and points it at a throwaway directory, so a server built without an
+ * explicit store cannot write into the developer's home.
  */
 const PLATFORM_ENV_PREFIXES = ['FOUNDRY_', 'AGENTSERVER_', 'OTEL_EXPORTER_', 'APPLICATIONINSIGHTS_'];
 

--- a/packages/agentserver/vitest.config.ts
+++ b/packages/agentserver/vitest.config.ts
@@ -1,6 +1,4 @@
 import { definePackageTests } from '../../scripts/vitest-config.ts';
 
-const config = definePackageTests();
 // The suite must not inherit the machine's deployment environment; see src/test-setup.ts.
-config.test = { ...config.test, setupFiles: ['./src/test-setup.ts'] };
-export default config;
+export default definePackageTests({ setupFiles: ['./src/test-setup.ts'] });

--- a/packages/foundry/README.md
+++ b/packages/foundry/README.md
@@ -51,6 +51,22 @@ Known limitations:
   service and the background replay log beside the sandbox state — the storage service has no
   events API — so stream replay after a sandbox recycle fails closed rather than resuming.
 
+## Where a local run stores responses
+
+`ResponsesHostServer` outside a container writes responses to
+`${AGENTSERVER_STATE_ROOT}/responses` (`~/.agentserver/responses` by default), so restarting
+`node main.ts` does not break a `previous_response_id` chain. Transcripts land there as plain
+JSON: nothing encrypts, expires or bounds them, so retention and cleanup are yours, and the
+directory needs the protection the conversations do. Point `AGENTSERVER_STATE_ROOT` elsewhere to
+move it, or opt out entirely:
+
+```ts
+new ResponsesHostServer({ agent, store: new InMemoryResponseProvider() });
+```
+
+A hosted container is unchanged: the Foundry storage service when the platform injects the
+project endpoint, the sandbox filesystem when it somehow does not.
+
 ---
 
 Part of [Agent Framework for TypeScript](https://github.com/polymind-inc/agent-framework-js) — an

--- a/packages/foundry/src/hosting/hosting.test.ts
+++ b/packages/foundry/src/hosting/hosting.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type {
@@ -47,6 +47,7 @@ import type { HostedAgentContext } from './hosted-context.js';
 import { getHostedAgentContext } from './hosted-context.js';
 import { OutputBuilder } from './output.js';
 import { FoundryResponseStore } from './response-store.js';
+import { ResponsesHostServer } from './server.js';
 import { FileSystemAgentSessionStore, InMemoryAgentSessionStore } from './session-store.js';
 
 function say(text: string): MockTurn {
@@ -715,6 +716,49 @@ describe('environment defaults', () => {
   it('keeps a local run in memory', () => {
     expect(defaultSessionStore(false).constructor.name).toBe('InMemoryAgentSessionStore');
     expect(defaultApprovalStorage(false).constructor.name).toBe('InMemoryApprovalStorage');
+  });
+
+  it('persists a local run’s responses to the state root, so a restart can be continued', async () => {
+    // The composition, not just `defaultStore(false)`: what a caller gets from
+    // `new ResponsesHostServer({ agent })` with no `store` is what the matrix is about.
+    const root = await mkdtemp(join(tmpdir(), 'afjs-host-store-'));
+    vi.stubEnv('AGENTSERVER_STATE_ROOT', root);
+    try {
+      const app = new ResponsesHostServer({
+        agent: new Agent({ client: new MockChatClient([say('Hello there')]), instructions: 'Be helpful.' }),
+        sessionStore: new InMemoryAgentSessionStore(),
+        approvalStorage: new InMemoryApprovalStorage(),
+        hosted: false,
+      });
+
+      const created = (await (await app.handle(post({ input: 'Hi' }))).json()) as ResponseObject;
+
+      // Clear text on disk, under the documented root — the transcript is readable by anyone who
+      // can read the directory, and nothing here ever removes it.
+      expect(await readFile(join(root, 'responses', `${created.id}.json`), 'utf8')).toContain('Hello there');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps an explicitly in-memory local run off the filesystem', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'afjs-host-store-'));
+    vi.stubEnv('AGENTSERVER_STATE_ROOT', root);
+    try {
+      const app = new ResponsesHostServer({
+        agent: new Agent({ client: new MockChatClient([say('Hello there')]), instructions: 'Be helpful.' }),
+        sessionStore: new InMemoryAgentSessionStore(),
+        approvalStorage: new InMemoryApprovalStorage(),
+        hosted: false,
+        store: new InMemoryResponseProvider(),
+      });
+
+      await app.handle(post({ input: 'Hi' }));
+
+      await expect(readdir(join(root, 'responses'))).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/foundry/src/hosting/response-store.test.ts
+++ b/packages/foundry/src/hosting/response-store.test.ts
@@ -347,8 +347,12 @@ describe('FoundryResponseStore request headers', () => {
 });
 
 describe('default store selection', () => {
-  it('keeps a local run in memory', () => {
-    expect(defaultStore(false).constructor.name).toBe('InMemoryResponseProvider');
+  it('persists a local run to the filesystem, so a restart can be continued', () => {
+    // Both reference servers make the same local choice — .NET registers `FileResponsesProvider`
+    // for a non-hosted host, Python's host falls through to `FileResponseStore`. Transcripts land
+    // in the clear under `${AGENTSERVER_STATE_ROOT}/responses`; `new InMemoryResponseProvider()`
+    // is the documented opt-out.
+    expect(defaultStore(false).constructor.name).toBe('FileResponseProvider');
   });
 
   it('activates the Foundry storage service in a container, the way Python does', () => {

--- a/packages/foundry/src/hosting/server.ts
+++ b/packages/foundry/src/hosting/server.ts
@@ -19,8 +19,9 @@ export interface ResponsesHostServerConfig
   /**
    * Where responses live. Defaults to {@link defaultStore}.
    *
-   * Supply one to override the default — {@link FileResponseProvider} to keep a deployed container
-   * off the storage service, or {@link InMemoryResponseProvider} for a self-contained test.
+   * Supply one to override the default — {@link FileResponseProvider} with an explicit `root` to
+   * move the files, or {@link InMemoryResponseProvider} to keep a local run process-local and off
+   * the filesystem entirely.
    */
   store?: ResponseProvider;
 }
@@ -30,9 +31,15 @@ export interface ResponsesHostServerConfig
  *
  * In a container: the Foundry storage service, the way Python's `ResponsesHostServer` activates
  * its provider when hosted — responses then survive sandbox recycling and conversations can move
- * between sandboxes. Locally: memory, so nothing outlives the process. A hosted container that
- * somehow lacks the platform-injected project endpoint falls back to the sandbox filesystem
- * rather than refusing to start.
+ * between sandboxes. Locally: the filesystem under `${AGENTSERVER_STATE_ROOT}/responses`
+ * (`~/.agentserver/responses` by default), so a `previous_response_id` chain survives a restart —
+ * both reference servers make the same local choice. A hosted container that somehow lacks the
+ * platform-injected project endpoint falls back to the sandbox filesystem rather than refusing to
+ * start.
+ *
+ * The local default writes whole transcripts to disk **in the clear** and expires nothing:
+ * retention and cleanup belong to whoever runs the process, and the directory needs the
+ * protection the conversations do. Pass `new InMemoryResponseProvider()` to opt out.
  *
  * The storage service requires the hosted-agent credential and the platform call id on every
  * write, and an `agent_reference` on every persisted response (all measured against the live
@@ -45,8 +52,10 @@ export interface ResponsesHostServerConfig
  */
 export function defaultStore(hosted: boolean): ResponseProvider {
   if (!hosted) {
-    // A local run is self-contained; nothing should outlive the process.
-    return new InMemoryResponseProvider();
+    // The sandbox filesystem, not memory: a local run that restarts can still be continued with
+    // `previous_response_id`. .NET registers `FileResponsesProvider` for the non-hosted host and
+    // Python's host falls through to `FileResponseStore`, both under the same state root.
+    return new FileResponseProvider();
   }
   const endpoint = projectEndpoint();
   if (endpoint === undefined) {

--- a/scripts/test-state-root.ts
+++ b/scripts/test-state-root.ts
@@ -1,0 +1,28 @@
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll } from 'vitest';
+
+/**
+ * Pins `AGENTSERVER_STATE_ROOT` to a throwaway directory for the duration of one test file.
+ *
+ * The agent server's default response store is file-backed under that root, so a suite that
+ * builds a server without naming a store writes transcripts to disk. Unpinned, those writes land
+ * in the developer's `~/.agentserver` — thousands of stray files across runs, and a test that
+ * reads "everything stored" seeing another run's leftovers. Every package gets this setup file
+ * (see `definePackageTests`), not just the ones that host a server today: the point is that
+ * forgetting to pass a store can never reach a real home directory.
+ *
+ * The directory is named but deliberately *not* created: a file whose tests are all skipped runs
+ * no `afterAll`, so an eagerly created one would survive the run. Named-only, nothing exists
+ * unless a store actually writes, and the store creates the path it needs.
+ *
+ * This runs *after* a package's own setup files, so an environment-clearing step cannot undo it.
+ * A test that wants its own root stubs the variable itself; `unstubEnvs` puts this one back.
+ */
+const root = join(tmpdir(), `afjs-state-root-${crypto.randomUUID()}`);
+process.env.AGENTSERVER_STATE_ROOT = root;
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});

--- a/scripts/vitest-config.ts
+++ b/scripts/vitest-config.ts
@@ -24,10 +24,22 @@ const workspaceAliases = {
   '@polymind-inc/agent-framework-a2a': source('a2a/src/index.ts'),
 };
 
-/** Shared source aliases and test discovery for a package's unit tests. */
-export function definePackageTests() {
+/**
+ * Shared source aliases and test discovery for a package's unit tests.
+ *
+ * `setupFiles` names the package's own setup files; the shared state-root isolation always runs
+ * last, so a package setup that clears the environment cannot strip it back off.
+ */
+export function definePackageTests(options: { setupFiles?: string[] } = {}) {
   return defineConfig({
     resolve: { alias: workspaceAliases },
-    test: { include: ['src/**/*.test.ts'], unstubEnvs: true },
+    test: {
+      include: ['src/**/*.test.ts'],
+      unstubEnvs: true,
+      setupFiles: [
+        ...(options.setupFiles ?? []),
+        fileURLToPath(new URL('./test-state-root.ts', import.meta.url)),
+      ],
+    },
   });
 }


### PR DESCRIPTION
## What this changes

Fixes #110. A server built without an explicit `store` kept responses in process memory, so a
`previous_response_id` chain answered 404 after a restart. `new ResponsesServer({ handler })` and a
non-hosted `ResponsesHostServer` now default to `FileResponseProvider` under
`${AGENTSERVER_STATE_ROOT}/responses` (`~/.agentserver/responses` when unset).

A hosted `ResponsesHostServer` is unchanged — the Foundry storage service when the platform injects
the project endpoint, the sandbox filesystem when it does not — and an explicit
`InMemoryResponseProvider` remains the process-local opt-out.

Tests get the same treatment structurally rather than by convention: every suite that builds a
server without naming a store now passes an in-memory one, and `scripts/test-state-root.ts` pins
`AGENTSERVER_STATE_ROOT` to a throwaway directory for every package's suites, with a test that
fails if that pin ever stops being applied.

## Parity

- Reference checked: .NET `ResponsesServerServiceCollectionExtensions.cs` registers
  `FileResponsesProvider` in the non-hosted branch, with the root resolved by `ResponsesStatePaths`
  (`AGENTSERVER_STATE_ROOT`, else `~/.agentserver`, `responses/` beneath). Python `_routing.py`
  falls through to `FileResponseStore()` after the hosted Foundry activation, having replaced the
  legacy `AGENTSERVER_RESPONSE_STORE_PATH` with the same unified root. Go has no agentserver. The
  test-isolation fixture follows .NET's `TestStateRootFixture`, which exists for exactly this reason.
- Wire format affected: no
- Public API affected: no
- Breaking change: yes

The default now performs filesystem I/O and persists whole transcripts **in the clear**, with
nothing expiring them. Retention, cleanup and directory permissions belong to whoever runs the
process; README, TSDoc and CHANGELOG say so. A deployment that wants the old behaviour passes
`new InMemoryResponseProvider()`. A test suite that lets the default apply must pin a temporary
state root, or it writes to the developer's home directory.

`ResponsesServerConfig.store` keeps its type and `defaultStore(hosted: boolean)` keeps its
signature; only the value returned for `hosted === false` changes. Session and approval stores keep
their in-memory local defaults — out of scope here, and worth a separate decision.

Verified independently that a full run leaves `~/.agentserver` untouched and no state-root
directory behind.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`
