### PR TITLE
Map Anthropic code-execution calls and result blocks to their typed contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,31 @@ contain breaking changes**; patch releases are fixes only.
   `getTools()` now rejects and names both remote tools and the name they collide on, rather than
   silently shadowing one of them.
 
+- **`@polymind-inc/agent-framework-anthropic`** — the code-execution beta's blocks are read as the
+  typed content the framework already models instead of falling through the generic rules. The beta
+  is requested by default, but a `tool_use` / `server_tool_use` whose name identifies code execution
+  arrived as an ordinary function call and every result block arrived as unknown content. A code
+  execution call is now a `code_interpreter_tool_call` carrying its call id and its input;
+  `code_execution_tool_result` becomes a `code_interpreter_tool_result` whose outputs are the run's
+  stdout (plain or encrypted) as text, its stderr as an error, and its files as `hosted_file` items;
+  `bash_code_execution_tool_result` becomes a `shell_tool_result` holding one
+  `shell_command_output` with stdout, stderr, exit code and a `timedOut` flag set for
+  `execution_time_exceeded`, with the run's files reported beside it; and
+  `text_editor_code_execution_tool_result` becomes a `function_result` whose items are the error,
+  the viewed text, the replaced lines or the create flag, annotated with the line spans the wire
+  reported. Each mapping matches Python's shape and keeps the provider block on
+  `rawRepresentation`, so fields the framework does not model survive. Ordinary tool calls are
+  untouched, and a block — or a result payload — of a kind this build does not model still becomes
+  unknown content that round-trips verbatim. Provider-executed calls are also no longer emitted
+  before their arguments arrive: while streaming, a `server_tool_use`, an `mcp_tool_use` or a code
+  execution call is converted once its block closes, so the accumulated `input_json_delta`
+  fragments reach the folded transcript instead of being dropped — a streamed hosted call used to
+  land with empty arguments. A local `tool_use` still streams its arguments as before. Replaying an
+  exchange that used code execution sends the provider's own blocks back on the assistant turn that
+  produced them, the rule unknown content already followed, so typing them costs the conversation
+  nothing on its next turn. No new exports, tool declaration factory or request-side field: the
+  contents produced are the ones core already defines and serializes.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/packages/anthropic/src/code-execution.test.ts
+++ b/packages/anthropic/src/code-execution.test.ts
@@ -630,4 +630,28 @@ describe('complete-message and streaming equivalence', () => {
       comparable(awaited.messages[0]?.contents ?? []),
     );
   });
+
+  // A code-execution call carries its program as a plain string, so its fragments spell a JSON
+  // string rather than an object. Reading only objects back would leave the streamed call holding
+  // the placeholder its block opened with while the awaited one held the program.
+  it.each<[string, unknown]>([
+    ['a string', "print('hi')"],
+    ['an array', ['print(1)', 'print(2)']],
+    ['null', null],
+  ])('folds %s input the awaited path would have carried', (_label, input) => {
+    const block = { type: 'server_tool_use', id: 's1', name: 'code_execution', input };
+    const state = createStreamParseState();
+
+    parseStreamEvent({ type: 'content_block_start', content_block: { ...block, input: {} } }, state);
+    parseStreamEvent(
+      {
+        type: 'content_block_delta',
+        delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) },
+      },
+      state,
+    );
+    const closed = parseStreamEvent({ type: 'content_block_stop' }, state);
+
+    expect(comparable(closed?.contents ?? [])).toEqual(comparable(parseBlock(block)));
+  });
 });

--- a/packages/anthropic/src/code-execution.test.ts
+++ b/packages/anthropic/src/code-execution.test.ts
@@ -1,0 +1,633 @@
+import type { ChatResponseUpdate, Content, Message } from '@polymind-inc/agent-framework-core';
+import { mergeChatUpdates, serializeContent } from '@polymind-inc/agent-framework-core';
+import { describe, expect, it } from 'vitest';
+import {
+  createStreamParseState,
+  parseContentBlocks,
+  parseMessage,
+  parseStreamEvent,
+} from './from-anthropic.js';
+import { toAnthropicMessages } from './to-anthropic.js';
+
+// Anthropic's code-execution beta answers with a family of blocks the generic rules cannot read:
+// the call announcing the run, and the code-execution / bash / text-editor results answering it.
+// These tests pin each variant to the typed content the framework already models.
+
+/** Reads a block through the complete-message path. */
+function parseBlock(block: unknown): Content[] {
+  return parseContentBlocks([block]);
+}
+
+/** The single content one block maps to. */
+function onlyContent(block: unknown): Content {
+  const contents = parseBlock(block);
+  expect(contents).toHaveLength(1);
+  return contents[0] as Content;
+}
+
+/** The `outputs` of a hosted tool result. */
+function outputsOf(content: Content): Content[] {
+  return (content as { outputs?: Content[] }).outputs ?? [];
+}
+
+/** The `result` of the function result a text-editor block maps to. */
+function resultOf(content: Content): Content[] {
+  return (content as { result?: Content[] }).result ?? [];
+}
+
+describe('code-execution tool calls', () => {
+  it.each([['tool_use'], ['server_tool_use']])(
+    'maps a %s block whose name identifies code execution to a code interpreter call',
+    (blockType) => {
+      const block = {
+        type: blockType,
+        id: 'srvtoolu_1',
+        name: 'code_execution',
+        input: { code: "print('hi')" },
+      };
+      const content = onlyContent(block);
+
+      expect(content).toEqual({
+        type: 'code_interpreter_tool_call',
+        callId: 'srvtoolu_1',
+        inputs: [{ type: 'text', text: '{"code":"print(\'hi\')"}', rawRepresentation: block }],
+        rawRepresentation: block,
+      });
+    },
+  );
+
+  it('maps the bash and text-editor code-execution tools the same way', () => {
+    const contents = parseBlock({ type: 'server_tool_use', id: 's1', name: 'bash_code_execution' }).concat(
+      parseBlock({ type: 'server_tool_use', id: 's2', name: 'text_editor_code_execution' }),
+    );
+    expect(contents.map((content) => content.type)).toEqual([
+      'code_interpreter_tool_call',
+      'code_interpreter_tool_call',
+    ]);
+    // A call with no input still reports one, so the shape does not depend on the wire's omissions.
+    expect(outputsOf(contents[0] as Content)).toEqual([]);
+    expect((contents[0] as { inputs: Content[] }).inputs).toEqual([
+      expect.objectContaining({ type: 'text', text: '{}' }),
+    ]);
+  });
+
+  it('leaves ordinary tool calls as function calls', () => {
+    const [local, server] = parseContentBlocks([
+      { type: 'tool_use', id: 'toolu_1', name: 'get_weather', input: { city: 'Osaka' } },
+      { type: 'server_tool_use', id: 'srvtoolu_2', name: 'web_search', input: { query: 'x' } },
+    ]);
+    expect(local).toMatchObject({ type: 'function_call', callId: 'toolu_1', name: 'get_weather' });
+    expect(local).not.toHaveProperty('informationalOnly');
+    expect(server).toMatchObject({
+      type: 'function_call',
+      callId: 'srvtoolu_2',
+      name: 'web_search',
+      informationalOnly: true,
+    });
+  });
+
+  it('carries a string input through unquoted', () => {
+    const content = onlyContent({
+      type: 'server_tool_use',
+      id: 's1',
+      name: 'code_execution',
+      input: "print('hi')",
+    });
+    expect((content as { inputs: Content[] }).inputs[0]).toMatchObject({ text: "print('hi')" });
+  });
+});
+
+describe('code_execution_tool_result variants', () => {
+  it('maps an error result to an error output', () => {
+    const inner = { type: 'code_execution_tool_result_error', error_code: 'execution_time_exceeded' };
+    const block = { type: 'code_execution_tool_result', tool_use_id: 'srvtoolu_1', content: inner };
+    const content = onlyContent(block);
+
+    expect(content).toEqual({
+      type: 'code_interpreter_tool_result',
+      callId: 'srvtoolu_1',
+      outputs: [{ type: 'error', message: 'execution_time_exceeded', rawRepresentation: inner }],
+      rawRepresentation: block,
+    });
+  });
+
+  it('maps stdout, stderr and hosted files of a successful run', () => {
+    const file = { type: 'code_execution_output', file_id: 'file_1' };
+    const inner = {
+      type: 'code_execution_result',
+      stdout: 'hello\n',
+      stderr: 'warning\n',
+      return_code: 0,
+      content: [file],
+    };
+    const content = onlyContent({
+      type: 'code_execution_tool_result',
+      tool_use_id: 'srvtoolu_1',
+      content: inner,
+    });
+
+    expect(outputsOf(content)).toEqual([
+      { type: 'text', text: 'hello\n', rawRepresentation: inner },
+      { type: 'error', message: 'warning\n', rawRepresentation: inner },
+      { type: 'hosted_file', fileId: 'file_1', rawRepresentation: file },
+    ]);
+  });
+
+  it('maps an encrypted stdout result to a text output', () => {
+    const inner = {
+      type: 'encrypted_code_execution_result',
+      encrypted_stdout: 'ENCRYPTED',
+      stderr: '',
+      return_code: 0,
+      content: [],
+    };
+    const content = onlyContent({
+      type: 'code_execution_tool_result',
+      tool_use_id: 'srvtoolu_1',
+      content: inner,
+    });
+
+    expect(outputsOf(content)).toEqual([{ type: 'text', text: 'ENCRYPTED', rawRepresentation: inner }]);
+  });
+
+  it('reports empty stdout and stderr as no output at all', () => {
+    const content = onlyContent({
+      type: 'code_execution_tool_result',
+      tool_use_id: 'srvtoolu_1',
+      content: { type: 'code_execution_result', stdout: '', stderr: '', return_code: 0, content: [] },
+    });
+    expect(outputsOf(content)).toEqual([]);
+  });
+
+  it('reports a missing result payload as an empty output list', () => {
+    expect(outputsOf(onlyContent({ type: 'code_execution_tool_result', tool_use_id: 'c1' }))).toEqual([]);
+  });
+
+  it('keeps a result variant it does not model as unknown content', () => {
+    const inner = { type: 'future_execution_result', payload: 1 };
+    const content = onlyContent({
+      type: 'code_execution_tool_result',
+      tool_use_id: 'c1',
+      content: inner,
+    });
+    expect(outputsOf(content)).toEqual([
+      { type: 'unknown', unknownType: 'future_execution_result', payload: 1, rawRepresentation: inner },
+    ]);
+  });
+});
+
+describe('bash_code_execution_tool_result variants', () => {
+  it('maps a successful run to a shell command output', () => {
+    const inner = {
+      type: 'bash_code_execution_result',
+      stdout: 'a.txt\n',
+      stderr: '',
+      return_code: 0,
+      content: [],
+    };
+    const block = { type: 'bash_code_execution_tool_result', tool_use_id: 'srvtoolu_1', content: inner };
+    const content = onlyContent(block);
+
+    expect(content).toEqual({
+      type: 'shell_tool_result',
+      callId: 'srvtoolu_1',
+      outputs: [
+        {
+          type: 'shell_command_output',
+          stdout: 'a.txt\n',
+          exitCode: 0,
+          timedOut: false,
+          rawRepresentation: inner,
+        },
+      ],
+      rawRepresentation: block,
+    });
+  });
+
+  it('maps a non-zero exit to stderr and the exit code', () => {
+    const content = onlyContent({
+      type: 'bash_code_execution_tool_result',
+      tool_use_id: 'srvtoolu_1',
+      content: {
+        type: 'bash_code_execution_result',
+        stdout: '',
+        stderr: 'no such file',
+        return_code: 1,
+        content: [],
+      },
+    });
+    expect(outputsOf(content)).toEqual([
+      expect.objectContaining({
+        type: 'shell_command_output',
+        stderr: 'no such file',
+        exitCode: 1,
+        timedOut: false,
+      }),
+    ]);
+  });
+
+  it('maps a tool error to a shell output carrying the error code', () => {
+    const content = onlyContent({
+      type: 'bash_code_execution_tool_result',
+      tool_use_id: 'srvtoolu_1',
+      content: { type: 'bash_code_execution_tool_result_error', error_code: 'unavailable' },
+    });
+    expect(outputsOf(content)).toEqual([
+      expect.objectContaining({ type: 'shell_command_output', stderr: 'unavailable', timedOut: false }),
+    ]);
+  });
+
+  it('marks an exceeded execution time as timed out', () => {
+    const content = onlyContent({
+      type: 'bash_code_execution_tool_result',
+      tool_use_id: 'srvtoolu_1',
+      content: { type: 'bash_code_execution_tool_result_error', error_code: 'execution_time_exceeded' },
+    });
+    expect(outputsOf(content)).toEqual([
+      expect.objectContaining({ stderr: 'execution_time_exceeded', timedOut: true }),
+    ]);
+  });
+
+  it('reports file outputs beside the shell result', () => {
+    const file = { type: 'bash_code_execution_output', file_id: 'file_9' };
+    const contents = parseBlock({
+      type: 'bash_code_execution_tool_result',
+      tool_use_id: 'srvtoolu_1',
+      content: {
+        type: 'bash_code_execution_result',
+        stdout: '',
+        stderr: '',
+        return_code: 0,
+        content: [file],
+      },
+    });
+    expect(contents).toEqual([
+      { type: 'hosted_file', fileId: 'file_9', rawRepresentation: file },
+      expect.objectContaining({ type: 'shell_tool_result', callId: 'srvtoolu_1' }),
+    ]);
+  });
+
+  it('keeps a bash result variant it does not model as unknown content', () => {
+    const content = onlyContent({
+      type: 'bash_code_execution_tool_result',
+      tool_use_id: 'c1',
+      content: { type: 'future_bash_result', payload: 2 },
+    });
+    expect(outputsOf(content)).toEqual([
+      expect.objectContaining({ type: 'unknown', unknownType: 'future_bash_result' }),
+    ]);
+  });
+});
+
+describe('text_editor_code_execution_tool_result variants', () => {
+  it('maps an error result to an error item on a function result', () => {
+    const inner = {
+      type: 'text_editor_code_execution_tool_result_error',
+      error_code: 'file_not_found',
+      error_message: 'File not found',
+    };
+    const block = {
+      type: 'text_editor_code_execution_tool_result',
+      tool_use_id: 'srvtoolu_1',
+      content: inner,
+    };
+    const content = onlyContent(block);
+
+    expect(content).toEqual({
+      type: 'function_result',
+      callId: 'srvtoolu_1',
+      result: [{ type: 'error', message: 'File not found', rawRepresentation: inner }],
+      rawRepresentation: block,
+    });
+  });
+
+  it('maps a view result to text annotated with the lines it covers', () => {
+    const inner = {
+      type: 'text_editor_code_execution_view_result',
+      content: 'file body',
+      file_type: 'text',
+      num_lines: 5,
+      start_line: 10,
+      total_lines: 40,
+    };
+    const content = onlyContent({
+      type: 'text_editor_code_execution_tool_result',
+      tool_use_id: 'srvtoolu_1',
+      content: inner,
+    });
+
+    expect(resultOf(content)).toEqual([
+      {
+        type: 'text',
+        text: 'file body',
+        annotations: [
+          {
+            type: 'citation',
+            annotatedRegions: [{ type: 'text_span', startIndex: 10, endIndex: 15 }],
+            rawRepresentation: inner,
+          },
+        ],
+        rawRepresentation: inner,
+      },
+    ]);
+  });
+
+  it('leaves a view result without line numbers unannotated', () => {
+    const content = onlyContent({
+      type: 'text_editor_code_execution_tool_result',
+      tool_use_id: 'srvtoolu_1',
+      content: { type: 'text_editor_code_execution_view_result', content: 'body', file_type: 'text' },
+    });
+    expect(resultOf(content)).toEqual([expect.objectContaining({ type: 'text', text: 'body' })]);
+    expect(resultOf(content)[0]).not.toHaveProperty('annotations');
+  });
+
+  it('maps a string-replace result to the replacement lines and both spans', () => {
+    const inner = {
+      type: 'text_editor_code_execution_str_replace_result',
+      lines: ['one', 'two'],
+      old_start: 5,
+      old_lines: 3,
+      new_start: 5,
+      new_lines: 2,
+    };
+    const content = onlyContent({
+      type: 'text_editor_code_execution_tool_result',
+      tool_use_id: 'srvtoolu_1',
+      content: inner,
+    });
+
+    expect(resultOf(content)).toEqual([
+      {
+        type: 'text',
+        text: 'one\ntwo',
+        annotations: [
+          {
+            type: 'citation',
+            annotatedRegions: [{ type: 'text_span', startIndex: 5, endIndex: 8 }],
+            rawRepresentation: inner,
+          },
+          {
+            type: 'citation',
+            snippet: 'one\ntwo',
+            annotatedRegions: [{ type: 'text_span', startIndex: 5, endIndex: 7 }],
+            rawRepresentation: inner,
+          },
+        ],
+        rawRepresentation: inner,
+      },
+    ]);
+  });
+
+  it('maps a string-replace result without spans to bare text', () => {
+    const content = onlyContent({
+      type: 'text_editor_code_execution_tool_result',
+      tool_use_id: 'srvtoolu_1',
+      content: { type: 'text_editor_code_execution_str_replace_result', lines: null },
+    });
+    expect(resultOf(content)).toEqual([expect.objectContaining({ type: 'text', text: '' })]);
+    expect(resultOf(content)[0]).not.toHaveProperty('annotations');
+  });
+
+  it('maps a create result to the file-update flag', () => {
+    const [created, updated] = [false, true].map((isFileUpdate) =>
+      resultOf(
+        onlyContent({
+          type: 'text_editor_code_execution_tool_result',
+          tool_use_id: 'srvtoolu_1',
+          content: { type: 'text_editor_code_execution_create_result', is_file_update: isFileUpdate },
+        }),
+      ),
+    );
+    expect(created).toEqual([expect.objectContaining({ type: 'text', text: 'File update: false' })]);
+    expect(updated).toEqual([expect.objectContaining({ type: 'text', text: 'File update: true' })]);
+  });
+
+  it('keeps a text-editor result variant it does not model as unknown content', () => {
+    const content = onlyContent({
+      type: 'text_editor_code_execution_tool_result',
+      tool_use_id: 'c1',
+      content: { type: 'future_editor_result', payload: 3 },
+    });
+    expect(resultOf(content)).toEqual([
+      expect.objectContaining({ type: 'unknown', unknownType: 'future_editor_result' }),
+    ]);
+  });
+});
+
+describe('unrecognized blocks', () => {
+  it('keeps a block kind it does not model as unknown content that round-trips verbatim', () => {
+    const block = { type: 'code_execution_future_result', tool_use_id: 'c1', detail: { a: 1 } };
+    const content = onlyContent(block);
+    expect(content).toMatchObject({ type: 'unknown', unknownType: 'code_execution_future_result' });
+    expect(serializeContent(content)).toEqual(block);
+  });
+
+  it('keeps a malformed result block, whose payload is not an object, readable', () => {
+    const contents = parseContentBlocks([
+      { type: 'code_execution_tool_result', tool_use_id: 'c1', content: 'oops' },
+      { type: 'bash_code_execution_tool_result', tool_use_id: 'c2', content: 42 },
+      { type: 'text_editor_code_execution_tool_result', tool_use_id: 'c3', content: null },
+    ]);
+    expect(contents.map((content) => content.type)).toEqual([
+      'code_interpreter_tool_result',
+      'shell_tool_result',
+      'function_result',
+    ]);
+    expect(outputsOf(contents[0] as Content)).toEqual([]);
+    expect(outputsOf(contents[1] as Content)).toEqual([]);
+    expect(resultOf(contents[2] as Content)).toEqual([]);
+  });
+});
+
+// Every top-level block kind the conversion models, in one response and in the stream that carries
+// the same response. Folding the stream must reproduce the awaited transcript: a provider-executed
+// call has no fragment representation, so its input has to survive the deltas that spell it out.
+const CODE_INPUT = { code: "print('hi')" };
+
+const COMPLETE_BLOCKS: readonly Record<string, unknown>[] = [
+  { type: 'text', text: 'Answer.' },
+  { type: 'thinking', thinking: 'Let me think.', signature: 'sig-1' },
+  { type: 'redacted_thinking', data: 'ENCRYPTED' },
+  { type: 'tool_use', id: 'toolu_1', name: 'get_weather', input: { city: 'Osaka' } },
+  { type: 'server_tool_use', id: 'srvtoolu_1', name: 'web_search', input: { query: 'weather' } },
+  {
+    type: 'web_search_tool_result',
+    tool_use_id: 'srvtoolu_1',
+    content: [{ type: 'web_search_result', url: 'https://example.test/a' }],
+  },
+  { type: 'web_fetch_tool_result', tool_use_id: 'srvtoolu_1', content: { url: 'https://example.test/a' } },
+  { type: 'mcp_tool_use', id: 'mcptoolu_1', name: 'lookup', server_name: 'docs', input: { q: 'x' } },
+  { type: 'mcp_tool_result', tool_use_id: 'mcptoolu_1', content: [{ type: 'text', text: 'answer' }] },
+  { type: 'server_tool_use', id: 'srvtoolu_2', name: 'code_execution', input: CODE_INPUT },
+  {
+    type: 'code_execution_tool_result',
+    tool_use_id: 'srvtoolu_2',
+    content: {
+      type: 'code_execution_result',
+      stdout: 'hi\n',
+      stderr: 'warn\n',
+      return_code: 0,
+      content: [{ type: 'code_execution_output', file_id: 'file_1' }],
+    },
+  },
+  { type: 'server_tool_use', id: 'srvtoolu_3', name: 'bash_code_execution', input: { command: 'ls' } },
+  {
+    type: 'bash_code_execution_tool_result',
+    tool_use_id: 'srvtoolu_3',
+    content: {
+      type: 'bash_code_execution_result',
+      stdout: 'a.txt\n',
+      stderr: '',
+      return_code: 0,
+      content: [{ type: 'bash_code_execution_output', file_id: 'file_2' }],
+    },
+  },
+  {
+    type: 'server_tool_use',
+    id: 'srvtoolu_4',
+    name: 'text_editor_code_execution',
+    input: { command: 'view', path: '/a' },
+  },
+  {
+    type: 'text_editor_code_execution_tool_result',
+    tool_use_id: 'srvtoolu_4',
+    content: {
+      type: 'text_editor_code_execution_view_result',
+      content: 'file body',
+      file_type: 'text',
+      num_lines: 2,
+      start_line: 1,
+      total_lines: 10,
+    },
+  },
+  { type: 'future_block', payload: 1 },
+];
+
+/** The stream that carries {@link COMPLETE_BLOCKS}, argument fragments and all. */
+function streamEvents(): unknown[] {
+  const events: unknown[] = [
+    { type: 'message_start', message: { id: 'msg_1', model: 'claude-sonnet-4-5', content: [] } },
+  ];
+  let index = 0;
+  const openBlock = (block: unknown, deltas: unknown[] = []): void => {
+    events.push({ type: 'content_block_start', index, content_block: block });
+    for (const delta of deltas) {
+      events.push({ type: 'content_block_delta', index, delta });
+    }
+    events.push({ type: 'content_block_stop', index });
+    index += 1;
+  };
+  /** A call block as the API opens it: an empty `input` placeholder plus JSON fragments. */
+  const openCall = (block: Record<string, unknown>): void => {
+    const json = JSON.stringify(block.input);
+    const half = Math.ceil(json.length / 2);
+    openBlock({ ...block, input: {} }, [
+      { type: 'input_json_delta', partial_json: json.slice(0, half) },
+      { type: 'input_json_delta', partial_json: json.slice(half) },
+    ]);
+  };
+
+  for (const block of COMPLETE_BLOCKS) {
+    switch (block.type) {
+      case 'text':
+        openBlock({ type: 'text', text: '' }, [{ type: 'text_delta', text: block.text }]);
+        break;
+      case 'thinking':
+        openBlock({ type: 'thinking', thinking: '', signature: '' }, [
+          { type: 'thinking_delta', thinking: block.thinking },
+          { type: 'signature_delta', signature: block.signature },
+        ]);
+        break;
+      case 'tool_use':
+      case 'server_tool_use':
+      case 'mcp_tool_use':
+        openCall(block);
+        break;
+      default:
+        openBlock(block);
+        break;
+    }
+  }
+  events.push({ type: 'message_delta', delta: { stop_reason: 'end_turn' } });
+  events.push({ type: 'message_stop' });
+  return events;
+}
+
+/**
+ * The comparable shape of a folded transcript.
+ *
+ * `serializeContent` strips the provider objects at every level — they are the one thing the two
+ * paths legitimately disagree on. A streamed *local* call still ends with its arguments as the JSON
+ * string the API spelled out, which the tool loop parses exactly as it parses the awaited object;
+ * normalizing that one field is what leaves every other difference visible.
+ */
+function comparable(contents: readonly Content[]): unknown[] {
+  return contents.map((content) => {
+    const wire = serializeContent(content);
+    if (wire.type === 'function_call' && typeof wire.arguments === 'string') {
+      wire.arguments = wire.arguments === '' ? {} : JSON.parse(wire.arguments);
+    }
+    return wire;
+  });
+}
+
+describe('complete-message and streaming equivalence', () => {
+  const awaited = parseMessage({
+    id: 'msg_1',
+    model: 'claude-sonnet-4-5',
+    content: COMPLETE_BLOCKS,
+    stop_reason: 'end_turn',
+  });
+
+  it('covers every top-level block kind the conversion models', () => {
+    expect(awaited.messages[0]?.contents.map((content) => content.type)).toEqual([
+      'text',
+      'text_reasoning',
+      'unknown',
+      'function_call',
+      'function_call',
+      'function_result',
+      'function_result',
+      'mcp_server_tool_call',
+      'mcp_server_tool_result',
+      'code_interpreter_tool_call',
+      'code_interpreter_tool_result',
+      'code_interpreter_tool_call',
+      'hosted_file',
+      'shell_tool_result',
+      'code_interpreter_tool_call',
+      'function_result',
+      'unknown',
+    ]);
+  });
+
+  it('replays a code-execution exchange as the blocks the API sent', () => {
+    // Typing these blocks must not cost the transcript its next turn: the calls the provider ran
+    // have no request-side form, so the blocks themselves go back, on the assistant turn that
+    // produced them. A `tool_result` answering a call the replay no longer contains would be a 400.
+    const blocks = COMPLETE_BLOCKS.filter((block) =>
+      `${block.type}${block.name ?? ''}`.includes('code_execution'),
+    );
+    const turn = parseMessage({ id: 'msg_1', content: blocks });
+    expect(toAnthropicMessages([turn.messages[0] as Message])).toEqual([
+      { role: 'assistant', content: blocks },
+    ]);
+  });
+
+  it('folds the stream into the awaited transcript', () => {
+    const state = createStreamParseState();
+    const updates: ChatResponseUpdate[] = [];
+    for (const event of streamEvents()) {
+      const update = parseStreamEvent(event, state);
+      if (update !== undefined) {
+        updates.push(update);
+      }
+    }
+    const folded = mergeChatUpdates(updates);
+
+    expect(comparable(folded.messages[0]?.contents ?? [])).toEqual(
+      comparable(awaited.messages[0]?.contents ?? []),
+    );
+  });
+});

--- a/packages/anthropic/src/code-execution.test.ts
+++ b/packages/anthropic/src/code-execution.test.ts
@@ -654,4 +654,31 @@ describe('complete-message and streaming equivalence', () => {
 
     expect(comparable(closed?.contents ?? [])).toEqual(comparable(parseBlock(block)));
   });
+
+  it('keeps accumulating across a usage snapshot that ends nothing', () => {
+    // A `message_delta` carrying only usage is not the end of the message. Converting the open
+    // call there would clear it mid-flight, and the fragments still to come would belong to no
+    // call and be dropped — the call would fold with its opening placeholder for an input.
+    const block = { type: 'server_tool_use', id: 's1', name: 'code_execution', input: { code: 'x' } };
+    const state = createStreamParseState();
+
+    parseStreamEvent({ type: 'content_block_start', content_block: { ...block, input: {} } }, state);
+    parseStreamEvent(
+      { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: '{"code"' } },
+      state,
+    );
+    const snapshot = parseStreamEvent(
+      { type: 'message_delta', delta: {}, usage: { output_tokens: 5 } },
+      state,
+    );
+    parseStreamEvent(
+      { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: ':"x"}' } },
+      state,
+    );
+    const closed = parseStreamEvent({ type: 'content_block_stop' }, state);
+
+    // The snapshot reports the usage it carried and nothing else.
+    expect(snapshot?.contents.map((content) => content.type)).toEqual(['usage']);
+    expect(comparable(closed?.contents ?? [])).toEqual(comparable(parseBlock(block)));
+  });
 });

--- a/packages/anthropic/src/code-execution.test.ts
+++ b/packages/anthropic/src/code-execution.test.ts
@@ -174,6 +174,30 @@ describe('code_execution_tool_result variants', () => {
       { type: 'unknown', unknownType: 'future_execution_result', payload: 1, rawRepresentation: inner },
     ]);
   });
+
+  it('keeps a file entry that names no file as unknown content', () => {
+    // An empty `fileId` would be a hosted file nothing can fetch, and the transcript would not say
+    // why. The entry is preserved instead, so a replay still carries it and it stays debuggable.
+    const missing = { type: 'code_execution_output' };
+    const numeric = { type: 'code_execution_output', file_id: 7 };
+    const content = onlyContent({
+      type: 'code_execution_tool_result',
+      tool_use_id: 'c1',
+      content: {
+        type: 'code_execution_result',
+        stdout: '',
+        stderr: '',
+        return_code: 0,
+        content: [missing, numeric, { type: 'code_execution_output', file_id: 'file_1' }],
+      },
+    });
+
+    expect(outputsOf(content)).toEqual([
+      { type: 'unknown', unknownType: 'code_execution_output', rawRepresentation: missing },
+      { type: 'unknown', unknownType: 'code_execution_output', file_id: 7, rawRepresentation: numeric },
+      expect.objectContaining({ type: 'hosted_file', fileId: 'file_1' }),
+    ]);
+  });
 });
 
 describe('bash_code_execution_tool_result variants', () => {

--- a/packages/anthropic/src/from-anthropic.ts
+++ b/packages/anthropic/src/from-anthropic.ts
@@ -699,9 +699,14 @@ export function parseStreamEvent(event: unknown, state: StreamParseState): ChatR
       const usage = usageContent(raw.usage, state.emittedUsage);
       const delta = (raw.delta ?? {}) as AnthropicBlock;
       const finishReason = parseFinishReason(delta.stop_reason);
+      // Only the event that ends the message closes a block still open. A `message_delta` carrying
+      // nothing but a usage snapshot is not the end of anything, and converting the call there
+      // would clear it while its fragments were still arriving — they would then belong to no
+      // call and be dropped, leaving the folded transcript holding a call without its input.
+      const pending = finishReason === undefined ? [] : flushPendingCall(state);
       return chatResponseUpdate({
         role: 'assistant',
-        contents: [...flushPendingCall(state), ...(usage === undefined ? [] : [usage])],
+        contents: [...pending, ...(usage === undefined ? [] : [usage])],
         ...(finishReason === undefined ? {} : { finishReason }),
         rawRepresentation: event,
       });

--- a/packages/anthropic/src/from-anthropic.ts
+++ b/packages/anthropic/src/from-anthropic.ts
@@ -632,17 +632,24 @@ function isProviderExecutedCall(block: AnthropicBlock): boolean {
   );
 }
 
-/** The accumulated fragments as an `input` object, or `undefined` when they do not form one. */
-function parsedInput(json: string): Record<string, unknown> | undefined {
+/**
+ * The accumulated fragments parsed back into the input they spell, or `undefined` when they spell
+ * no complete JSON value.
+ *
+ * Any JSON value, not only an object: a code-execution call carries its program as a plain string,
+ * and reading only objects would leave the streamed form holding the opening placeholder while the
+ * awaited form held the program. The result is wrapped so that a literal `null` — itself valid
+ * JSON — stays distinguishable from fragments that parsed into nothing.
+ */
+function parsedInput(json: string): { value: unknown } | undefined {
   if (json.trim() === '') {
     return undefined;
   }
   try {
-    const parsed: unknown = JSON.parse(json);
-    return isRecord(parsed) ? parsed : undefined;
+    return { value: JSON.parse(json) as unknown };
   } catch {
     // A truncated stream leaves half a JSON document behind; the opening placeholder is closer to
-    // the model's intent than a fragment that cannot be parsed back into arguments.
+    // the model's intent than a fragment that cannot be parsed back into an input.
     return undefined;
   }
 }
@@ -657,7 +664,7 @@ function flushPendingCall(state: StreamParseState): Content[] {
   const input = parsedInput(pending.json);
   // Converted without the streaming state, so the completed block reads exactly as the same block
   // does in an awaited response.
-  return parseContentBlocks([input === undefined ? pending.block : { ...pending.block, input }]);
+  return parseContentBlocks([input === undefined ? pending.block : { ...pending.block, input: input.value }]);
 }
 
 function contentUpdate(contents: Content[], event: unknown): ChatResponseUpdate | undefined {

--- a/packages/anthropic/src/from-anthropic.ts
+++ b/packages/anthropic/src/from-anthropic.ts
@@ -251,7 +251,15 @@ function codeInterpreterInputs(block: AnthropicBlock): Content[] {
   ];
 }
 
-/** The `hosted_file` items a code-execution or bash result lists under `content`. */
+/**
+ * The `hosted_file` items a code-execution or bash result lists under `content`.
+ *
+ * An entry naming no file is not a hosted file: coercing it would put an item with an empty id in
+ * the transcript, where nothing can fetch it and nothing says why. It is kept as unknown content
+ * instead — the same treatment an unrecognized result payload gets — so it round-trips verbatim and
+ * stays visible for whoever has to explain it. Python reads these off a typed SDK model whose
+ * `file_id` is required, so it never meets the case; this reads the wire.
+ */
 function hostedFiles(result: AnthropicBlock): Content[] {
   const files: Content[] = [];
   for (const candidate of Array.isArray(result.content) ? result.content : []) {
@@ -259,7 +267,12 @@ function hostedFiles(result: AnthropicBlock): Content[] {
     if (file === undefined) {
       continue;
     }
-    files.push({ type: 'hosted_file', fileId: String(file.file_id ?? ''), rawRepresentation: file });
+    const fileId = file.file_id;
+    files.push(
+      typeof fileId === 'string' && fileId !== ''
+        ? { type: 'hosted_file', fileId, rawRepresentation: file }
+        : unknownContent(file),
+    );
   }
   return files;
 }

--- a/packages/anthropic/src/from-anthropic.ts
+++ b/packages/anthropic/src/from-anthropic.ts
@@ -7,6 +7,7 @@ import type {
   UsageDetails,
 } from '@polymind-inc/agent-framework-core';
 import { chatResponse, chatResponseUpdate, unknownContent } from '@polymind-inc/agent-framework-core';
+import { isRecord, safeStringify } from '@polymind-inc/agent-framework-core/internal';
 import type { AnthropicBlock } from './to-anthropic.js';
 
 /**
@@ -142,6 +143,8 @@ function openingArguments(
 export interface StreamParseState {
   /** The call a following `input_json_delta` belongs to. */
   currentCall?: { callId: string; blockType: string };
+  /** The provider-executed call whose block is open, and the input fragments seen so far. */
+  pendingCall?: { block: AnthropicBlock; json: string };
   /** The cumulative usage already emitted, so snapshots can be turned into increments. */
   emittedUsage: Record<string, number>;
 }
@@ -211,6 +214,196 @@ function parseMessageFields(message: unknown, state?: StreamParseState): ParsedM
   return fields;
 }
 
+/** A nested wire payload, or `undefined` when the block does not carry one as an object. */
+function asBlock(value: unknown): AnthropicBlock | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+/** A wire string, or `undefined` when it is absent or empty — the fields Python treats as unset. */
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+/**
+ * Whether a call block names one of Anthropic's code-execution tools.
+ *
+ * A substring test, as in Python: the tool's name is caller-chosen and the versioned defaults
+ * (`code_execution`, `bash_code_execution`, `text_editor_code_execution`) all carry it.
+ */
+function isCodeExecutionName(name: unknown): boolean {
+  return typeof name === 'string' && name.includes('code_execution');
+}
+
+/**
+ * The `inputs` of a code-interpreter call: the code and data the interpreter was handed.
+ *
+ * A string input is carried through as it stands; anything else is rendered as JSON, which is also
+ * what the streamed `input_json_delta` fragments spell out, so both paths report the same text.
+ */
+function codeInterpreterInputs(block: AnthropicBlock): Content[] {
+  const input = block.input ?? {};
+  return [
+    {
+      type: 'text',
+      text: typeof input === 'string' ? input : safeStringify(input),
+      rawRepresentation: block,
+    },
+  ];
+}
+
+/** The `hosted_file` items a code-execution or bash result lists under `content`. */
+function hostedFiles(result: AnthropicBlock): Content[] {
+  const files: Content[] = [];
+  for (const candidate of Array.isArray(result.content) ? result.content : []) {
+    const file = asBlock(candidate);
+    if (file === undefined) {
+      continue;
+    }
+    files.push({ type: 'hosted_file', fileId: String(file.file_id ?? ''), rawRepresentation: file });
+  }
+  return files;
+}
+
+/** The outputs of a `code_execution_tool_result` payload. */
+function codeExecutionOutputs(result: AnthropicBlock): Content[] {
+  switch (result.type) {
+    case 'code_execution_tool_result_error':
+      return [{ type: 'error', message: String(result.error_code ?? ''), rawRepresentation: result }];
+    case 'code_execution_result':
+    case 'encrypted_code_execution_result': {
+      const outputs: Content[] = [];
+      // The encrypted variant reports its stdout under a different key and never a plain one.
+      const stdout = nonEmptyString(
+        result.type === 'code_execution_result' ? result.stdout : result.encrypted_stdout,
+      );
+      if (stdout !== undefined) {
+        outputs.push({ type: 'text', text: stdout, rawRepresentation: result });
+      }
+      const stderr = nonEmptyString(result.stderr);
+      if (stderr !== undefined) {
+        outputs.push({ type: 'error', message: stderr, rawRepresentation: result });
+      }
+      outputs.push(...hostedFiles(result));
+      return outputs;
+    }
+    default:
+      // A payload variant this build does not model is kept whole rather than read for fields it
+      // may not have; the unknown-content round trip carries it verbatim.
+      return [unknownContent(result)];
+  }
+}
+
+/** The command output and the hosted files of a `bash_code_execution_tool_result` payload. */
+function bashExecutionOutputs(result: AnthropicBlock): { outputs: Content[]; files: Content[] } {
+  switch (result.type) {
+    case 'bash_code_execution_tool_result_error': {
+      const errorCode = String(result.error_code ?? '');
+      return {
+        outputs: [
+          {
+            type: 'shell_command_output',
+            stderr: errorCode,
+            // The one error code that is a timeout rather than a failure of the command itself.
+            timedOut: errorCode === 'execution_time_exceeded',
+            rawRepresentation: result,
+          },
+        ],
+        files: [],
+      };
+    }
+    case 'bash_code_execution_result': {
+      const stdout = nonEmptyString(result.stdout);
+      const stderr = nonEmptyString(result.stderr);
+      const exitCode = asNumber(result.return_code);
+      return {
+        outputs: [
+          {
+            type: 'shell_command_output',
+            ...(stdout === undefined ? {} : { stdout }),
+            ...(stderr === undefined ? {} : { stderr }),
+            ...(exitCode === undefined ? {} : { exitCode }),
+            timedOut: false,
+            rawRepresentation: result,
+          },
+        ],
+        files: hostedFiles(result),
+      };
+    }
+    default:
+      return { outputs: [unknownContent(result)], files: [] };
+  }
+}
+
+/** A citation covering `[start, start + lines)`, or `undefined` when the wire reported neither. */
+function lineSpanAnnotation(start: unknown, lines: unknown, result: AnthropicBlock): Annotation | undefined {
+  const startIndex = asNumber(start);
+  const lineCount = asNumber(lines);
+  if (startIndex === undefined || lineCount === undefined) {
+    return undefined;
+  }
+  return {
+    type: 'citation',
+    annotatedRegions: [{ type: 'text_span', startIndex, endIndex: startIndex + lineCount }],
+    rawRepresentation: result,
+  };
+}
+
+/** The outputs of a `text_editor_code_execution_tool_result` payload. */
+function textEditorOutputs(result: AnthropicBlock): Content[] {
+  switch (result.type) {
+    case 'text_editor_code_execution_tool_result_error': {
+      // The error code gates the message, as in Python: a payload that reports a code but no
+      // message describes itself through the raw representation rather than through prose.
+      const errorCode = String(result.error_code ?? '');
+      const errorMessage = errorCode === '' ? '' : (nonEmptyString(result.error_message) ?? '');
+      return [{ type: 'error', message: errorMessage, rawRepresentation: result }];
+    }
+    case 'text_editor_code_execution_view_result': {
+      const annotation = lineSpanAnnotation(result.start_line, result.num_lines, result);
+      return [
+        {
+          type: 'text',
+          text: String(result.content ?? ''),
+          ...(annotation === undefined ? {} : { annotations: [annotation] }),
+          rawRepresentation: result,
+        },
+      ];
+    }
+    case 'text_editor_code_execution_str_replace_result': {
+      const lines = Array.isArray(result.lines) ? result.lines.map(String) : [];
+      const text = lines.join('\n');
+      const annotations: Annotation[] = [];
+      const replaced = lineSpanAnnotation(result.old_start, result.old_lines, result);
+      if (replaced !== undefined) {
+        annotations.push(replaced);
+      }
+      const inserted = lineSpanAnnotation(result.new_start, result.new_lines, result);
+      if (inserted !== undefined) {
+        // Only the new span quotes what is now there; the old one points at lines that are gone.
+        annotations.push(text === '' ? inserted : { ...inserted, snippet: text });
+      }
+      return [
+        {
+          type: 'text',
+          text,
+          ...(annotations.length === 0 ? {} : { annotations }),
+          rawRepresentation: result,
+        },
+      ];
+    }
+    case 'text_editor_code_execution_create_result':
+      return [
+        {
+          type: 'text',
+          text: `File update: ${result.is_file_update === true}`,
+          rawRepresentation: result,
+        },
+      ];
+    default:
+      return [unknownContent(result)];
+  }
+}
+
 /**
  * Converts Messages API content blocks into framework content.
  *
@@ -267,8 +460,20 @@ export function parseContentBlocks(blocks: readonly unknown[], state?: StreamPar
       case 'tool_use':
       case 'server_tool_use': {
         const callId = String(block.id ?? '');
+        const codeExecution = isCodeExecutionName(block.name);
         if (state !== undefined) {
-          state.currentCall = { callId, blockType: String(block.type) };
+          // Only a local `tool_use` streams its arguments onwards; a code-execution call is
+          // reported whole, so its fragments must not be attributed to a function call.
+          state.currentCall = { callId, blockType: codeExecution ? 'code_execution' : String(block.type) };
+        }
+        if (codeExecution) {
+          contents.push({
+            type: 'code_interpreter_tool_call',
+            callId,
+            inputs: codeInterpreterInputs(block),
+            rawRepresentation: block,
+          });
+          break;
         }
         contents.push({
           type: 'function_call',
@@ -326,6 +531,42 @@ export function parseContentBlocks(blocks: readonly unknown[], state?: StreamPar
         });
         break;
       }
+      case 'code_execution_tool_result': {
+        const result = asBlock(block.content);
+        contents.push({
+          type: 'code_interpreter_tool_result',
+          callId: String(block.tool_use_id ?? ''),
+          outputs: result === undefined ? [] : codeExecutionOutputs(result),
+          rawRepresentation: block,
+        });
+        break;
+      }
+      case 'bash_code_execution_tool_result': {
+        const result = asBlock(block.content);
+        const parsed = result === undefined ? { outputs: [], files: [] } : bashExecutionOutputs(result);
+        // The files a bash run produced are siblings of the shell result rather than outputs
+        // nested inside it, matching Python — they surface directly on the response that way.
+        contents.push(...parsed.files);
+        contents.push({
+          type: 'shell_tool_result',
+          callId: String(block.tool_use_id ?? ''),
+          outputs: parsed.outputs,
+          rawRepresentation: block,
+        });
+        break;
+      }
+      case 'text_editor_code_execution_tool_result': {
+        // The text editor has no hosted-tool content of its own: Python reports its outcome as an
+        // ordinary function result answering the call, and so does this.
+        const result = asBlock(block.content);
+        contents.push({
+          type: 'function_result',
+          callId: String(block.tool_use_id ?? ''),
+          result: result === undefined ? [] : textEditorOutputs(result),
+          rawRepresentation: block,
+        });
+        break;
+      }
       case 'web_search_tool_result':
       case 'web_fetch_tool_result': {
         // The provider ran the search and reported the result; it answers a `server_tool_use`.
@@ -375,10 +616,61 @@ export function parseMessage(message: unknown): ChatResponse<undefined> {
 }
 
 /**
+ * Whether the provider, not the framework, runs this call.
+ *
+ * Such a call is modelled as one whole content item — a hosted call or an informational function
+ * call — so it has no fragment form to stream. Its `input_json_delta` fragments are accumulated
+ * and the call is converted once its block closes, which is what makes a streamed transcript carry
+ * the same arguments as an awaited one. A local `tool_use` keeps streaming its fragments, because
+ * the function-calling loop consumes them as they arrive.
+ */
+function isProviderExecutedCall(block: AnthropicBlock): boolean {
+  return (
+    block.type === 'server_tool_use' ||
+    block.type === 'mcp_tool_use' ||
+    (block.type === 'tool_use' && isCodeExecutionName(block.name))
+  );
+}
+
+/** The accumulated fragments as an `input` object, or `undefined` when they do not form one. */
+function parsedInput(json: string): Record<string, unknown> | undefined {
+  if (json.trim() === '') {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(json);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    // A truncated stream leaves half a JSON document behind; the opening placeholder is closer to
+    // the model's intent than a fragment that cannot be parsed back into arguments.
+    return undefined;
+  }
+}
+
+/** Converts the provider-executed call left open, if there is one, and clears it. */
+function flushPendingCall(state: StreamParseState): Content[] {
+  const pending = state.pendingCall;
+  if (pending === undefined) {
+    return [];
+  }
+  delete state.pendingCall;
+  const input = parsedInput(pending.json);
+  // Converted without the streaming state, so the completed block reads exactly as the same block
+  // does in an awaited response.
+  return parseContentBlocks([input === undefined ? pending.block : { ...pending.block, input }]);
+}
+
+function contentUpdate(contents: Content[], event: unknown): ChatResponseUpdate | undefined {
+  return contents.length === 0
+    ? undefined
+    : chatResponseUpdate({ role: 'assistant', contents, rawRepresentation: event });
+}
+
+/**
  * Converts one streaming event, or `undefined` for the events that carry nothing.
  *
- * `message_stop` and `content_block_stop` are pure framing: the framework's fold already knows
- * where a message ends.
+ * `message_stop` and `content_block_stop` are otherwise pure framing — the framework's fold already
+ * knows where a message ends — but they are where a deferred provider-executed call is emitted.
  */
 export function parseStreamEvent(event: unknown, state: StreamParseState): ChatResponseUpdate | undefined {
   if (typeof event !== 'object' || event === null) {
@@ -402,32 +694,44 @@ export function parseStreamEvent(event: unknown, state: StreamParseState): ChatR
       const finishReason = parseFinishReason(delta.stop_reason);
       return chatResponseUpdate({
         role: 'assistant',
-        contents: usage === undefined ? [] : [usage],
+        contents: [...flushPendingCall(state), ...(usage === undefined ? [] : [usage])],
         ...(finishReason === undefined ? {} : { finishReason }),
         rawRepresentation: event,
       });
     }
-    case 'content_block_start':
-    case 'content_block_delta': {
-      const block = raw.type === 'content_block_start' ? raw.content_block : raw.delta;
-      if (raw.type === 'content_block_delta') {
-        const deltaType = (block as AnthropicBlock | null | undefined)?.type;
-        if (
-          deltaType !== 'text_delta' &&
-          deltaType !== 'thinking_delta' &&
-          deltaType !== 'signature_delta' &&
-          deltaType !== 'input_json_delta'
-        ) {
-          // A delta is a fragment, not a replayable Messages API content block. Preserving an
-          // unknown fragment as UnknownContent would send that fragment as a whole block on the
-          // next turn and permanently poison the transcript.
-          return undefined;
-        }
+    // A stream that ends without closing its last block still reports the call it opened.
+    case 'content_block_stop':
+    case 'message_stop':
+      return contentUpdate(flushPendingCall(state), event);
+    case 'content_block_start': {
+      const block = asBlock(raw.content_block);
+      const pending = flushPendingCall(state);
+      if (block !== undefined && isProviderExecutedCall(block)) {
+        state.pendingCall = { block, json: '' };
+        // Fragments now belong to the pending call, not to any call announced before it.
+        delete state.currentCall;
+        return contentUpdate(pending, event);
       }
-      const contents = parseContentBlocks([block], state);
-      return contents.length === 0
-        ? undefined
-        : chatResponseUpdate({ role: 'assistant', contents, rawRepresentation: event });
+      return contentUpdate([...pending, ...parseContentBlocks([block], state)], event);
+    }
+    case 'content_block_delta': {
+      const delta = asBlock(raw.delta);
+      if (delta?.type === 'input_json_delta' && state.pendingCall !== undefined) {
+        state.pendingCall.json += String(delta.partial_json ?? '');
+        return undefined;
+      }
+      if (
+        delta?.type !== 'text_delta' &&
+        delta?.type !== 'thinking_delta' &&
+        delta?.type !== 'signature_delta' &&
+        delta?.type !== 'input_json_delta'
+      ) {
+        // A delta is a fragment, not a replayable Messages API content block. Preserving an
+        // unknown fragment as UnknownContent would send that fragment as a whole block on the
+        // next turn and permanently poison the transcript.
+        return undefined;
+      }
+      return contentUpdate(parseContentBlocks([delta], state), event);
     }
     default:
       return undefined;

--- a/packages/anthropic/src/from-anthropic.wire-fallbacks.test.ts
+++ b/packages/anthropic/src/from-anthropic.wire-fallbacks.test.ts
@@ -101,21 +101,58 @@ describe('streamed tool-call argument handling', () => {
     expect(update?.contents[0]).toMatchObject({ arguments: { city: 'Osaka' } });
   });
 
-  it('drops argument fragments of a server-side call instead of feeding them to the tool loop', () => {
+  it('accumulates the argument fragments of a server-side call instead of feeding them to the tool loop', () => {
+    // The framework never executes this call, so it has no fragment form: nothing is emitted until
+    // the block closes, and then it carries the arguments the fragments spelled out.
     const state = createStreamParseState();
-    parseStreamEvent(
+    const opened = parseStreamEvent(
       {
         type: 'content_block_start',
         content_block: { type: 'server_tool_use', id: 's1', name: 'web_search' },
       },
       state,
     );
+    expect(opened).toBeUndefined();
     expect(
       parseStreamEvent(
         { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: '{"q":' } },
         state,
       ),
     ).toBeUndefined();
+    expect(
+      parseStreamEvent(
+        { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: '"x"}' } },
+        state,
+      ),
+    ).toBeUndefined();
+    expect(parseStreamEvent({ type: 'content_block_stop' }, state)?.contents[0]).toMatchObject({
+      type: 'function_call',
+      callId: 's1',
+      name: 'web_search',
+      arguments: { q: 'x' },
+      informationalOnly: true,
+    });
+  });
+
+  it('reports a call left open by a truncated stream when the message ends', () => {
+    const state = createStreamParseState();
+    parseStreamEvent(
+      {
+        type: 'content_block_start',
+        content_block: { type: 'server_tool_use', id: 's1', name: 'web_search', input: {} },
+      },
+      state,
+    );
+    parseStreamEvent(
+      { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: '{"q":' } },
+      state,
+    );
+    // Half a JSON document is not arguments; the opening placeholder is what survives.
+    expect(parseStreamEvent({ type: 'message_stop' }, state)?.contents[0]).toMatchObject({
+      type: 'function_call',
+      callId: 's1',
+      arguments: {},
+    });
   });
 
   it('drops an argument fragment that no call announced', () => {
@@ -142,16 +179,16 @@ describe('streamed tool-call argument handling', () => {
 
   it('tracks a streamed MCP call the same way, defaulting its fields', () => {
     const state = createStreamParseState();
-    const update = parseStreamEvent(
-      { type: 'content_block_start', content_block: { type: 'mcp_tool_use' } },
-      state,
-    );
+    expect(
+      parseStreamEvent({ type: 'content_block_start', content_block: { type: 'mcp_tool_use' } }, state),
+    ).toBeUndefined();
+    const update = parseStreamEvent({ type: 'content_block_stop' }, state);
     expect(update?.contents[0]).toMatchObject({
       type: 'mcp_server_tool_call',
       callId: '',
       toolName: '',
       serverName: '',
-      arguments: '',
+      arguments: {},
     });
   });
 });

--- a/packages/anthropic/src/to-anthropic.ts
+++ b/packages/anthropic/src/to-anthropic.ts
@@ -116,6 +116,40 @@ function toolResultContent(result: unknown): AnthropicBlock[] | string {
   return safeStringify(result);
 }
 
+/** The blocks a provider-run code-execution call and its result arrive as. */
+const PROVIDER_EXECUTED_BLOCKS = new Set([
+  'tool_use',
+  'server_tool_use',
+  'code_execution_tool_result',
+  'bash_code_execution_tool_result',
+  'text_editor_code_execution_tool_result',
+]);
+
+/**
+ * The block to replay for content describing a call the provider ran itself.
+ *
+ * These contents model an outcome, not a request the caller can make: there is no block to build
+ * from their fields, and the result blocks have to go back on the assistant turn that produced
+ * them rather than as a `tool_result` answering a call the transcript no longer contains. The
+ * block the API sent is replayed instead — the same forward-compatible rule {@link Content} of
+ * type `unknown` follows — so an exchange that used code execution survives the next request.
+ */
+function providerExecutedBlock(content: Content): AnthropicBlock | undefined {
+  if (
+    content.type !== 'code_interpreter_tool_call' &&
+    content.type !== 'code_interpreter_tool_result' &&
+    content.type !== 'shell_tool_result' &&
+    content.type !== 'function_result'
+  ) {
+    return undefined;
+  }
+  const raw = content.rawRepresentation;
+  if (!isRecord(raw) || typeof raw.type !== 'string' || !PROVIDER_EXECUTED_BLOCKS.has(raw.type)) {
+    return undefined;
+  }
+  return raw;
+}
+
 /**
  * Converts one framework content item into Messages API blocks.
  *
@@ -124,6 +158,11 @@ function toolResultContent(result: unknown): AnthropicBlock[] | string {
  * `_prepare_message_for_anthropic`).
  */
 function appendContent(blocks: AnthropicBlock[], content: Content): void {
+  const providerExecuted = providerExecutedBlock(content);
+  if (providerExecuted !== undefined) {
+    blocks.push(providerExecuted);
+    return;
+  }
   switch (content.type) {
     case 'text': {
       // The API rejects empty text blocks.


### PR DESCRIPTION
## What this changes

Fixes #112. The client requests the code-execution beta by default, but receive conversion had no
rule for what the beta answers with: a `tool_use` or `server_tool_use` naming a code-execution tool
arrived as an ordinary function call — one the tool loop would try to run locally — and every result
block arrived as unknown content. The contents these blocks belong in are ones core already defines
and serializes, so no core change was needed.

Code-execution calls become `code_interpreter_tool_call`; `code_execution_tool_result` becomes
`code_interpreter_tool_result`; `bash_code_execution_tool_result` becomes a `shell_tool_result` with
its `shell_command_output`; `text_editor_code_execution_tool_result` becomes a `function_result` with
the line spans the wire reported. Every mapping keeps the provider block on `rawRepresentation`, and
an unrecognized block — or result payload — still becomes unknown content that round-trips verbatim.

Two things this surfaced, both fixed here:

**A pre-existing streaming bug in adjacent branches.** A provider-executed call has no fragment
form, but the stream emitted it when its block opened, before its arguments existed, and dropped
every `input_json_delta` that followed — so a streamed `server_tool_use` or `mcp_tool_use` landed
with *no arguments at all*. An existing test named `drops argument fragments of a server-side call`
had pinned that as intended. Such a call is now converted once its block closes. Fixing only the
code-execution branch would have left the identical bug one branch away.

**A round-trip regression typing the blocks would otherwise cause.** With the text-editor result
mapped to a `function_result`, the request path replayed it as a `tool_result` on a user turn while
its call — now a `code_interpreter_tool_call` — was dropped, producing a `tool_result` answering a
call the request no longer contained, which the API rejects. Verified with a probe rather than by
reading. Provider-executed content now replays as the block the API sent, the same
forward-compatibility rule unknown content already followed. Python has the same hole.

## Parity

- Reference checked: Python `_parse_contents_from_anthropic`, branch for branch — the substring test
  on the tool name, all four `code_execution_tool_result` arms, the three bash arms including
  `execution_time_exceeded` as the timeout signal and files reported beside the result rather than
  inside it, and the four text-editor arms with their line spans. .NET and Go have no Anthropic
  content conversion at all, so Python is the sole authority. Python has 12 tests over this surface;
  this has 32.
- Deliberate divergences: `File update: true/false` in JS boolean spelling; an unrecognized inner
  payload is preserved as unknown rather than dropped; the streaming deferral above (Python emits
  the placeholder and leaks the fragments); replaying from the raw block (Python drops it); and an
  absent `error_message` yields an empty message rather than a null one.
- Wire format affected: yes
- Public API affected: no
- Breaking change: no

A replayed code-execution exchange now sends the provider's own blocks instead of a rewritten
`tool_use` + `tool_result`, and a streamed hosted call now carries its arguments. Nothing is
exported that was not exported before — no declaration factory and no hosted-tool API, both out of
scope by the issue.

Known gap, filed separately: `rawRepresentation` is not serialized, so a code-execution turn
restored from a *persisted* session has no block to replay. In-memory sessions, the default, are
unaffected.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
