### PR TITLE
Settle the chat telemetry attribute shapes and report server.address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,18 @@ contain breaking changes**; patch releases are fixes only.
   `getTools()` now rejects and names both remote tools and the name they collide on, rather than
   silently shadowing one of them.
 
+- **`@polymind-inc/agent-framework-core`** — chat spans and the two chat metrics
+  (`gen_ai.client.token.usage`, `gen_ai.client.operation.duration`) now carry `server.address`,
+  naming the endpoint the model call went to. The key was already on the metric dimension
+  allowlist but nothing produced a value, so no span or histogram ever reported it. The value is
+  the host of the client's endpoint (`api.openai.com`), the form the semantic conventions define
+  for this key and the one MCP spans already emit, and it is `unknown` when the client names no
+  endpoint — so a dashboard grouping by `server.address` sees one dimension set across every
+  provider. `ChatClientMetadata` gains an optional `providerUri` for a client to declare that
+  endpoint; the OpenAI, Anthropic and Foundry clients fill it from their SDK's base URL. No
+  existing attribute changed type or shape, and `server.port` is still not emitted. The
+  `invoke_agent` span does not carry the address: it describes the agent, not a connection.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,30 @@ contain breaking changes**; patch releases are fixes only.
   existing attribute changed type or shape, and `server.port` is still not emitted. The
   `invoke_agent` span does not carry the address: it describes the agent, not a connection.
 
+- **[BREAKING] `@polymind-inc/agent-framework-core`** — the parts inside `gen_ai.input.messages`
+  and `gen_ai.output.messages` are named with the semantic conventions' vocabulary instead of the
+  framework's own content types, and the `chat` span's final output message now carries a
+  `finish_reason`. **Dashboard migration:** a query that filters or groups on a part's `type` must
+  be updated — `text_reasoning` → `reasoning`, `data` → `blob`, `function_call` → `tool_call`,
+  `function_result` → `tool_call_response`. `text` and `uri` already matched and are unchanged, as
+  is every part kind the conventions do not name, which keeps its framework type on both sides.
+  The old spellings were internal names that appeared in no other implementation's traces: Python's
+  `_to_otel_part_latest_experimental` and .NET's `OtelMessageSerializer` both emit the four names
+  above, so one query now reads message parts from a TypeScript, Python or .NET trace alike. The
+  new `finish_reason` sits beside `role` and `parts` on the **last** output message of the `chat`
+  span only, carrying the same normalized value as `gen_ai.response.finish_reasons` (`tool_calls`
+  becomes `tool_call`) — the position and the span Python stamps it in; the `invoke_agent` span's
+  output messages are unchanged. Nothing was added to a part's payload: parts stay compact
+  (`text` carries its `content`, every other part is its `type` alone), so tool-call ids, names and
+  arguments, tool-result ids and responses, blob bytes, URIs, mime types and modalities are still
+  deliberately absent from spans — they belong to the transcript, and a rendered image attachment
+  alone would grow one message list past the size at which a backend truncates the attribute and
+  the whole list is lost. That trade-off, the fields it drops, and the cross-implementation
+  differences in `gen_ai.response.finish_reasons` (an array of strings here, JSON text in Python
+  and .NET, absent in Go) are now documented on the `GEN_AI` attribute constants. `server.port` is
+  still deliberately emitted by nothing, on spans and on metric dimensions alike, and its absence
+  is now pinned by tests.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/packages/anthropic/src/chat-client.test.ts
+++ b/packages/anthropic/src/chat-client.test.ts
@@ -86,6 +86,17 @@ describe('construction', () => {
     expect(() => new AnthropicChatClient({ model: '' })).toThrow(ConfigurationError);
   });
 
+  it('reports the endpoint so telemetry can name the server it called', () => {
+    // The endpoint verbatim, not its host: `server.address` is derived from this in one place, in
+    // core, so every provider reports that attribute the same way.
+    const client = new AnthropicChatClient({
+      model: 'claude-sonnet-4-5',
+      apiKey: 'k',
+      baseURL: 'https://anthropic.example.com/v1',
+    });
+    expect(client.metadata.providerUri).toBe('https://anthropic.example.com/v1');
+  });
+
   it('rejects a blank MCP server label with a ConfigurationError', () => {
     const { client } = clientWith([]);
     expect(() => client.getMcpTool({ serverLabel: '  ', serverUrl: 'https://mcp.example/sse' })).toThrow(

--- a/packages/anthropic/src/chat-client.ts
+++ b/packages/anthropic/src/chat-client.ts
@@ -144,7 +144,12 @@ export class AnthropicChatClient
       });
     this.#model = config.model;
     this.#defaultMaxTokens = config.defaultMaxTokens ?? DEFAULT_MAX_TOKENS;
-    this.metadata = { providerName: 'anthropic', modelId: config.model };
+    const baseURL = String(this.#client.baseURL ?? '');
+    this.metadata = {
+      providerName: 'anthropic',
+      modelId: config.model,
+      ...(baseURL === '' ? {} : { providerUri: baseURL }),
+    };
   }
 
   /** The underlying SDK client, for provider features the framework does not model. */

--- a/packages/core/src/client/chat-client.ts
+++ b/packages/core/src/client/chat-client.ts
@@ -10,6 +10,14 @@ export interface ChatClientMetadata {
   readonly providerName: string;
   readonly modelId?: string;
   /**
+   * The endpoint requests go to, as an absolute URL.
+   *
+   * Its host becomes `server.address` on chat spans and on the chat metrics. Leave it unset when
+   * the client has no single endpoint; the address is then reported as `'unknown'` rather than
+   * dropped, so a dashboard's dimension set stays the same shape across providers.
+   */
+  readonly providerUri?: string;
+  /**
    * Whether `conversationId` names a service-side anchor that stays stable across responses, as
    * opposed to a per-response chain that must advance to each round's reported id.
    *

--- a/packages/core/src/client/telemetry.ts
+++ b/packages/core/src/client/telemetry.ts
@@ -1,6 +1,6 @@
 import type { Attributes, Span } from '@opentelemetry/api';
 import { errorTypeOf } from '../errors.js';
-import { GEN_AI, GEN_AI_OPERATION } from '../observability/attributes.js';
+import { GEN_AI, GEN_AI_OPERATION, SERVER, serverAddress } from '../observability/attributes.js';
 import { recordChatMetrics } from '../observability/metrics.js';
 import {
   addMessageEvents,
@@ -24,6 +24,9 @@ function requestAttributes(metadata: ChatClientMetadata, options: ChatOptions | 
   const attributes: Attributes = {
     [GEN_AI.operation]: GEN_AI_OPERATION.chat,
     [GEN_AI.providerName]: metadata.providerName,
+    // Set here rather than on the span alone: this object is also the source of the metric
+    // dimensions, so span and histograms report one value for one call by construction.
+    [SERVER.address]: serverAddress(metadata.providerUri),
   };
   const model = options?.model ?? metadata.modelId;
   if (model !== undefined) attributes[GEN_AI.requestModel] = model;

--- a/packages/core/src/client/telemetry.ts
+++ b/packages/core/src/client/telemetry.ts
@@ -160,8 +160,8 @@ export function withChatTelemetry<TOptions extends ChatOptions>(
               metricAttributes[GEN_AI.responseModel] = response.model;
             }
             if (failure === undefined && span !== undefined) {
-              finishChatSpan(span, response);
               const finishReason = responseFinishReason(response);
+              finishChatSpan(span, response, finishReason);
               addMessageEvents(span, {
                 providerName: client.metadata.providerName,
                 messages: response.messages,

--- a/packages/core/src/client/test-support.ts
+++ b/packages/core/src/client/test-support.ts
@@ -44,14 +44,16 @@ export interface RecordedCall {
  * in {@link MockChatClient.calls} for assertions on what reached the client.
  */
 export class MockChatClient implements ChatClient<ChatOptions> {
-  readonly metadata: ChatClientMetadata = { providerName: 'mock', modelId: 'mock-model' };
+  readonly metadata: ChatClientMetadata;
   /** Every call received so far, in order. */
   readonly calls: RecordedCall[] = [];
   #index = 0;
   readonly #turns: MockTurn[];
 
-  constructor(turns: MockTurn[]) {
+  /** `metadata` overrides the defaults, for tests that assert on provider-derived telemetry. */
+  constructor(turns: MockTurn[], metadata?: Partial<ChatClientMetadata>) {
     this.#turns = turns;
+    this.metadata = { providerName: 'mock', modelId: 'mock-model', ...metadata };
   }
 
   /** Shorthand for `calls.length`. */

--- a/packages/core/src/client/test-support.ts
+++ b/packages/core/src/client/test-support.ts
@@ -24,6 +24,13 @@ export interface MockTurn {
    * awaited call, and as a trailing `usage` content while streaming.
    */
   usage?: UsageDetails;
+  /**
+   * The provider object behind this turn, for tests about the fields a response only carries there.
+   *
+   * Some providers report a finish reason on the wire object and leave the normalized field empty;
+   * a turn that sets this can drive the code that reads it back.
+   */
+  rawRepresentation?: unknown;
 }
 
 /** A recorded call to {@link MockChatClient.getResponse}. */
@@ -84,6 +91,7 @@ export class MockChatClient implements ChatClient<ChatOptions> {
             responseId,
             ...(turn.finishReason === undefined ? {} : { finishReason: turn.finishReason }),
             ...(turn.usage === undefined ? {} : { usageDetails: turn.usage }),
+            ...(turn.rawRepresentation === undefined ? {} : { rawRepresentation: turn.rawRepresentation }),
           });
           return arrayToStream(chatResponseToUpdates(direct));
         }

--- a/packages/core/src/observability/attributes.ts
+++ b/packages/core/src/observability/attributes.ts
@@ -26,6 +26,30 @@ export const GEN_AI = {
   // Response
   responseId: 'gen_ai.response.id',
   responseModel: 'gen_ai.response.model',
+  /**
+   * Why the model stopped, as a **native string array** — the type the semantic conventions
+   * define for this key.
+   *
+   * **Cross-implementation difference.** The four implementations do not agree on this attribute,
+   * and no two of them are queryable the same way, so no representation could have been adopted
+   * that matched more than one of them:
+   *
+   * | Implementation | A tool-calling response reports |
+   * | --- | --- |
+   * | this one | `["tool_call"]` (array of strings) |
+   * | Python | `'["tool_calls"]'` (JSON text) |
+   * | .NET | `'["toolcalls"]'` (JSON text, punctuation removed) |
+   * | Go | attribute not emitted |
+   *
+   * A dashboard reading this attribute from a TypeScript trace filters on the array directly; the
+   * same query against a Python or .NET trace needs a JSON parse first, and the value it finds
+   * inside is spelled differently again.
+   *
+   * The values are the convention's, not the provider's: `tool_calls` is normalized to
+   * `tool_call` (see {@link otelFinishReason}). The unnormalized provider spelling is still
+   * reported in the `finish_reason` of the `gen_ai.choice` message event, which the convention
+   * defines separately.
+   */
   finishReasons: 'gen_ai.response.finish_reasons',
 
   // Usage
@@ -51,7 +75,47 @@ export const GEN_AI = {
   toolResult: 'gen_ai.tool.call.result',
 
   // Message content — only recorded when sensitive data is explicitly enabled.
+  /**
+   * The prompt, as `[{ "role": …, "parts": [{ "type": … }] }]` — a **compact** rendering of the
+   * convention's message shape.
+   *
+   * **What a part carries.** A `text` part carries its `content`. Every other part is its `type`
+   * and nothing else, named with the convention's vocabulary (`reasoning`, `blob`, `uri`,
+   * `tool_call`, `tool_call_response`) so the same query works against a Python or .NET trace.
+   *
+   * **What a part deliberately drops**, which Python and .NET both include:
+   *
+   * | Part | Omitted here |
+   * | --- | --- |
+   * | `tool_call` | `id`, `name`, `arguments` |
+   * | `tool_call_response` | `id`, `response` |
+   * | `blob` | the base64 bytes, `mime_type`, `modality` |
+   * | `uri` | `uri`, `mime_type`, `modality` |
+   * | `reasoning` | `content` |
+   *
+   * A dashboard therefore sees the **shape** of an exchange — how many turns, in what roles, of
+   * what kinds — and reads the payloads from the transcript instead.
+   *
+   * **Why.** Two reasons, both about what a span attribute is for. Size: a span attribute is a
+   * single string on a record that ships on every call, and one image attachment rendered as a
+   * blob part grows one message list from a few hundred bytes to tens of kilobytes — past the
+   * point where an exporter or backend truncates the attribute, which costs the *whole* message
+   * list, not just the blob. Exposure: tool arguments and tool results are the parts most likely
+   * to hold credentials, access tokens and consent links, and they would land in a trace backend
+   * whose retention and access rules are not the transcript's.
+   *
+   * Message content of any kind is recorded only when `configureObservability` or
+   * `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` turns it on; with capture off, neither
+   * this key nor {@link GEN_AI.outputMessages} appears on any span.
+   */
   inputMessages: 'gen_ai.input.messages',
+  /**
+   * The completion, in the same compact form as {@link GEN_AI.inputMessages}.
+   *
+   * On the `chat` span the last message additionally carries `finish_reason`, normalized the way
+   * {@link GEN_AI.finishReasons} is (`tool_calls` becomes `tool_call`). The `invoke_agent` span
+   * leaves it off, as the reference implementations do.
+   */
   outputMessages: 'gen_ai.output.messages',
   systemInstructions: 'gen_ai.system_instructions',
 
@@ -94,6 +158,18 @@ export const GEN_AI_MESSAGE_EVENT = {
 export const SERVER = {
   /** The host the request goes to, for example `api.openai.com`. Not a full URL. */
   address: 'server.address',
+  /**
+   * The endpoint's port — **deliberately never produced for a chat call**.
+   *
+   * The key stays here and in the metric dimension allowlist as a forward declaration, the way
+   * Python lists it among its metric attributes without a generator; the dimension filter skips a
+   * key with no value, so no histogram series is split by it.
+   *
+   * Known non-conformance: the semantic conventions make this key conditionally required once
+   * `server.address` is present, and chat spans do report an address. Reporting the port is a
+   * separate decision from reporting the address, because it is also a histogram dimension. MCP
+   * spans, which follow their own convention, do report it.
+   */
   port: 'server.port',
 } as const;
 
@@ -125,7 +201,15 @@ export const GEN_AI_OPERATION = {
   createAgent: 'create_agent',
 } as const;
 
-/** Maps a framework `finishReason` to the semantic-convention value (Python `FINISH_REASON_MAP`). */
+/**
+ * Maps a framework `finishReason` to the semantic-convention value (Python `FINISH_REASON_MAP`).
+ *
+ * Only `tool_calls` differs; `stop`, `length` and `content_filter` are already the convention's
+ * words and pass through, as does any value outside the map. Applied to
+ * {@link GEN_AI.finishReasons} and to the `finish_reason` stamped on the last output message —
+ * the two places Python maps it — but not to the `gen_ai.choice` event body, which the convention
+ * defines with the provider's own spelling.
+ */
 export function otelFinishReason(finishReason: string): string {
   return finishReason === 'tool_calls' ? 'tool_call' : finishReason;
 }

--- a/packages/core/src/observability/attributes.ts
+++ b/packages/core/src/observability/attributes.ts
@@ -83,6 +83,21 @@ export const GEN_AI_MESSAGE_EVENT = {
 } as const;
 
 /**
+ * OpenTelemetry general server attributes.
+ *
+ * Not GenAI-specific: the same two keys identify the endpoint behind a model call and behind an
+ * MCP connection, so both conventions reuse them and so must every emitter here — a dashboard
+ * filtering on `server.address` has to see one vocabulary, whichever span it lands on.
+ *
+ * @see https://opentelemetry.io/docs/specs/semconv/attributes-registry/server/
+ */
+export const SERVER = {
+  /** The host the request goes to, for example `api.openai.com`. Not a full URL. */
+  address: 'server.address',
+  port: 'server.port',
+} as const;
+
+/**
  * OpenTelemetry MCP semantic-convention attributes.
  *
  * Values match Python's `OtelAttr.MCP_*`.
@@ -93,6 +108,9 @@ export const MCP = {
   methodName: 'mcp.method.name',
   /** Set on the `initialize` span once the MCP client wires it (Python parity; deferred low). */
   protocolVersion: 'mcp.protocol.version',
+  // The same two keys as {@link SERVER}, spelled out because `isolatedDeclarations` needs a
+  // literal here rather than a reference. Change one side and you must change the other; the
+  // observability tests fail if the pairs ever disagree.
   serverAddress: 'server.address',
   serverPort: 'server.port',
   /** The resource a `resources/read` span was for. Python has no equivalent constant yet. */
@@ -110,4 +128,30 @@ export const GEN_AI_OPERATION = {
 /** Maps a framework `finishReason` to the semantic-convention value (Python `FINISH_REASON_MAP`). */
 export function otelFinishReason(finishReason: string): string {
   return finishReason === 'tool_calls' ? 'tool_call' : finishReason;
+}
+
+/** What {@link serverAddress} reports when the endpoint cannot be determined. */
+export const UNKNOWN_SERVER_ADDRESS = 'unknown';
+
+/**
+ * The `server.address` value for a client whose endpoint is `providerUri`.
+ *
+ * The host, not the URL: the convention defines this key as the server's address, and it is also
+ * a metric dimension — a full endpoint URL carries the deployment path, so histogram series would
+ * split per deployment instead of per host.
+ *
+ * An absent or unparseable endpoint reports {@link UNKNOWN_SERVER_ADDRESS} rather than nothing, so
+ * every chat call contributes to the same dimension set whether or not its client names a URL.
+ */
+export function serverAddress(providerUri: string | undefined): string {
+  if (providerUri === undefined || providerUri === '') {
+    return UNKNOWN_SERVER_ADDRESS;
+  }
+  let hostname: string;
+  try {
+    hostname = new URL(providerUri).hostname;
+  } catch {
+    return UNKNOWN_SERVER_ADDRESS;
+  }
+  return hostname === '' ? UNKNOWN_SERVER_ADDRESS : hostname;
 }

--- a/packages/core/src/observability/metrics.test.ts
+++ b/packages/core/src/observability/metrics.test.ts
@@ -137,6 +137,34 @@ describe('chat metrics', () => {
     expect(dimensionSets).toEqual(['unknown', 'unknown', 'unknown']);
   });
 
+  it('carries no server.port dimension, even when the endpoint names a port', async () => {
+    const client = new MockChatClient(
+      [
+        {
+          contents: [textContent('hi')],
+          finishReason: 'stop',
+          usage: { inputTokenCount: 1, outputTokenCount: 2 },
+        },
+      ],
+      { providerUri: 'https://api.example.com:8443/v1' },
+    );
+
+    await new Agent({ client }).run('hello');
+
+    const scope = await collect();
+    const points = (scope?.metrics ?? []).flatMap(
+      (metric) => metric.dataPoints as Array<DataPoint<Histogram>>,
+    );
+    expect(points).toHaveLength(3);
+    // Deliberate: nothing produces a value for this key, so no histogram series is split by it.
+    // It stays in the dimension allowlist as a forward declaration — `metricDimensions` skips a
+    // key with no value — and emitting it is a separate decision from `server.address`.
+    for (const point of points) {
+      expect(point.attributes).not.toHaveProperty(SERVER.port);
+      expect(point.attributes[SERVER.address]).toBe('api.example.com');
+    }
+  });
+
   it('carries error.type on the duration of a failed call', async () => {
     const failing = {
       metadata: { providerName: 'mock' },

--- a/packages/core/src/observability/metrics.test.ts
+++ b/packages/core/src/observability/metrics.test.ts
@@ -16,6 +16,7 @@ import { Agent } from '../agent/agent.js';
 import { MockChatClient } from '../client/test-support.js';
 import { tool } from '../tools/tool.js';
 import { textContent } from '../types/content.js';
+import { SERVER } from './attributes.js';
 import {
   GEN_AI_METRICS,
   OPERATION_DURATION_BUCKET_BOUNDARIES,
@@ -100,6 +101,40 @@ describe('chat metrics', () => {
     expect(points[0]?.value.buckets.boundaries).toEqual([...OPERATION_DURATION_BUCKET_BOUNDARIES]);
     // High-cardinality span attributes must not become metric dimensions.
     expect(points[0]?.attributes).not.toHaveProperty('gen_ai.response.id');
+  });
+
+  it('carries the same server.address on both histograms and on the chat span', async () => {
+    const client = new MockChatClient(
+      [
+        {
+          contents: [textContent('hi')],
+          finishReason: 'stop',
+          usage: { inputTokenCount: 1, outputTokenCount: 2 },
+        },
+      ],
+      { providerUri: 'https://api.example.com/openai/v1' },
+    );
+
+    await new Agent({ client }).run('hello');
+
+    const scope = await collect();
+    const dimensionSets = (scope?.metrics ?? [])
+      .flatMap((metric) => metric.dataPoints as Array<DataPoint<Histogram>>)
+      .map((point) => point.attributes[SERVER.address]);
+    // Two token-usage points (input and output) plus one duration point.
+    expect(dimensionSets).toEqual(['api.example.com', 'api.example.com', 'api.example.com']);
+    const chat = spanExporter.getFinishedSpans().find((span) => span.name === 'chat mock-model');
+    expect(chat?.attributes[SERVER.address]).toBe('api.example.com');
+  });
+
+  it("carries server.address 'unknown' on both histograms when the client names no endpoint", async () => {
+    await new Agent({ client: usingClient({ inputTokenCount: 1, outputTokenCount: 2 }) }).run('hello');
+
+    const scope = await collect();
+    const dimensionSets = (scope?.metrics ?? [])
+      .flatMap((metric) => metric.dataPoints as Array<DataPoint<Histogram>>)
+      .map((point) => point.attributes[SERVER.address]);
+    expect(dimensionSets).toEqual(['unknown', 'unknown', 'unknown']);
   });
 
   it('carries error.type on the duration of a failed call', async () => {

--- a/packages/core/src/observability/metrics.ts
+++ b/packages/core/src/observability/metrics.ts
@@ -1,7 +1,7 @@
 import type { Attributes, Histogram, Meter } from '@opentelemetry/api';
 import { metrics } from '@opentelemetry/api';
 import type { UsageDetails } from '../types/usage.js';
-import { GEN_AI } from './attributes.js';
+import { GEN_AI, SERVER } from './attributes.js';
 import { INSTRUMENTATION_VERSION } from './version.js';
 
 /** Package identity reported on every metric this framework emits. */
@@ -82,8 +82,8 @@ const METRIC_ATTRIBUTES: readonly string[] = [
   GEN_AI.providerName,
   GEN_AI.requestModel,
   GEN_AI.responseModel,
-  'server.address',
-  'server.port',
+  SERVER.address,
+  SERVER.port,
 ];
 
 /** Keeps only the dimensions a metric may carry. */

--- a/packages/core/src/observability/tracing.test.ts
+++ b/packages/core/src/observability/tracing.test.ts
@@ -14,7 +14,7 @@ import { tool } from '../tools/tool.js';
 import { textContent } from '../types/content.js';
 import { message } from '../types/message.js';
 import { agentResponse } from '../types/response.js';
-import { GEN_AI } from './attributes.js';
+import { GEN_AI, MCP, SERVER } from './attributes.js';
 import { configureObservability, getTracer } from './settings.js';
 import { addMessageEvents, responseFinishReason, startAgentRunSpan } from './tracing.js';
 
@@ -191,6 +191,48 @@ describe('GenAI tracing', () => {
     expect(chat.attributes[GEN_AI.temperature]).toBe(0.5);
     expect(chat.attributes[GEN_AI.maxTokens]).toBe(100);
     expect(chat.attributes[GEN_AI.responseId]).toBe('resp_1');
+  });
+
+  it('spells the server keys one way for chat spans and MCP spans alike', () => {
+    // `isolatedDeclarations` forbids MCP referencing SERVER for these two, so the duplicate
+    // literals are held together here instead: one key, one vocabulary, whichever span carries it.
+    expect(MCP.serverAddress).toBe(SERVER.address);
+    expect(MCP.serverPort).toBe(SERVER.port);
+  });
+
+  it('records the endpoint host as server.address on the chat span', async () => {
+    const mock = new MockChatClient([{ contents: [textContent('hi')], finishReason: 'stop' }], {
+      providerUri: 'https://api.example.com/openai/v1',
+    });
+
+    await new Agent({ client: mock, name: 'bot' }).run('hello');
+
+    const chat = byName('chat mock-model');
+    assert.exists(chat);
+    expect(chat.attributes[SERVER.address]).toBe('api.example.com');
+    // Only the chat span names an endpoint: the agent span describes the agent, not the
+    // connection, so the reference implementations leave the address off it.
+    expect(byName('invoke_agent bot')?.attributes[SERVER.address]).toBeUndefined();
+  });
+
+  it("reports server.address as 'unknown' when the client names no endpoint", async () => {
+    const mock = new MockChatClient([{ contents: [textContent('hi')], finishReason: 'stop' }]);
+
+    await new Agent({ client: mock, name: 'bot' }).run('hello');
+
+    const chat = byName('chat mock-model');
+    assert.exists(chat);
+    expect(chat.attributes[SERVER.address]).toBe('unknown');
+  });
+
+  it("reports server.address as 'unknown' when the endpoint is not a parseable URL", async () => {
+    const mock = new MockChatClient([{ contents: [textContent('hi')], finishReason: 'stop' }], {
+      providerUri: 'api.example.com',
+    });
+
+    await new Agent({ client: mock, name: 'bot' }).run('hello');
+
+    expect(byName('chat mock-model')?.attributes[SERVER.address]).toBe('unknown');
   });
 
   it('records the tool call id and type on execute_tool', async () => {

--- a/packages/core/src/observability/tracing.test.ts
+++ b/packages/core/src/observability/tracing.test.ts
@@ -767,6 +767,19 @@ describe('gen_ai.response.finish_reasons', () => {
     await drain(new Agent({ client: new MockChatClient([toolCallTurn]), name: 'bot' }).run('q'));
     expect(byName('invoke_agent bot')?.attributes[GEN_AI.finishReasons]).toEqual(['tool_call']);
   });
+
+  it('reads a reason the provider reported only on its wire object', async () => {
+    // The resolution that finds it there also feeds the output messages and the choice events, so
+    // the attribute has to come from the same reading — otherwise one response is described by a
+    // reason on two surfaces and by nothing on the third.
+    const wireOnly = {
+      contents: [textContent('hi')],
+      rawRepresentation: { finish_reason: 'tool_calls' },
+    };
+    await new Agent({ client: new MockChatClient([wireOnly]), name: 'bot' }).run('q');
+
+    expect(byName('chat mock-model')?.attributes[GEN_AI.finishReasons]).toEqual(['tool_call']);
+  });
 });
 
 describe('message-content attributes', () => {

--- a/packages/core/src/observability/tracing.test.ts
+++ b/packages/core/src/observability/tracing.test.ts
@@ -771,7 +771,8 @@ describe('gen_ai.response.finish_reasons', () => {
   it('reads a reason the provider reported only on its wire object', async () => {
     // The resolution that finds it there also feeds the output messages and the choice events, so
     // the attribute has to come from the same reading — otherwise one response is described by a
-    // reason on two surfaces and by nothing on the third.
+    // reason on some surfaces and by nothing on the others. Every span reporting the attribute
+    // resolves it the same way, in one place.
     const wireOnly = {
       contents: [textContent('hi')],
       rawRepresentation: { finish_reason: 'tool_calls' },
@@ -779,6 +780,13 @@ describe('gen_ai.response.finish_reasons', () => {
     await new Agent({ client: new MockChatClient([wireOnly]), name: 'bot' }).run('q');
 
     expect(byName('chat mock-model')?.attributes[GEN_AI.finishReasons]).toEqual(['tool_call']);
+    // The agent span resolves the same way and still finds nothing, because an agent response's
+    // `rawRepresentation` is the update it was folded from — measured to be a `ChatResponseUpdate`
+    // carrying `contents`, `role` and ids — not the provider object the chat response held. A
+    // reason reported only on the wire therefore reaches the chat span alone. This pins that:
+    // if the agent response ever starts carrying the provider object, it fails and the difference
+    // gets a decision rather than appearing by accident.
+    expect(byName('invoke_agent bot')?.attributes[GEN_AI.finishReasons]).toBeUndefined();
   });
 });
 

--- a/packages/core/src/observability/tracing.test.ts
+++ b/packages/core/src/observability/tracing.test.ts
@@ -16,7 +16,7 @@ import { message } from '../types/message.js';
 import { agentResponse } from '../types/response.js';
 import { GEN_AI, MCP, SERVER } from './attributes.js';
 import { configureObservability, getTracer } from './settings.js';
-import { addMessageEvents, responseFinishReason, startAgentRunSpan } from './tracing.js';
+import { addMessageEvents, responseFinishReason, setMessageContent, startAgentRunSpan } from './tracing.js';
 
 const exporter = new InMemorySpanExporter();
 /** Names of spans that were *started*, whether or not they were ended. */
@@ -697,6 +697,211 @@ describe('v1.36.0 message events', () => {
     const chat = spans().find((span) => span.name === 'chat mock-model');
     assert.exists(chat);
     expect(chat.events.map((event) => event.name)).toEqual(['gen_ai.user.message']);
+  });
+});
+
+describe('gen_ai.response.finish_reasons', () => {
+  /**
+   * The four implementations disagree on this attribute's encoding, so its exact value is pinned
+   * here rather than left to the shape assertions above: Python emits the JSON text
+   * `'["tool_calls"]'`, .NET emits `'["toolcalls"]'`, and this implementation emits the native
+   * string array the semantic conventions define, with the convention's `tool_call` spelling.
+   */
+  const stopTurn = { contents: [textContent('hi')], finishReason: 'stop' };
+  /**
+   * A call the service already ran (`informationalOnly`), so the loop has nothing to execute and
+   * the run ends on the round that reported `tool_calls` — the only way both spans of one run
+   * carry the reason that needs normalizing.
+   */
+  const toolCallTurn = {
+    contents: [
+      {
+        type: 'function_call' as const,
+        callId: 'c1',
+        name: 'lookup',
+        arguments: '{}',
+        informationalOnly: true,
+      },
+    ],
+    finishReason: 'tool_calls',
+  };
+
+  async function drain(stream: AsyncIterable<unknown>): Promise<void> {
+    for await (const _ of stream) {
+      // Consume.
+    }
+  }
+
+  it('records a native string array on the chat span of an awaited run', async () => {
+    await new Agent({ client: new MockChatClient([stopTurn]), name: 'bot' }).run('q');
+    expect(byName('chat mock-model')?.attributes[GEN_AI.finishReasons]).toEqual(['stop']);
+
+    exporter.reset();
+    await new Agent({ client: new MockChatClient([toolCallTurn]), name: 'bot' }).run('q');
+    expect(byName('chat mock-model')?.attributes[GEN_AI.finishReasons]).toEqual(['tool_call']);
+  });
+
+  it('records a native string array on the chat span of a streamed run', async () => {
+    await drain(new Agent({ client: new MockChatClient([stopTurn]), name: 'bot' }).run('q'));
+    expect(byName('chat mock-model')?.attributes[GEN_AI.finishReasons]).toEqual(['stop']);
+
+    exporter.reset();
+    await drain(new Agent({ client: new MockChatClient([toolCallTurn]), name: 'bot' }).run('q'));
+    expect(byName('chat mock-model')?.attributes[GEN_AI.finishReasons]).toEqual(['tool_call']);
+  });
+
+  it('records a native string array on the invoke_agent span of an awaited run', async () => {
+    await new Agent({ client: new MockChatClient([stopTurn]), name: 'bot' }).run('q');
+    expect(byName('invoke_agent bot')?.attributes[GEN_AI.finishReasons]).toEqual(['stop']);
+
+    exporter.reset();
+    await new Agent({ client: new MockChatClient([toolCallTurn]), name: 'bot' }).run('q');
+    expect(byName('invoke_agent bot')?.attributes[GEN_AI.finishReasons]).toEqual(['tool_call']);
+  });
+
+  it('records a native string array on the invoke_agent span of a streamed run', async () => {
+    await drain(new Agent({ client: new MockChatClient([stopTurn]), name: 'bot' }).run('q'));
+    expect(byName('invoke_agent bot')?.attributes[GEN_AI.finishReasons]).toEqual(['stop']);
+
+    exporter.reset();
+    await drain(new Agent({ client: new MockChatClient([toolCallTurn]), name: 'bot' }).run('q'));
+    expect(byName('invoke_agent bot')?.attributes[GEN_AI.finishReasons]).toEqual(['tool_call']);
+  });
+});
+
+describe('message-content attributes', () => {
+  /** One transcript carrying every part kind the convention names. */
+  const transcript = [
+    message('user', [
+      textContent('hello'),
+      { type: 'text_reasoning' as const, text: 'deliberating' },
+      { type: 'data' as const, uri: 'data:image/png;base64,QUFBQQ==', mediaType: 'image/png' },
+      { type: 'uri' as const, uri: 'https://example.test/photo.png', mediaType: 'image/png' },
+    ]),
+    message('assistant', [
+      {
+        type: 'function_call' as const,
+        callId: 'c1',
+        name: 'lookup',
+        arguments: '{"token":"s3cr3t"}',
+        informationalOnly: true,
+      },
+    ]),
+    message('tool', [{ type: 'function_result' as const, callId: 'c1', result: 'confidential answer' }]),
+  ];
+
+  it('names the parts with the convention vocabulary rather than the framework content types', async () => {
+    configureObservability({ captureMessageContent: true });
+    const mock = new MockChatClient([{ contents: [textContent('ok')], finishReason: 'stop' }]);
+
+    await new Agent({ client: mock, name: 'bot' }).run(transcript);
+
+    const chat = byName('chat mock-model');
+    assert.exists(chat);
+    expect(JSON.parse(String(chat.attributes[GEN_AI.inputMessages]))).toEqual([
+      {
+        role: 'user',
+        parts: [{ type: 'text', content: 'hello' }, { type: 'reasoning' }, { type: 'blob' }, { type: 'uri' }],
+      },
+      { role: 'assistant', parts: [{ type: 'tool_call' }] },
+      { role: 'tool', parts: [{ type: 'tool_call_response' }] },
+    ]);
+    // The same vocabulary reaches the agent span, which serializes the same messages.
+    expect(JSON.parse(String(byName('invoke_agent bot')?.attributes[GEN_AI.inputMessages]))).toEqual(
+      JSON.parse(String(chat.attributes[GEN_AI.inputMessages])),
+    );
+  });
+
+  it('keeps tool payloads, blob bytes and URIs out of the serialized parts', async () => {
+    configureObservability({ captureMessageContent: true });
+    const mock = new MockChatClient([{ contents: [textContent('ok')], finishReason: 'stop' }]);
+
+    await new Agent({ client: mock, name: 'bot' }).run(transcript);
+
+    // What the compact form deliberately drops: a dashboard reads these from the transcript, not
+    // from a trace, so credentials inside tool arguments never reach a span.
+    const serialized = String(byName('chat mock-model')?.attributes[GEN_AI.inputMessages]);
+    expect(serialized).not.toContain('s3cr3t');
+    expect(serialized).not.toContain('confidential answer');
+    expect(serialized).not.toContain('QUFBQQ==');
+    expect(serialized).not.toContain('example.test');
+    expect(serialized).not.toContain('image/png');
+    expect(serialized).not.toContain('c1');
+    expect(serialized).not.toContain('lookup');
+  });
+
+  it('stamps the finish reason on the final output message of the chat span only', async () => {
+    configureObservability({ captureMessageContent: true });
+    const mock = new MockChatClient([{ contents: [textContent('done')], finishReason: 'tool_calls' }]);
+
+    await new Agent({ client: mock, name: 'bot' }).run('q');
+
+    const chat = byName('chat mock-model');
+    assert.exists(chat);
+    expect(JSON.parse(String(chat.attributes[GEN_AI.outputMessages]))).toEqual([
+      { role: 'assistant', parts: [{ type: 'text', content: 'done' }], finish_reason: 'tool_call' },
+    ]);
+    // Input messages describe what was sent, so they never carry one.
+    for (const input of JSON.parse(String(chat.attributes[GEN_AI.inputMessages]))) {
+      expect(input).not.toHaveProperty('finish_reason');
+    }
+    // The agent span leaves it off: the reference implementations pass the reason to the chat
+    // serialization alone.
+    expect(JSON.parse(String(byName('invoke_agent bot')?.attributes[GEN_AI.outputMessages]))).toEqual([
+      { role: 'assistant', parts: [{ type: 'text', content: 'done' }] },
+    ]);
+  });
+
+  it('stamps the finish reason on the last message only', () => {
+    configureObservability({ captureMessageContent: true });
+    const span = getTracer().startSpan('chat test');
+    setMessageContent(
+      span,
+      GEN_AI.outputMessages,
+      [message('assistant', [textContent('a')]), message('assistant', [textContent('b')])],
+      'stop',
+    );
+    span.end();
+
+    expect(JSON.parse(String(byName('chat test')?.attributes[GEN_AI.outputMessages]))).toEqual([
+      { role: 'assistant', parts: [{ type: 'text', content: 'a' }] },
+      { role: 'assistant', parts: [{ type: 'text', content: 'b' }], finish_reason: 'stop' },
+    ]);
+  });
+
+  it('omits the message attributes on the chat span until capture is opted in', async () => {
+    const mock = new MockChatClient([{ contents: [textContent('secret answer')], finishReason: 'stop' }]);
+
+    await new Agent({ client: mock, name: 'bot' }).run('secret question');
+
+    const chat = byName('chat mock-model');
+    assert.exists(chat);
+    expect(chat.attributes[GEN_AI.inputMessages]).toBeUndefined();
+    expect(chat.attributes[GEN_AI.outputMessages]).toBeUndefined();
+    expect(chat.attributes[GEN_AI.systemInstructions]).toBeUndefined();
+  });
+});
+
+describe('server.port', () => {
+  it('is emitted by no span this framework starts', async () => {
+    const mock = new MockChatClient([{ contents: [textContent('hi')], finishReason: 'stop' }], {
+      providerUri: 'https://api.example.com:8443/v1',
+    });
+
+    await new Agent({ client: mock, name: 'bot' }).run('hello');
+
+    // Deliberate: the endpoint's port is not reported anywhere, on any span, even when the
+    // endpoint names one. The key stays in the metric dimension allowlist as a forward
+    // declaration, and `metricDimensions` skips a key with no value.
+    //
+    // Known non-conformance: the semantic conventions make `server.port` conditionally required
+    // once `server.address` is present. Emitting it is a separate decision, because the port is
+    // also a histogram dimension and the reference implementations disagree on whether to report
+    // it at all.
+    for (const span of spans()) {
+      expect(span.attributes[SERVER.port]).toBeUndefined();
+    }
+    expect(byName('chat mock-model')?.attributes[SERVER.address]).toBe('api.example.com');
   });
 });
 

--- a/packages/core/src/observability/tracing.ts
+++ b/packages/core/src/observability/tracing.ts
@@ -42,24 +42,55 @@ export function setResponseAttributes(
   setUsageAttributes(span, response.usageDetails);
 }
 
+/**
+ * The `type` the convention gives a part, for the framework content types it names.
+ *
+ * The framework's own content vocabulary is not the convention's: `text_reasoning`, `data`,
+ * `function_call` and `function_result` are internal spellings, and a dashboard querying parts by
+ * type has to see the same word here as it does in a Python or .NET trace. Anything the convention
+ * does not name keeps its framework type, which is what both reference implementations do with
+ * their generic parts.
+ */
+const OTEL_PART_TYPE: Readonly<Record<string, string>> = {
+  text: 'text',
+  text_reasoning: 'reasoning',
+  data: 'blob',
+  uri: 'uri',
+  function_call: 'tool_call',
+  function_result: 'tool_call_response',
+};
+
 /** One part of the sensitive-data serialization: only the field the convention asks for. */
 function spanPart(content: Content): { type: string; content?: string } {
-  return content.type === 'text' ? { type: 'text', content: content.text } : { type: content.type };
+  const type = OTEL_PART_TYPE[content.type] ?? content.type;
+  return content.type === 'text' ? { type, content: content.text } : { type };
 }
 
 /** One message of the sensitive-data serialization, as a JSON object string. */
-function serializeMessageForSpan(msg: Message): string {
-  return JSON.stringify({ role: msg.role, parts: msg.contents.map(spanPart) });
+function serializeMessageForSpan(msg: Message, finishReason: string | undefined): string {
+  return JSON.stringify({
+    role: msg.role,
+    parts: msg.contents.map(spanPart),
+    ...(finishReason === undefined || finishReason === ''
+      ? {}
+      : { finish_reason: otelFinishReason(finishReason) }),
+  });
 }
 
 /**
- * Serializes messages for the sensitive-data attributes.
+ * Serializes messages for the sensitive-data attributes, stamping `finishReason` on the last one.
  *
  * Only the fields the convention asks for, so a span does not carry provider objects or base64
  * payloads: those belong in the transcript, not in a trace.
+ *
+ * The reason goes on the final message alone, the position Python stamps it in — it describes how
+ * the response ended, not how each message did.
  */
-function serializeMessagesForSpan(messages: readonly Message[]): string {
-  return `[${messages.map(serializeMessageForSpan).join(',')}]`;
+function serializeMessagesForSpan(messages: readonly Message[], finishReason: string | undefined): string {
+  const last = messages.length - 1;
+  return `[${messages
+    .map((msg, index) => serializeMessageForSpan(msg, index === last ? finishReason : undefined))
+    .join(',')}]`;
 }
 
 /**
@@ -80,12 +111,22 @@ export function capturesContent(span: Span): boolean {
  * emitted solely on the `chat` span, while this attribute form goes on both the `invoke_agent`
  * and `chat` spans — the split the reference implementations settled on for their message
  * telemetry.
+ *
+ * `finishReason` is stamped on the last message, normalized the same way
+ * `gen_ai.response.finish_reasons` is. Only the `chat` span passes one: the reference
+ * implementations hand the reason to the model call's serialization and leave the agent span's
+ * output messages without it.
  */
-export function setMessageContent(span: Span, key: string, messages: readonly Message[]): void {
+export function setMessageContent(
+  span: Span,
+  key: string,
+  messages: readonly Message[],
+  finishReason?: string,
+): void {
   if (messages.length === 0 || !capturesContent(span)) {
     return;
   }
-  span.setAttribute(key, serializeMessagesForSpan(messages));
+  span.setAttribute(key, serializeMessagesForSpan(messages, finishReason));
 }
 
 /**
@@ -550,9 +591,15 @@ export function startAgentRunSpan(
   };
 }
 
-/** Records the outcome of a chat call on its span. */
-export function finishChatSpan(span: Span, response: ChatResponse<unknown>): void {
+/**
+ * Records the outcome of a chat call on its span.
+ *
+ * `finishReason` is the value {@link responseFinishReason} resolved for this response; the caller
+ * passes it in so the output messages, the message events and `gen_ai.response.finish_reasons` all
+ * report one reading of one response.
+ */
+export function finishChatSpan(span: Span, response: ChatResponse<unknown>, finishReason?: string): void {
   setResponseAttributes(span, response);
   setAttr(span, GEN_AI.conversationId, response.conversationId);
-  setMessageContent(span, GEN_AI.outputMessages, response.messages);
+  setMessageContent(span, GEN_AI.outputMessages, response.messages, finishReason);
 }

--- a/packages/core/src/observability/tracing.ts
+++ b/packages/core/src/observability/tracing.ts
@@ -601,9 +601,11 @@ export function startAgentRunSpan(
 /**
  * Records the outcome of a chat call on its span.
  *
- * `finishReason` is the value {@link responseFinishReason} resolved for this response; the caller
- * passes it in so the output messages, the message events and `gen_ai.response.finish_reasons` all
- * report one reading of one response.
+ * `finishReason` stamps the last output message, and nothing else here: the attribute is set from
+ * {@link setResponseAttributes}, which resolves the reason itself, and the message events are the
+ * caller's to add. Pass {@link responseFinishReason} of the same response — the caller resolves it
+ * once for the events too — so the message and the events read the response the same way the
+ * attribute does.
  */
 export function finishChatSpan(span: Span, response: ChatResponse<unknown>, finishReason?: string): void {
   setResponseAttributes(span, response);

--- a/packages/core/src/observability/tracing.ts
+++ b/packages/core/src/observability/tracing.ts
@@ -29,15 +29,22 @@ function setUsageAttributes(span: Span, usage: UsageDetails | undefined): void {
   setAttr(span, GEN_AI.reasoningOutputTokens, usage.reasoningOutputTokenCount);
 }
 
-/** Records what a response reported: id, model, why it stopped, and what it cost. */
+/**
+ * Records what a response reported: id, model, why it stopped, and what it cost.
+ *
+ * The finish reason is resolved rather than read straight off the field, so a provider that reports
+ * it only on its wire object is described the same way here as it is anywhere else the reason is
+ * read. Every span that reports one goes through this, which is what keeps them agreeing.
+ */
 export function setResponseAttributes(
   span: Span,
   response: ResponseBase<unknown> & { model?: string },
 ): void {
   setAttr(span, GEN_AI.responseId, response.responseId);
   setAttr(span, GEN_AI.responseModel, response.model);
-  if (response.finishReason !== undefined) {
-    span.setAttribute(GEN_AI.finishReasons, [otelFinishReason(response.finishReason)]);
+  const finishReason = responseFinishReason(response);
+  if (finishReason !== undefined && finishReason !== '') {
+    span.setAttribute(GEN_AI.finishReasons, [otelFinishReason(finishReason)]);
   }
   setUsageAttributes(span, response.usageDetails);
 }
@@ -600,13 +607,6 @@ export function startAgentRunSpan(
  */
 export function finishChatSpan(span: Span, response: ChatResponse<unknown>, finishReason?: string): void {
   setResponseAttributes(span, response);
-  // Restated from the resolved reason, which `setResponseAttributes` cannot see: it reads the
-  // response field, while a provider that reports the reason only on its wire object is exactly
-  // what the resolution exists for. Without this the messages below and the choice events would
-  // name a reason this attribute never mentioned.
-  if (finishReason !== undefined && finishReason !== '') {
-    span.setAttribute(GEN_AI.finishReasons, [otelFinishReason(finishReason)]);
-  }
   setAttr(span, GEN_AI.conversationId, response.conversationId);
   setMessageContent(span, GEN_AI.outputMessages, response.messages, finishReason);
 }

--- a/packages/core/src/observability/tracing.ts
+++ b/packages/core/src/observability/tracing.ts
@@ -600,6 +600,13 @@ export function startAgentRunSpan(
  */
 export function finishChatSpan(span: Span, response: ChatResponse<unknown>, finishReason?: string): void {
   setResponseAttributes(span, response);
+  // Restated from the resolved reason, which `setResponseAttributes` cannot see: it reads the
+  // response field, while a provider that reports the reason only on its wire object is exactly
+  // what the resolution exists for. Without this the messages below and the choice events would
+  // name a reason this attribute never mentioned.
+  if (finishReason !== undefined && finishReason !== '') {
+    span.setAttribute(GEN_AI.finishReasons, [otelFinishReason(finishReason)]);
+  }
   setAttr(span, GEN_AI.conversationId, response.conversationId);
   setMessageContent(span, GEN_AI.outputMessages, response.messages, finishReason);
 }

--- a/packages/foundry/src/chat-client.test.ts
+++ b/packages/foundry/src/chat-client.test.ts
@@ -76,6 +76,7 @@ describe('FoundryChatClient', () => {
     expect(deployment.metadata).toEqual({
       providerName: 'azure.ai.foundry',
       modelId: 'gpt-4o',
+      providerUri: `${PROJECT}/openai/v1/`,
       stableConversationId: expect.any(Function),
     });
   });
@@ -122,6 +123,9 @@ describe('FoundryChatClient', () => {
 
     expect(server.baseURL).toBe(`${PROJECT}/agents/support-bot/endpoint/protocols/openai/`);
     expect(server.metadata.modelId).toBeUndefined();
+    // The resolved project endpoint, inherited from the Responses client: telemetry derives
+    // `server.address` from it, so a Foundry span names the project host rather than 'unknown'.
+    expect(server.metadata.providerUri).toBe(server.baseURL);
   });
 
   it('omits model from a server agent request body', () => {

--- a/packages/openai/src/chat-client.test.ts
+++ b/packages/openai/src/chat-client.test.ts
@@ -791,6 +791,16 @@ describe('OpenAIChatClient configuration', () => {
     ).toBe('azure.ai.openai');
   });
 
+  it('reports the endpoint so telemetry can name the server it called', () => {
+    // The endpoint verbatim, not its host: `server.address` is derived from this in one place, in
+    // core, so every provider reports that attribute the same way.
+    const client = new OpenAIChatClient({
+      client: fakeClient(vi.fn(), 'https://my-resource.openai.azure.com/openai/v1'),
+      model: 'm',
+    });
+    expect(client.metadata.providerUri).toBe('https://my-resource.openai.azure.com/openai/v1');
+  });
+
   it('recognizes an AzureOpenAI client by type, including subclasses behind a non-Azure gateway', () => {
     // The baseURL deliberately looks nothing like an Azure host: only the client type gives it away.
     const azureOptions = {

--- a/packages/openai/src/chat-client.ts
+++ b/packages/openai/src/chat-client.ts
@@ -272,9 +272,11 @@ export class OpenAIChatClient
       });
     this.#model = config.model;
     this.#includeReasoningEncryptedContent = config.includeReasoningEncryptedContent ?? true;
+    const baseURL = String(this.#client.baseURL ?? '');
     this.metadata = {
       providerName: detectProviderName(this.#client),
       ...(config.model === undefined ? {} : { modelId: config.model }),
+      ...(baseURL === '' ? {} : { providerUri: baseURL }),
       stableConversationId: isConversationObjectId,
     };
   }


### PR DESCRIPTION
## What this changes

Fixes #109, which held three independent telemetry questions. Two are settled by retaining what
TypeScript does and documenting why; one is implemented.

**`server.address` is now reported** on chat spans and on the chat token/duration histograms, from a
new optional `ChatClientMetadata.providerUri`. The key was already on the metric allowlist with
nothing producing it. It is set once, on the object both the span and the metric dimensions read, so
one call reports one address by construction.

**`gen_ai.response.finish_reasons` keeps its shape** — a native `string[]` with `tool_calls`
normalized to `tool_call`. The three reference implementations do not agree with each other
(Python `'["tool_calls"]'`, .NET `'["toolcalls"]'`, Go emits nothing), so there is no shape to align
to; `string[]` is what the convention defines, and a JSON-encoded string would force every dashboard
to parse before it can filter. The difference is documented, and exact-value tests now cover chat and
`invoke_agent` across awaited and streamed — the `tool_calls` → `tool_call` normalization previously
had no test at all.

**Message parts stay compact**, with two gaps closed. Going rich was measured at 285 → 40,793 bytes
(143×) for one round carrying an image, because a `blob` part inlines the whole payload into a span
attribute, where most backends truncate — losing the entire message list rather than one part — and
it would newly expose tool-call arguments and OAuth consent links to the trace backend. What is
closed instead: part `type` values now use the convention's vocabulary, which Python, .NET and the
convention all agree on and only TypeScript spelled internally; and the final output message of the
chat span carries its `finish_reason`, the position and scope Python uses.

**`server.port` stays unimplemented**, per the issue's instruction to settle it on semconv/.NET
grounds rather than Python parity. Its absence is now pinned by tests across every span this
framework starts and both histograms, and the known non-conformance is recorded: the convention makes
it conditionally required once `server.address` is set.

## Parity

- Reference checked: Python `observability.py` — `_to_otel_part_latest_experimental` for every part
  name, the last-message `finish_reason` stamp, `FINISH_REASON_MAP`, the chat-only `finish_reason=`
  call sites versus the two `invoke_agent` ones that omit it, and `server.address` from `service_url`
  with an `"unknown"` fallback. .NET `OtelMessageParts.cs` / `OtelMessageSerializer.cs` for the same
  part names and `ProviderUri.Host` for the address; its agent span inherits the chat tags only
  because `OpenTelemetryAgent` relabels the chat activity instead of starting its own, which this
  codebase does not do. Go's otelprovider emits no chat span and no `server.*` at all.
- Deliberate divergences: `server.address` carries the endpoint's host rather than the raw URL Python
  writes — the convention defines this stable key as a host, .NET derives the host, this repo's MCP
  spans already emit `url.hostname` for the same key, and it is a metric dimension where full URLs
  would split each histogram series per deployment path. Content types the convention does not name
  keep their framework spelling, which is what both references do with their generic parts.
- Wire format affected: no
- Public API affected: yes
- Breaking change: yes

`ChatClientMetadata.providerUri` is new and optional; a client that omits it reports `"unknown"`.

What breaks: the `type` value inside `gen_ai.input.messages` / `gen_ai.output.messages` parts, and
only when message capture is opted in. `text_reasoning` → `reasoning`, `data` → `blob`,
`function_call` → `tool_call`, `function_result` → `tool_call_response`; `text` and `uri` are
unchanged. A dashboard filtering parts by type needs those four spellings updated. No part gained a
payload field, and no other attribute, event or metric changed.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`
