### PR TITLE
Coalesce streamed code-interpreter fragments by call id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,21 @@ contain breaking changes**; patch releases are fixes only.
   still deliberately emitted by nothing, on spans and on metric dimensions alike, and its absence
   is now pinned by tests.
 
+- **`@polymind-inc/agent-framework-core`** — a streamed code-interpreter call now folds back into
+  one item. `coalesceContents`, and with it `mergeUpdates` / `mergeChatUpdates`, previously left
+  every `code_interpreter_tool_call` and `code_interpreter_tool_result` fragment in the transcript,
+  so a provider that streams the code as deltas produced a list of partial calls where the awaited
+  form of the same turn holds one. Fragments are now correlated by their content type together with
+  `callId`, falling back to `additionalProperties.item_id` when the provider streams no call id,
+  and fold into the first fragment with that key — which keeps its position, so narration that
+  arrived between the fragments stays where it was. `inputs` and `outputs` merge the way Python's
+  `_merge_content_item_lists` does: text-only lists collapse to the longer side when one is a
+  prefix of the other (the `done` event repeating the whole code replaces its own deltas instead of
+  being appended to them), disjoint text is joined, and anything else is concatenated;
+  `additionalProperties` merge with the later fragment winning and annotations are concatenated.
+  Fragments naming different calls, a call and a result naming one id, and fragments naming nothing
+  at all are all left exactly as they arrived. The other content types coalesce as before.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/packages/core/src/types/coalesce.ts
+++ b/packages/core/src/types/coalesce.ts
@@ -1,6 +1,8 @@
 import { decodeBase64, encodeBase64 } from './base64.js';
 import type {
+  Annotation,
   Content,
+  ContentBase,
   DataContent,
   FunctionCallContent,
   TextContent,
@@ -36,10 +38,11 @@ function withOptionalProps<T extends object>(base: T, props: Record<string, unkn
 }
 
 /**
- * A content item participates in coalescing only when it carries no annotations.
+ * A content item joins a positional run only when it carries no annotations.
  *
  * Merging annotated items would invalidate their span offsets, so the reference implementations
- * (Go `message.coalesce`) leave them alone.
+ * (Go `message.coalesce`) leave them alone. The keyed code-interpreter pass is not gated on this
+ * — see {@link coalesceCodeInterpreter} for why its items have no offsets to invalidate.
  */
 function coalescable(content: Content): boolean {
   return content.annotations === undefined || content.annotations.length === 0;
@@ -299,6 +302,175 @@ const RULES: Rule[] = [
   },
 ];
 
+/**
+ * The two code-interpreter contents, seen through the fields the keyed pass merges.
+ *
+ * `inputs` belongs to the call and `outputs` to the result; one shape covers both because the
+ * merge rule is identical on either side and each field is folded only when a fragment has it.
+ */
+interface CodeInterpreterFragment extends ContentBase {
+  type: 'code_interpreter_tool_call' | 'code_interpreter_tool_result';
+  callId?: string;
+  inputs?: Content[];
+  outputs?: Content[];
+}
+
+function isCodeInterpreter(content: Content): content is CodeInterpreterFragment {
+  return content.type === 'code_interpreter_tool_call' || content.type === 'code_interpreter_tool_result';
+}
+
+/**
+ * What correlates two code-interpreter fragments, or `undefined` when nothing does.
+ *
+ * The provider's own call id wins; a streamed fragment that carries none is keyed by the
+ * `item_id` its provider metadata reports, which is what a Responses-style
+ * `code_interpreter_call_code.delta` puts there. An empty or non-string value names no call, so
+ * the fragment is left alone rather than folded into whichever fragment happens to be keyless
+ * too (Python `_code_interpreter_key`).
+ */
+function codeInterpreterKey(content: CodeInterpreterFragment): string | undefined {
+  const callId = content.callId;
+  const key = callId === undefined || callId === '' ? content.additionalProperties?.item_id : callId;
+  return typeof key === 'string' && key !== '' ? key : undefined;
+}
+
+/** The concatenated text of `items`, or `undefined` when they are not all text. */
+function contentItemsText(items: readonly Content[]): string | undefined {
+  let text = '';
+  for (const item of items) {
+    if (item.type !== 'text') {
+      return undefined;
+    }
+    text += item.text;
+  }
+  return text;
+}
+
+/**
+ * Folds one streamed `inputs` or `outputs` list into what the run has accumulated.
+ *
+ * The shape of the list decides how. A text-only list is one growing string, so when either side
+ * is a prefix of the other the longer side wins outright: a `done` event repeats the whole code
+ * its deltas spelled out, and appending that would put the program in twice. Only genuinely
+ * disjoint text is concatenated. Any other list — logs next to a generated image — is appended,
+ * because those are separate results rather than fragments of one.
+ *
+ * Ported from Python `_merge_content_item_lists`. Go takes the other route for this merge
+ * (`message.CoalesceContents` concatenates the lists and re-runs itself over them).
+ */
+function mergeContentItemLists(
+  existing: Content[] | undefined,
+  incoming: Content[] | undefined,
+): Content[] | undefined {
+  if (incoming === undefined) {
+    return existing;
+  }
+  if (existing === undefined) {
+    return incoming;
+  }
+  const existingText = contentItemsText(existing);
+  const incomingText = contentItemsText(incoming);
+  if (existingText !== undefined && incomingText !== undefined) {
+    if (incomingText.startsWith(existingText)) {
+      return incoming;
+    }
+    if (existingText.startsWith(incomingText)) {
+      return existing;
+    }
+    // Disjoint text: keep the first item's metadata and give it the joined string. `existing` is
+    // non-empty here — an empty list has empty text, which is a prefix of everything.
+    return [{ ...(existing[0] as TextContent), text: existingText + incomingText }];
+  }
+  return [...existing, ...incoming];
+}
+
+function combineAnnotations(
+  a: Annotation[] | undefined,
+  b: Annotation[] | undefined,
+): Annotation[] | undefined {
+  if (a === undefined) {
+    return b;
+  }
+  return b === undefined ? a : [...a, ...b];
+}
+
+/**
+ * Folds `incoming` into the fragment that opened the run.
+ *
+ * The first fragment's remaining fields are kept as they are — its `callId`, and its
+ * `rawRepresentation`, which stays the provider object this call was first seen as (Go keeps the
+ * first item's header for the same merge; Python accumulates a list, a shape this framework does
+ * not give `rawRepresentation`, which it neither serializes nor compares).
+ */
+function mergeCodeInterpreter(
+  existing: CodeInterpreterFragment,
+  incoming: CodeInterpreterFragment,
+): CodeInterpreterFragment {
+  const merged: CodeInterpreterFragment = { ...existing };
+  const inputs = mergeContentItemLists(existing.inputs, incoming.inputs);
+  if (inputs !== undefined) {
+    merged.inputs = inputs;
+  }
+  const outputs = mergeContentItemLists(existing.outputs, incoming.outputs);
+  if (outputs !== undefined) {
+    merged.outputs = outputs;
+  }
+  const annotations = combineAnnotations(existing.annotations, incoming.annotations);
+  if (annotations !== undefined) {
+    merged.annotations = annotations;
+  }
+  const props = mergeAdditionalProperties(existing.additionalProperties, incoming.additionalProperties);
+  if (props !== undefined) {
+    merged.additionalProperties = props;
+  }
+  return merged;
+}
+
+/**
+ * Merges code-interpreter call and result fragments that name the same call.
+ *
+ * This one is keyed rather than positional: a provider interleaves the code it is running with
+ * the text it is narrating, so the fragments of one call are not adjacent and the run-based rules
+ * would never see them together. Each key's fragments fold into the first one, which keeps its
+ * place in the transcript, and fragments naming different calls — or naming nothing — stay
+ * separate. Ported from Python `_coalesce_code_interpreter_content`.
+ *
+ * Unlike every other rule here, an annotated fragment still merges: these items carry no text of
+ * their own, so there are no span offsets for a merge to invalidate, and Python concatenates the
+ * annotations onto the folded item.
+ */
+function coalesceCodeInterpreter(contents: Content[]): Content[] {
+  const out: Content[] = [];
+  // Content type, then call id, to the index the first fragment with that key took in `out`: a
+  // call and a result naming one id are two separate items, so the type is part of the key.
+  const firstOfKey = new Map<string, Map<string, number>>();
+  for (const content of contents) {
+    if (!isCodeInterpreter(content)) {
+      out.push(content);
+      continue;
+    }
+    const key = codeInterpreterKey(content);
+    if (key === undefined) {
+      out.push(content);
+      continue;
+    }
+    let byKey = firstOfKey.get(content.type);
+    if (byKey === undefined) {
+      byKey = new Map();
+      firstOfKey.set(content.type, byKey);
+    }
+    const at = byKey.get(key);
+    if (at === undefined) {
+      // A fragment nothing joins is left exactly as it arrived, like a run of one above.
+      byKey.set(key, out.length);
+      out.push(content);
+      continue;
+    }
+    out[at] = mergeCodeInterpreter(out[at] as CodeInterpreterFragment, content);
+  }
+  return out;
+}
+
 function applyRule(contents: Content[], rule: Rule): Content[] {
   const out: Content[] = [];
   const participates = rule.coalescable ?? coalescable;
@@ -328,10 +500,10 @@ function applyRule(contents: Content[], rule: Rule): Content[] {
 }
 
 /**
- * Merges adjacent compatible content items.
+ * Merges compatible content items back into the logical items a provider streamed as fragments.
  *
- * Streaming providers emit content in fragments: text deltas, reasoning deltas and partial
- * function-call argument strings. Coalescing rebuilds the logical items:
+ * Most rules are positional — text deltas, reasoning deltas and partial function-call argument
+ * strings arrive back to back:
  *
  * - consecutive `text` items are concatenated;
  * - consecutive `text_reasoning` items are concatenated when their ids agree and they are the same
@@ -341,9 +513,15 @@ function applyRule(contents: Content[], rule: Rule): Content[] {
  *   arguments shallow-merged) when their `callId`s agree;
  * - consecutive textual `data` items with the same media type and name are concatenated.
  *
- * Items carrying {@link Annotation}s are never merged — with one exception, an *empty* annotated
- * text item, which is how a streamed citation arrives (see {@link coalescableText}). A run of a
- * single item is returned unchanged. Matches Go `message.CoalesceContents`.
+ * Items carrying {@link Annotation}s are never merged by those rules — with one exception, an
+ * *empty* annotated text item, which is how a streamed citation arrives (see
+ * {@link coalescableText}). A positional run of a single item is returned unchanged. Matches Go
+ * `message.CoalesceContents`.
+ *
+ * Code-interpreter fragments are keyed instead: `code_interpreter_tool_call` and
+ * `code_interpreter_tool_result` items naming the same call — by `callId`, or by
+ * `additionalProperties.item_id` when the provider streams no call id — fold into the first of
+ * them wherever it sits, even with narration in between (see {@link coalesceCodeInterpreter}).
  *
  * @param contents - The content list to coalesce. Not mutated.
  * @returns A new list.
@@ -353,5 +531,5 @@ export function coalesceContents(contents: readonly Content[]): Content[] {
   for (const rule of RULES) {
     result = applyRule(result, rule);
   }
-  return result;
+  return coalesceCodeInterpreter(result);
 }

--- a/packages/core/src/types/response.test.ts
+++ b/packages/core/src/types/response.test.ts
@@ -1,6 +1,7 @@
 import { assert, describe, expect, it } from 'vitest';
 import { decodeBase64 } from './base64.js';
 import { coalesceContents } from './coalesce.js';
+import type { Content } from './content.js';
 import { dataContent, textContent, unknownContent } from './content.js';
 import type { AgentResponseUpdate, ChatResponseUpdate } from './response.js';
 import {
@@ -401,6 +402,158 @@ describe('coalesceContents', () => {
     expect(merged).toEqual([
       { type: 'text_reasoning', id: 'rs_1', text: 'ab' },
       { type: 'text_reasoning', id: 'rs_2', text: 'c' },
+    ]);
+  });
+
+  it('replaces code-interpreter deltas with the later full value for the same call', () => {
+    // The streamed shape a Responses-style provider emits: argument deltas followed by a `done`
+    // event repeating the whole code. Concatenating them would run `print(print(1))`. The merged
+    // item keeps the first fragment's raw representation, the object the call was first seen as.
+    const merged = coalesceContents([
+      {
+        type: 'code_interpreter_tool_call',
+        callId: 'ci_1',
+        inputs: [textContent('print(')],
+        rawRepresentation: { event: 'delta' },
+      },
+      {
+        type: 'code_interpreter_tool_call',
+        callId: 'ci_1',
+        inputs: [textContent('print(1)')],
+        rawRepresentation: { event: 'done' },
+      },
+    ]);
+    expect(merged).toEqual([
+      {
+        type: 'code_interpreter_tool_call',
+        callId: 'ci_1',
+        inputs: [textContent('print(1)')],
+        rawRepresentation: { event: 'delta' },
+      },
+    ]);
+  });
+
+  it('merges code-interpreter fragments separated by other content at the first occurrence', () => {
+    const merged = coalesceContents([
+      { type: 'code_interpreter_tool_call', callId: 'ci_1', inputs: [textContent('pri')] },
+      textContent('running it now'),
+      { type: 'code_interpreter_tool_call', callId: 'ci_1', inputs: [textContent('nt(1)')] },
+    ]);
+    expect(merged).toEqual([
+      { type: 'code_interpreter_tool_call', callId: 'ci_1', inputs: [textContent('print(1)')] },
+      textContent('running it now'),
+    ]);
+  });
+
+  it('keeps code-interpreter fragments apart when the type or the id differs', () => {
+    const merged = coalesceContents([
+      { type: 'code_interpreter_tool_call', callId: 'ci_1', inputs: [textContent('a')] },
+      { type: 'code_interpreter_tool_call', callId: 'ci_2', inputs: [textContent('b')] },
+      // Same id as the first fragment, but a result is not a call: the key is the pair.
+      { type: 'code_interpreter_tool_result', callId: 'ci_1', outputs: [textContent('c')] },
+    ]);
+    expect(merged).toEqual([
+      { type: 'code_interpreter_tool_call', callId: 'ci_1', inputs: [textContent('a')] },
+      { type: 'code_interpreter_tool_call', callId: 'ci_2', inputs: [textContent('b')] },
+      { type: 'code_interpreter_tool_result', callId: 'ci_1', outputs: [textContent('c')] },
+    ]);
+  });
+
+  it('keys a code-interpreter fragment by its item id when it carries no call id', () => {
+    const merged = coalesceContents([
+      {
+        type: 'code_interpreter_tool_result',
+        outputs: [textContent('one')],
+        additionalProperties: { item_id: 'ci_1', sequence_number: 1 },
+      },
+      {
+        type: 'code_interpreter_tool_result',
+        outputs: [textContent(' two')],
+        additionalProperties: { item_id: 'ci_1', sequence_number: 2 },
+      },
+    ]);
+    expect(merged).toEqual([
+      {
+        type: 'code_interpreter_tool_result',
+        outputs: [textContent('one two')],
+        additionalProperties: { item_id: 'ci_1', sequence_number: 2 },
+      },
+    ]);
+  });
+
+  it('leaves keyless code-interpreter fragments untouched', () => {
+    // Nothing names these calls, so folding them together would invent a correlation. Each pair
+    // shares the same absent key, which is what a rule that keyed on `undefined`, on `''` or on a
+    // non-string `item_id` would happily merge.
+    const fragments: Content[] = [
+      { type: 'code_interpreter_tool_call', inputs: [textContent('a')] },
+      { type: 'code_interpreter_tool_call', inputs: [textContent('b')] },
+      { type: 'code_interpreter_tool_call', callId: '', inputs: [textContent('c')] },
+      { type: 'code_interpreter_tool_call', callId: '', inputs: [textContent('d')] },
+      {
+        type: 'code_interpreter_tool_call',
+        additionalProperties: { item_id: 7 },
+        inputs: [textContent('e')],
+      },
+      {
+        type: 'code_interpreter_tool_call',
+        additionalProperties: { item_id: 7 },
+        inputs: [textContent('f')],
+      },
+    ];
+    const merged = coalesceContents(fragments);
+    expect(merged).toEqual(fragments);
+    expect(merged[0]).toBe(fragments[0]);
+  });
+
+  it('merges annotated code-interpreter fragments, combining their annotations', () => {
+    // The offset rule that keeps annotated text apart does not reach here: these items hold no
+    // text of their own, so Python merges them and concatenates the annotations.
+    const merged = coalesceContents([
+      {
+        type: 'code_interpreter_tool_result',
+        callId: 'ci_1',
+        outputs: [textContent('out')],
+        annotations: [{ type: 'citation', title: 'first' }],
+      },
+      {
+        type: 'code_interpreter_tool_result',
+        callId: 'ci_1',
+        outputs: [{ type: 'data', uri: 'data:image/png;base64,AAA=', mediaType: 'image/png' }],
+        annotations: [{ type: 'citation', title: 'second' }],
+      },
+    ]);
+    expect(merged).toEqual([
+      {
+        type: 'code_interpreter_tool_result',
+        callId: 'ci_1',
+        outputs: [
+          textContent('out'),
+          { type: 'data', uri: 'data:image/png;base64,AAA=', mediaType: 'image/png' },
+        ],
+        annotations: [
+          { type: 'citation', title: 'first' },
+          { type: 'citation', title: 'second' },
+        ],
+      },
+    ]);
+  });
+
+  it('folds streamed code-interpreter fragments through mergeUpdates', () => {
+    const response = mergeUpdates([
+      update({
+        contents: [{ type: 'code_interpreter_tool_call', callId: 'ci_1', inputs: [textContent('1+')] }],
+      }),
+      update({
+        contents: [{ type: 'code_interpreter_tool_call', callId: 'ci_1', inputs: [textContent('1+1')] }],
+      }),
+      update({
+        contents: [{ type: 'code_interpreter_tool_result', callId: 'ci_1', outputs: [textContent('2')] }],
+      }),
+    ]);
+    expect(response.messages[0]?.contents).toEqual([
+      { type: 'code_interpreter_tool_call', callId: 'ci_1', inputs: [textContent('1+1')] },
+      { type: 'code_interpreter_tool_result', callId: 'ci_1', outputs: [textContent('2')] },
     ]);
   });
 });


### PR DESCRIPTION
## What this changes

Part of #113 — completes the **core / coalesce — code interpreter** item.

`coalesceContents` folded a stream by position only, so code-interpreter call and result fragments
arrived in the transcript as several partial items instead of one. A keyed pass now merges fragments
sharing a content type and a `callId` — or, when the call id is absent, an
`additionalProperties.item_id` — at the first occurrence, so fragments separated by other content
still fold together. Different types, different ids and keyless items are left exactly as they were.

No in-repo provider currently emits multiple fragments per key today: the OpenAI client reconstructs
these at `response.output_item.done` and the Anthropic client defers the whole call until its block
closes. The gap is real for `coalesceContents` as public API, for a transcript a Python client
wrote, and for a third-party client built on the framework.

## Parity

- Reference checked: Python `_coalesce_code_interpreter_content`, branch for branch — the
  first-occurrence `seen` map, the `_code_interpreter_key` type gate and `item_id` fallback, and all
  five branches of `_merge_content_item_lists`. Go's equivalent is adjacent-only, keyed on `CallID`
  alone, excludes annotated items and re-coalesces concatenated inputs, so it cannot drop a `done`
  event repeating the whole payload; not followed, and the comments say why. .NET has no equivalent.
- Deliberate divergences from Python: `rawRepresentation` keeps the first fragment's value rather
  than accumulating a list, because this framework never serializes or compares it and gives it no
  list shape — Go keeps the first too. A lone fragment is returned by identity rather than
  deep-copied, matching the existing rule that runs of one are left untouched.
- Wire format affected: no
- Public API affected: no
- Breaking change: no

`coalesceContents` keeps its signature; its behaviour changes for code-interpreter contents, which
the changelog states. A session written after folding a fragmented stream now holds one item per
call instead of several partial ones; existing stored sessions round-trip unchanged.

Python has no dedicated tests for this rule and Go's do not cover non-adjacent fragments; this adds
seven.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
