### PR TITLE
Leave the finish reason off the trailing metadata-only update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,19 @@ contain breaking changes**; patch releases are fixes only.
   still deliberately emitted by nothing, on spans and on metric dimensions alike, and its absence
   is now pinned by tests.
 
+- **`@polymind-inc/agent-framework-core`** — the trailing metadata-only update that
+  `chatResponseToUpdates` and `agentResponseToUpdates` append for response-level usage, additional
+  properties or a continuation token no longer repeats the response's `finishReason`. Anything that
+  reads an exploded response as a stream — the function-invocation loop replaying a non-streaming
+  round, a middleware answering a run without invoking the agent, the telemetry client — saw the
+  turn announce a finish reason a second time on an update carrying no message content, a shape no
+  provider stream produces. The message updates carry the reason exactly as before, so folding the
+  sequence back yields the same response, and both reference implementations agree: .NET's
+  `ChatResponse.ToChatResponseUpdates` builds its trailing update from `AdditionalProperties` and
+  usage alone, and Go's `Response.ToUpdates` is asserted to leave that update's finish reason empty.
+  One consequence, shared with both of them: a response that has no messages at all — where the
+  trailing update is the only one — no longer reports a finish reason to whoever folds the sequence.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/packages/core/src/types/response.test.ts
+++ b/packages/core/src/types/response.test.ts
@@ -5,6 +5,7 @@ import { dataContent, textContent, unknownContent } from './content.js';
 import type { AgentResponseUpdate, ChatResponseUpdate } from './response.js';
 import {
   agentResponse,
+  agentResponseToUpdates,
   agentResponseUpdate,
   chatResponse,
   chatResponseToUpdates,
@@ -185,6 +186,97 @@ describe('chatResponseToUpdates', () => {
     );
     expect(updates).toEqual([]);
     expect(mergeChatUpdates(updates).messages).toEqual([]);
+  });
+
+  it('emits no trailing update for a usage record whose every counter is zero', () => {
+    const updates: ChatResponseUpdate[] = chatResponseToUpdates(
+      chatResponse<undefined>({
+        messages: [{ role: 'assistant', contents: [textContent('hi')], messageId: 'm1' }],
+        usageDetails: { inputTokenCount: 0, outputTokenCount: 0 },
+      }),
+    );
+    expect(updates).toHaveLength(1);
+    expect(updates[0]?.messageId).toBe('m1');
+  });
+
+  it('finishes every message update and leaves the trailing metadata update unfinished', () => {
+    const original = chatResponse<undefined>({
+      messages: [
+        { role: 'assistant', contents: [textContent('hi')], messageId: 'm1' },
+        { role: 'assistant', contents: [textContent(' there')], messageId: 'm2' },
+      ],
+      responseId: 'resp_1',
+      conversationId: 'conv_1',
+      model: 'gpt-4o',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      finishReason: 'content_filter',
+      usageDetails: { inputTokenCount: 4, outputTokenCount: 6 },
+      additionalProperties: { tenant: 'contoso' },
+      continuationToken: { responseId: 'resp_1' },
+    });
+
+    const updates: ChatResponseUpdate[] = chatResponseToUpdates(original);
+
+    expect(updates.map((u) => u.finishReason)).toEqual(['content_filter', 'content_filter', undefined]);
+    const trailing = updates[2];
+    assert.exists(trailing);
+    expect(trailing.contents).toEqual([
+      { type: 'usage', usageDetails: { inputTokenCount: 4, outputTokenCount: 6 } },
+    ]);
+    expect(trailing.additionalProperties).toEqual({ tenant: 'contoso' });
+    expect(trailing.continuationToken).toEqual({ responseId: 'resp_1' });
+    expect(trailing.responseId).toBe('resp_1');
+    expect(trailing.conversationId).toBe('conv_1');
+    expect(trailing.model).toBe('gpt-4o');
+    expect(trailing.createdAt).toBe('2026-01-01T00:00:00.000Z');
+    // The message updates keep the response-level finish reason, so folding still recovers it.
+    expect(mergeChatUpdates<undefined>(updates).finishReason).toBe('content_filter');
+  });
+});
+
+describe('agentResponseToUpdates', () => {
+  it('finishes every message update and leaves the trailing metadata update unfinished', () => {
+    const original = agentResponse<undefined>({
+      messages: [
+        { role: 'assistant', contents: [textContent('hi')], messageId: 'm1' },
+        { role: 'assistant', contents: [textContent(' there')], messageId: 'm2' },
+      ],
+      responseId: 'resp_1',
+      agentId: 'agent_1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      finishReason: 'stop',
+      usageDetails: { inputTokenCount: 4, outputTokenCount: 6 },
+      additionalProperties: { tenant: 'contoso' },
+      continuationToken: { responseId: 'resp_1' },
+    });
+
+    const updates: AgentResponseUpdate[] = agentResponseToUpdates(original);
+
+    expect(updates.map((u) => u.finishReason)).toEqual(['stop', 'stop', undefined]);
+    const trailing = updates[2];
+    assert.exists(trailing);
+    expect(trailing.contents).toEqual([
+      { type: 'usage', usageDetails: { inputTokenCount: 4, outputTokenCount: 6 } },
+    ]);
+    expect(trailing.additionalProperties).toEqual({ tenant: 'contoso' });
+    expect(trailing.continuationToken).toEqual({ responseId: 'resp_1' });
+    expect(trailing.responseId).toBe('resp_1');
+    expect(trailing.agentId).toBe('agent_1');
+    expect(trailing.createdAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(mergeUpdates<undefined>(updates).finishReason).toBe('stop');
+  });
+
+  it('emits a metadata-only update carrying no finish reason when the response has no messages', () => {
+    const updates: AgentResponseUpdate[] = agentResponseToUpdates(
+      agentResponse<undefined>({
+        messages: [],
+        finishReason: 'stop',
+        usageDetails: { inputTokenCount: 4 },
+      }),
+    );
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]?.finishReason).toBeUndefined();
   });
 });
 

--- a/packages/core/src/types/response.ts
+++ b/packages/core/src/types/response.ts
@@ -425,15 +425,19 @@ function responseToUpdates(
     inits.push(init);
   }
 
-  // Go gates the trailing update on a non-zero usage record (`!isZeroUsage`), not mere presence.
+  // A usage record whose every counter is zero reports nothing, so it does not on its own earn a
+  // trailing update.
   const hasUsage = !isEmptyUsage(response.usageDetails);
   if (hasUsage || response.additionalProperties !== undefined || response.continuationToken !== undefined) {
     const init: ResponseUpdateInitBase = {
       contents: hasUsage ? [{ type: 'usage', usageDetails: response.usageDetails as UsageDetails }] : [],
     };
+    // No `finishReason` on this one: the reason describes the generation the message updates hold,
+    // and it is those updates that carry it into a folded response. Stamping it here as well would
+    // report the turn as finished a second time, after its last message.
     copyDefined(init, response, ['responseId', 'createdAt', 'continuationToken']);
     addExtras(init);
-    copyDefined(init, response, ['finishReason', 'additionalProperties']);
+    copyDefined(init, response, ['additionalProperties']);
     inits.push(init);
   }
   return inits;


### PR DESCRIPTION
## What this changes

Part of #113 — completes the **core / explode — terminal metadata** item.

`chatResponseToUpdates` and `agentResponseToUpdates` copied the response-level `finishReason` onto
the trailing metadata-only update as well as onto the message updates, reporting the turn as
finished a second time after its last message. The trailing update now carries only what it is for:
usage, additional properties, continuation data and the ids.

Message updates keep the reason, so a folded response with messages is byte-identical. A response
with no messages folds without one — the same result both reference implementations produce.

## Parity

- Reference checked: .NET `ChatResponse.ToChatResponseUpdates` builds its extra update from
  `AdditionalProperties` and usage alone and never sets `FinishReason`; Go `agent.Response.ToUpdates`
  does the same and asserts it in `response_test.go` ("expected empty FinishReason"). Python has no
  explode. Reference test counts: Go 6, .NET 2; this now has 6.
- Wire format affected: yes
- Public API affected: no
- Breaking change: no

The exploded update sequence no longer repeats `finishReason` on the trailing update. No HTTP or SSE
payload changes — nothing in agentserver or foundry reads `update.finishReason`. A continuation
token minted from an exploded sequence carries one fewer optional field; older tokens still
deserialize.

A stale comment went with it: it justified the trailing-update gate by Go's `isZeroUsage`, a function
Go removed in its #876. The rule is now stated as ours, with a test.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
