### PR TITLE
Emit the UserInputRequiredException marker on user-input results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,19 @@ contain breaking changes**; patch releases are fixes only.
   still deliberately emitted by nothing, on spans and on metric dimensions alike, and its absence
   is now pinned by tests.
 
+- **`@polymind-inc/agent-framework-core`** — a tool that stops for a human without naming anything
+  a human could settle now reports `exception: "UserInputRequiredException"` on the
+  `function_result` it hands the model, instead of `"UserInputRequiredError"`. The marker is
+  wire-visible and was being derived from the thrown error's class name, so a consumer branching on
+  `function_result.exception` — or a transcript compared against another implementation — saw a
+  string no other implementation emits; Python's `_execute_single_function_call` writes
+  `exception="UserInputRequiredException"` for the same case. The marker is now a fixed literal
+  rather than the error's `name`, so subclassing or renaming `UserInputRequiredError` cannot change
+  it. Everything else about this path is unchanged: the model-facing text is still
+  `Tool requires user input but no request details were provided.`, `includeDetailedErrors` still
+  appends ` Exception: <message>` to that text and nothing else, the round still counts against the
+  consecutive-error budget, and the run still continues.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/packages/core/src/client/function-execution.ts
+++ b/packages/core/src/client/function-execution.ts
@@ -29,6 +29,14 @@ import type {
  * `Content.from_function_result(result=…, exception="UserInputRequiredException")`.
  */
 const USER_INPUT_UNAVAILABLE_RESULT_TEXT = 'Tool requires user input but no request details were provided.';
+/**
+ * The `exception` marker that same result carries.
+ *
+ * Wire-visible, and therefore a fixed literal rather than the thrown error's `name`, so a consumer
+ * that branches on `function_result.exception` reads the same string here as from Python. The
+ * thrown error's own `name` — which a subclass or a rename can change — is never consulted.
+ */
+const USER_INPUT_REQUIRED_EXCEPTION = 'UserInputRequiredException';
 /** What a rejected call reports back to the model. Matches Python's `_tools.py` wording. */
 const REJECTED_RESULT_TEXT = 'Error: Tool call invocation was rejected by user.';
 
@@ -223,9 +231,9 @@ async function invokeOne(
             error,
             errorReport: {
               result: USER_INPUT_UNAVAILABLE_RESULT_TEXT,
-              // Python writes the exception *type* here rather than its message; the message is
+              // The marker names the exception *type*, not the thrown message; the message is
               // still reachable through `includeDetailedErrors`, as for every other failure.
-              exception: error.name,
+              exception: USER_INPUT_REQUIRED_EXCEPTION,
             },
           };
         } else {

--- a/packages/core/src/client/function-invocation.test.ts
+++ b/packages/core/src/client/function-invocation.test.ts
@@ -1298,13 +1298,15 @@ describe('withFunctionInvocation UserInputRequiredError', () => {
     expect(inner.callCount).toBe(2);
     expect(response.text).toBe('handled');
     const results = resultsOf(response.messages.flatMap((m) => m.contents));
+    // Exact, whole-content match: with detailed errors off the two strings are fixed, so nothing
+    // derived from the thrown error may leak into either of them.
     expect(results).toEqual([
-      expect.objectContaining({
+      {
         type: 'function_result',
         callId: 'c1',
         result: 'Tool requires user input but no request details were provided.',
-        exception: 'UserInputRequiredError',
-      }),
+        exception: 'UserInputRequiredException',
+      },
     ]);
     // Nothing is handed to the caller: there is no request a human could answer.
     expect(
@@ -1330,7 +1332,38 @@ describe('withFunctionInvocation UserInputRequiredError', () => {
       'Tool requires user input but no request details were provided. ' +
         'Exception: Tool requires user input to proceed.',
     );
-    expect(results[0]?.exception).toBe('UserInputRequiredError');
+    // The detail rides on `result`; the marker stays the fixed literal either way.
+    expect(results[0]?.exception).toBe('UserInputRequiredException');
+  });
+
+  it('marks the empty-contents result with the wire literal, not the thrown error name', async () => {
+    // The marker is wire-visible, so it names Python's exception type rather than the class that
+    // was thrown here. A subclass raised under a different `name` must not change what is emitted.
+    class RenamedUserInputRequiredError extends UserInputRequiredError {
+      constructor() {
+        super([]);
+        this.name = 'DifferentlyNamedError';
+      }
+    }
+    const renamed = tool({
+      name: 'needs_input',
+      description: 'needs a human',
+      parameters: { type: 'object', properties: {} },
+      execute: async () => {
+        throw new RenamedUserInputRequiredError();
+      },
+    });
+    const inner = new MockChatClient([
+      { contents: [call('c1', 'needs_input')], finishReason: 'tool_calls' },
+      { contents: [textContent('handled')], finishReason: 'stop' },
+    ]);
+
+    const response = await withFunctionInvocation(inner).getResponse([], {
+      tools: [renamed],
+    } as ChatOptions);
+
+    const results = resultsOf(response.messages.flatMap((m) => m.contents));
+    expect(results[0]?.exception).toBe('UserInputRequiredException');
   });
 
   it('counts an empty-contents raise toward the consecutive-error budget', async () => {


### PR DESCRIPTION
## What this changes

Part of #113 — completes the **core / missing user-input literal** item.

A `UserInputRequiredError` thrown with no requests produced a `function_result` whose `exception`
marker was `error.name` — `UserInputRequiredError`, this package's class name, which no reference
implementation emits. A consumer branching on that field read a different string here than from
Python. It is now the fixed literal `UserInputRequiredException`.

## Parity

- Reference checked: Python `_tools.py`, the `except UserInputRequiredException` arm of
  `_execute_single_function_call` — an empty `contents` yields a function result with
  `exception="UserInputRequiredException"` and does not terminate the loop. Neither .NET nor Go has a
  counterpart (`grep -rn "UserInputRequired"` finds nothing in either), so Python is the sole
  authority for this literal.
- Wire format affected: yes
- Public API affected: no
- Breaking change: no

Only this marker changes. The result text, call id, inherited additional properties and every other
result path are byte-identical, and the detailed-error behaviour on both settings is unchanged and
pinned. A test throws a subclass renamed to `DifferentlyNamedError` and asserts the marker is still
the literal, so the thrown error's `name` cannot leak back in.

The span error still reports `UserInputRequiredError` through `error.type`, which reads the real
error — unchanged.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
