### PR TITLE
Send the Anthropic tool choice independently of tool declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,18 @@ contain breaking changes**; patch releases are fixes only.
   still deliberately emitted by nothing, on spans and on metric dimensions alike, and its absence
   is now pinned by tests.
 
+- **`@polymind-inc/agent-framework-anthropic`** — a configured `toolChoice` now reaches the wire
+  even when the request declares no tools. `tool_choice` was gated on the request carrying local
+  tool declarations or an `mcp_servers` entry, so a choice set on a request with neither was
+  dropped — including the function-calling loop's own final round, which withdraws local
+  declarations precisely while pinning the choice to `'none'`, and any caller that asks a
+  tool-free request not to call tools. Python's `_prepare_tools_for_anthropic` and Go's
+  `anthropicprovider` both build `tool_choice` from the option alone, so the field is now sent
+  whenever a choice was configured and omitted only when none was. Requests that already carried
+  declarations are unchanged, as is the mapping itself (`auto` → `auto`, `required` → `any` or a
+  single named `tool`, `none` → `none`). The OpenAI Responses client still gates `tool_choice` on
+  `tools`, matching its own reference implementation.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/packages/anthropic/src/chat-client.test.ts
+++ b/packages/anthropic/src/chat-client.test.ts
@@ -10,6 +10,7 @@ import {
   serializeMessage,
   textContent,
   tool,
+  withFunctionInvocation,
 } from '@polymind-inc/agent-framework-core';
 import { arrayToStream } from '@polymind-inc/agent-framework-core/internal';
 import { describe, expect, it } from 'vitest';
@@ -224,6 +225,58 @@ describe('request mapping', () => {
     expect(toAnthropicToolChoice('none')).toEqual({ type: 'none' });
     expect(toAnthropicToolChoice({ required: ['a'] })).toEqual({ type: 'tool', name: 'a' });
     expect(toAnthropicToolChoice({ required: ['a', 'b'] })).toEqual({ type: 'any' });
+  });
+
+  describe('tool choice independence', () => {
+    const search = tool({
+      name: 'search',
+      description: 'Searches',
+      parameters: { type: 'object', properties: { q: { type: 'string' } } },
+      execute: () => 'ok',
+    });
+    const prompt: Message[] = [{ role: 'user', contents: [textContent('hi')] }];
+
+    it('sends a configured choice on a request that declares no tools at all', () => {
+      const { client } = clientWith([message('hi')]);
+      const request = client.buildRequest(prompt, { toolChoice: 'none' });
+
+      expect(request.tool_choice).toEqual({ type: 'none' });
+      expect(request).not.toHaveProperty('tools');
+      expect(request).not.toHaveProperty('mcp_servers');
+    });
+
+    it('sends a configured choice on a request that declares only an MCP server', () => {
+      const { client } = clientWith([message('hi')]);
+      const request = client.buildRequest(prompt, {
+        tools: [client.getMcpTool({ serverLabel: 'docs', serverUrl: 'https://mcp.example/sse' })],
+        toolChoice: 'auto',
+      });
+
+      expect(request.tool_choice).toEqual({ type: 'auto' });
+      expect(request).not.toHaveProperty('tools');
+      expect(request.mcp_servers).toHaveLength(1);
+    });
+
+    it('sends a configured choice on a request that declares local tools', () => {
+      const { client } = clientWith([message('hi')]);
+      const request = client.buildRequest(prompt, {
+        tools: [search],
+        toolChoice: { required: ['search'] },
+      });
+
+      expect(request.tool_choice).toEqual({ type: 'tool', name: 'search' });
+      expect(request.tools).toHaveLength(1);
+    });
+
+    it.each([
+      { label: 'with local tools', tools: [search] },
+      { label: 'without any tools', tools: undefined },
+    ])('omits tool_choice when no choice was configured ($label)', ({ tools }) => {
+      const { client } = clientWith([message('hi')]);
+      const request = client.buildRequest(prompt, tools === undefined ? undefined : { tools });
+
+      expect(request).not.toHaveProperty('tool_choice');
+    });
   });
 
   it('sends structured output through output_config.format', () => {
@@ -848,6 +901,31 @@ describe('through the agent', () => {
     // The second request replays the call and its result as the roles the API demands.
     const second = messages.requests[1]?.messages as Array<{ role: string; content: unknown }>;
     expect(second.map((m) => m.role)).toEqual(['user', 'assistant', 'user']);
+  });
+
+  it('still sends the pinned choice on the final round, after local tools are withdrawn', async () => {
+    // The function-calling loop's last round withdraws local declarations and pins the choice to
+    // `'none'`, so a request with a choice but no declarations is a shape this package produces on
+    // its own — not a hypothetical.
+    const { client, messages } = clientWith([
+      {
+        id: 'msg_1',
+        model: 'claude-sonnet-4-5',
+        content: [{ type: 'tool_use', id: 'call_1', name: 'get_weather', input: { city: 'Tokyo' } }],
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+      message('Tokyo is sunny.'),
+    ]);
+
+    await withFunctionInvocation(client, { maxIterations: 1 }).getResponse(
+      [{ role: 'user', contents: [textContent('weather in Tokyo?')] }],
+      { tools: [weather] },
+    );
+
+    expect(messages.requests).toHaveLength(2);
+    expect(messages.requests[1]).not.toHaveProperty('tools');
+    expect(messages.requests[1]?.tool_choice).toEqual({ type: 'none' });
   });
 
   it('parses structured output', async () => {

--- a/packages/anthropic/src/chat-client.ts
+++ b/packages/anthropic/src/chat-client.ts
@@ -253,9 +253,11 @@ export class AnthropicChatClient
     if (mcp_servers !== undefined) {
       request.mcp_servers = mcp_servers;
     }
-    if (tools !== undefined || mcp_servers !== undefined) {
-      setIfDefined(request, 'tool_choice', toAnthropicToolChoice(options?.toolChoice));
-    }
+    // The choice travels on the option alone, never gated on what this request declares. The
+    // function-calling loop's final round withdraws local declarations while pinning the choice to
+    // `'none'`, so gating would drop the instruction on exactly the request that exists to send it.
+    // Python and Go build it from the option alone too; it is omitted only when none was configured.
+    setIfDefined(request, 'tool_choice', toAnthropicToolChoice(options?.toolChoice));
 
     Object.assign(request, options?.additionalProperties ?? {});
 


### PR DESCRIPTION
## What this changes

Part of #113 — completes the **anthropic / `toolChoice` without tools** item.

`buildRequest` sent `tool_choice` only when the request also carried `tools` or `mcp_servers`, so a
configured choice was dropped from a request that declares neither. The choice is now built from the
option alone and omitted only when none was configured.

The framework produces exactly that request itself: on the function-calling loop's final round,
`withoutFunctionTools` withdraws the local declarations *and* pins `toolChoice: 'none'` — the
instruction was being dropped precisely where it was deliberate.

## Parity

- Reference checked: Python `_chat_client.py` builds the choice after the `if tools:` block and
  returns it regardless, with an early return when no choice was configured; Go
  `anthropicprovider/agent.go` keeps `params.Tools` and the tool-mode branch as separate `if`s. The
  .NET Anthropic package in this repo carries no option mapping — it lives in the Anthropic .NET SDK.
- Wire format affected: yes
- Public API affected: no
- Breaking change: no

`tool_choice` now appears on requests that carry a configured choice and no declarations. Every
request that already carried it carries the identical value; the `auto`/`any`/`tool`/`none` mapping
is untouched.

The same-shaped gate in the OpenAI client is **not** a bug and is left alone: Python's OpenAI
Responses client pops both `tool_choice` and `parallel_tool_calls` when there are no tools, so that
gate is parity. The changelog says so, to stop a later sweep "fixing" it.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
