### PR TITLE
Say why the empty-message guard is there

### DIFF
--- a/packages/anthropic/src/chat-client.test.ts
+++ b/packages/anthropic/src/chat-client.test.ts
@@ -106,6 +106,15 @@ describe('construction', () => {
 });
 
 describe('request mapping', () => {
+  it('refuses a request that would carry no messages', () => {
+    // A divergence this build chooses: the reference implementation sends the empty list and lets
+    // the service answer. Pinned so the divergence stays deliberate rather than drifting back.
+    const { client, messages } = clientWith([message('hi')]);
+
+    expect(() => client.buildRequest([])).toThrow(ChatClientError);
+    expect(messages.requests).toHaveLength(0);
+  });
+
   it('maps the framework options onto the Messages API request', () => {
     const { client } = clientWith([message('hi')]);
 

--- a/packages/anthropic/src/chat-client.ts
+++ b/packages/anthropic/src/chat-client.ts
@@ -176,7 +176,10 @@ export class AnthropicChatClient
   buildRequest(messages: Message[], options?: AnthropicChatOptions): Record<string, unknown> {
     const converted = toAnthropicMessages(messages);
     if (converted.length === 0) {
-      // The API rejects an empty message list with an opaque 400; Python raises up front too.
+      // A deliberate divergence, not parity: the reference implementation sends the empty list and
+      // lets the service answer with a 400 that names nothing the caller can act on. Failing here
+      // instead costs a round trip and says which call was empty, while changing no request the
+      // service would have accepted.
       throw new ChatClientError('Messages are required: the request would carry no messages.');
     }
 

--- a/packages/anthropic/src/chat-client.ts
+++ b/packages/anthropic/src/chat-client.ts
@@ -178,7 +178,7 @@ export class AnthropicChatClient
     if (converted.length === 0) {
       // A deliberate divergence, not parity: the reference implementation sends the empty list and
       // lets the service answer with a 400 that names nothing the caller can act on. Failing here
-      // instead costs a round trip and says which call was empty, while changing no request the
+      // instead saves that round trip and says which call was empty, while changing no request the
       // service would have accepted.
       throw new ChatClientError('Messages are required: the request would carry no messages.');
     }


### PR DESCRIPTION
## What this changes

Part of #113 — completes the **anthropic / empty-message comment** item. No runtime change.

The comment on the empty-message guard claimed the reference implementation raises up front too. It
does not: Python's Anthropic client raises for an empty model, for a shell tool without a function
and for structured instructions after a system message, and nothing for an empty message list — it
sends the list and lets the service answer.

The guard stays, because failing before the request saves that round trip and names the call that
was empty. The comment now says that, as a deliberate divergence rather than parity.

The guard had no test at all. One is added, so the divergence stays deliberate instead of drifting
back the next time someone reads the comment.

## Parity

- Reference checked: Python `_chat_client.py` — every `raise` in the file, none of them on the
  message list.
- Wire format affected: no
- Public API affected: no
- Breaking change: no

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
