### PR TITLE
Put each text block of an MCP error result on its own line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,20 @@ contain breaking changes**; patch releases are fixes only.
   still deliberately emitted by nothing, on spans and on metric dimensions alike, and its absence
   is now pinned by tests.
 
+- **`@polymind-inc/agent-framework-mcp`** — the failure text of a tool result that reports
+  `isError` now puts each text block on its own line. The blocks of a failed call are separate
+  messages — a summary and its detail, or one line per item that failed — and concatenating them
+  without a separator ran them together as `...rejected itretry after 30s`, in the
+  `ToolInvocationError` the model is told about and in the `tools/call` span's status message
+  alike. Both are now assembled by one rule: text blocks only, in order, joined with a newline,
+  with empty blocks contributing nothing rather than a blank line, and `structuredContent` keeping
+  its place as the last line of a call that reported both. A result whose blocks carry no text at
+  all still falls back to the generic `MCP tool "<name>" reported an error.` message. The shared
+  `textOfContents` is untouched and stays a verbatim concatenation — it answers what a message
+  said, where a streamed response splits text at arbitrary token boundaries. The equivalent
+  assembly in `FoundryToolbox` is unchanged for now; it diverges in more than the separator and is
+  tracked separately.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,10 +217,12 @@ contain breaking changes**; patch releases are fixes only.
   messages — a summary and its detail, or one line per item that failed — and concatenating them
   without a separator ran them together as `...rejected itretry after 30s`, in the
   `ToolInvocationError` the model is told about and in the `tools/call` span's status message
-  alike. Both are now assembled by one rule: text blocks only, in order, joined with a newline,
-  with empty blocks contributing nothing rather than a blank line, and `structuredContent` keeping
-  its place as the last line of a call that reported both. A result whose blocks carry no text at
-  all still falls back to the generic `MCP tool "<name>" reported an error.` message. The shared
+  alike. Both are now joined by one rule: text blocks only, in order, separated by a newline, with
+  empty blocks contributing nothing rather than a blank line. The two texts are not identical — the
+  exception is built from the converted contents, so a call that reported `structuredContent` still
+  carries it as the last line, while the span message is built from the result's own blocks and
+  never had it. A result whose blocks carry no text at all still falls back to the generic
+  `MCP tool "<name>" reported an error.` message. The shared
   `textOfContents` is untouched and stays a verbatim concatenation — it answers what a message
   said, where a streamed response splits text at arbitrary token boundaries. The equivalent
   assembly in `FoundryToolbox` is unchanged for now; it diverges in more than the separator and is

--- a/packages/core/src/types/content.test.ts
+++ b/packages/core/src/types/content.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Content } from './content.js';
-import { isUserInputRequest } from './content.js';
+import { isUserInputRequest, textOfContents } from './content.js';
 
 describe('isUserInputRequest', () => {
   it('matches the userInputRequest marker and both request discriminators', () => {
@@ -35,5 +35,22 @@ describe('isUserInputRequest', () => {
     for (const content of negatives) {
       expect(isUserInputRequest(content)).toBe(false);
     }
+  });
+});
+
+describe('textOfContents', () => {
+  it('concatenates text with no separator of its own', () => {
+    // What a message *said*, verbatim: a streamed response arrives as many text contents split
+    // at arbitrary token boundaries, so any separator this helper inserted would appear inside
+    // words. Callers that want their parts kept apart — a list of independent messages, say —
+    // must join them themselves rather than relax this.
+    const contents: Content[] = [
+      { type: 'text', text: 'Hel' },
+      { type: 'data', uri: 'data:image/png;base64,AAAA', mediaType: 'image/png' },
+      { type: 'text', text: '' },
+      { type: 'text', text: 'lo' },
+    ];
+
+    expect(textOfContents(contents)).toBe('Hello');
   });
 });

--- a/packages/mcp/src/client.test.ts
+++ b/packages/mcp/src/client.test.ts
@@ -18,7 +18,7 @@ import { MockChatClient } from '@polymind-inc/agent-framework-core/testing';
 import { describe, expect, it, vi } from 'vitest';
 import { McpClient } from './client.js';
 import { McpConnection } from './connection.js';
-import { fromMcpContent } from './content.js';
+import { fromMcpContent, mcpErrorText } from './content.js';
 import type { TestTool } from './test-server.js';
 import { SlowStartServer, TestMcpServer } from './test-server.js';
 
@@ -1031,5 +1031,32 @@ describe('telemetry', () => {
     } finally {
       await provider.shutdown();
     }
+  });
+});
+
+describe('mcpErrorText', () => {
+  it.each<[string, unknown]>([
+    ['a string', 'not a list'],
+    ['an object', { type: 'text', text: 'lonely' }],
+    ['null', null],
+    ['undefined', undefined],
+  ])('reads %s as no text rather than throwing', (_label, items) => {
+    // The blocks come off the wire, so a server can answer with anything. Reading one as a list
+    // without checking would turn a tool failure into a failure to describe the failure — the
+    // caller would get a TypeError where it expected the server's reason. The transports in these
+    // tests cannot produce it, because the MCP client library validates the result first, so the
+    // rule is pinned here at the helper that has to hold it either way.
+    expect(mcpErrorText(items)).toBe('');
+  });
+
+  it('joins the text blocks of a well-formed list', () => {
+    expect(
+      mcpErrorText([
+        { type: 'text', text: 'rejected it' },
+        { type: 'image', data: 'AAAA' },
+        { type: 'text', text: '' },
+        { type: 'text', text: 'retry after 30s' },
+      ]),
+    ).toBe('rejected it\nretry after 30s');
   });
 });

--- a/packages/mcp/src/client.test.ts
+++ b/packages/mcp/src/client.test.ts
@@ -45,6 +45,16 @@ function server(): TestMcpServer {
   ]);
 }
 
+/** The message of the {@link ToolInvocationError} `call` rejects with, for exact comparison. */
+async function messageOfRejection(call: unknown): Promise<string> {
+  const error = await Promise.resolve(call).then(
+    () => undefined,
+    (reason: unknown) => reason,
+  );
+  expect(error).toBeInstanceOf(ToolInvocationError);
+  return (error as Error).message;
+}
+
 describe('tool enumeration', () => {
   it('stays disconnected until tools are needed', async () => {
     const mcp = new McpClient({ transport: server() });
@@ -346,6 +356,55 @@ describe('tool invocation', () => {
     await mcp.close();
   });
 
+  it('puts each text block of an error result on its own line', async () => {
+    // The blocks of a failed call are separate messages, not one message split across blocks:
+    // concatenated without a separator they read as `...rejected itretry after 30s`.
+    const mcp = new McpClient({
+      transport: new TestMcpServer([
+        {
+          name: 'multi-failure',
+          call: () => ({
+            content: [
+              { type: 'text', text: 'the upstream API rejected it' },
+              { type: 'text', text: '' },
+              { type: 'image', data: 'AAAA', mimeType: 'image/png' },
+              { type: 'text', text: 'retry after 30s' },
+            ],
+            isError: true,
+          }),
+        },
+      ]),
+    });
+    const [multiFailure] = await mcp.getTools();
+
+    const error = await messageOfRejection(multiFailure?.execute?.({}, { callId: 'call_1' }));
+
+    // The empty block contributes nothing rather than a blank line, and the image none at all.
+    expect(error).toBe('the upstream API rejected it\nretry after 30s');
+    await mcp.close();
+  });
+
+  it('gives structuredContent its own line in the error text', async () => {
+    const mcp = new McpClient({
+      transport: new TestMcpServer([
+        {
+          name: 'detailed-failure',
+          call: () => ({
+            content: [{ type: 'text', text: 'the request was rejected' }],
+            structuredContent: { code: 'quota_exceeded' },
+            isError: true,
+          }),
+        },
+      ]),
+    });
+    const [detailedFailure] = await mcp.getTools();
+
+    const error = await messageOfRejection(detailedFailure?.execute?.({}, { callId: 'call_1' }));
+
+    expect(error).toBe('the request was rejected\n{"code":"quota_exceeded"}');
+    await mcp.close();
+  });
+
   it('supplies a generic message when an error result carries no text', async () => {
     const mcp = new McpClient({
       transport: new TestMcpServer([
@@ -357,6 +416,31 @@ describe('tool invocation', () => {
     await expect(muteFailure?.execute?.({}, { callId: 'call_1' })).rejects.toThrow(
       'MCP tool "mute-failure" reported an error.',
     );
+    await mcp.close();
+  });
+
+  it('supplies the generic message when an error result has only non-text blocks', async () => {
+    // Joining nothing yields the empty string, which as a tool failure message says nothing at
+    // all; the fallback names the tool instead. Blocks with no text at all must reach it too.
+    const mcp = new McpClient({
+      transport: new TestMcpServer([
+        {
+          name: 'picture-failure',
+          call: () => ({
+            content: [
+              { type: 'image', data: 'AAAA', mimeType: 'image/png' },
+              { type: 'text', text: '' },
+            ],
+            isError: true,
+          }),
+        },
+      ]),
+    });
+    const [pictureFailure] = await mcp.getTools();
+
+    const error = await messageOfRejection(pictureFailure?.execute?.({}, { callId: 'call_1' }));
+
+    expect(error).toBe('MCP tool "picture-failure" reported an error.');
     await mcp.close();
   });
 

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -10,12 +10,11 @@ import {
   AgentFrameworkError,
   ConfigurationError,
   ToolInvocationError,
-  textOfContents,
   tool,
 } from '@polymind-inc/agent-framework-core';
 import { errorMessageOf } from '@polymind-inc/agent-framework-core/internal';
 import { McpConnection } from './connection.js';
-import { fromMcpContents, mcpMetaProperties } from './content.js';
+import { fromMcpContents, mcpErrorText, mcpMetaProperties } from './content.js';
 import type { McpHeaderProvider } from './headers.js';
 import type { McpSkillsSourceConfig } from './skills.js';
 import { mcpSkillsSource } from './skills.js';
@@ -364,7 +363,7 @@ export class McpClient {
             // as a success would tell the model the call worked and hand it the error text as
             // the answer; throwing routes it through the loop's error handling instead. The
             // connection has already marked the span with `error.type = tool_error`.
-            const text = textOfContents(contents);
+            const text = mcpErrorText(contents);
             throw new ToolInvocationError(
               declared.name,
               text === '' ? `MCP tool "${declared.name}" reported an error.` : text,

--- a/packages/mcp/src/connection.test.ts
+++ b/packages/mcp/src/connection.test.ts
@@ -379,4 +379,31 @@ describe('telemetry', () => {
     expect(span?.attributes['error.type']).toBe('tool_error');
     expect(span?.status.message).toBe('the tool is broken');
   });
+
+  it('puts each text block of an isError result on its own line in the span status', async () => {
+    // The span message and the exception the caller raises describe the same failure, so they
+    // are assembled by the same rule; a concatenation without separators reads as one run-on
+    // sentence in the trace viewer.
+    const connection = connectionTo(
+      new TestMcpServer([
+        {
+          name: 'explode',
+          call: () => ({
+            content: [
+              { type: 'text', text: 'the upstream API rejected it' },
+              { type: 'text', text: '' },
+              { type: 'image', data: 'AAAA', mimeType: 'image/png' },
+              { type: 'text', text: 'retry after 30s' },
+            ],
+            isError: true,
+          }),
+        },
+      ]),
+    );
+    await connection.callTool('explode', {});
+    await connection.close();
+
+    const span = exporter.getFinishedSpans().find((s) => s.name === 'tools/call explode');
+    expect(span?.status.message).toBe('the upstream API rejected it\nretry after 30s');
+  });
 });

--- a/packages/mcp/src/connection.ts
+++ b/packages/mcp/src/connection.ts
@@ -18,6 +18,7 @@ import {
   setMcpSpanError,
   withMcpClientSpan,
 } from '@polymind-inc/agent-framework-core';
+import { mcpErrorText } from './content.js';
 import type { McpHeaderProvider } from './headers.js';
 import { headerInjectingFetch } from './headers.js';
 
@@ -64,20 +65,6 @@ function httpTransportFactory(config: McpConnectionConfig): () => Transport {
   const url = new URL(String(config.url));
   const fetchImpl = headerInjectingFetch(url, config.headers, config.fetch ?? globalThis.fetch);
   return () => new StreamableHTTPClientTransport(url, { fetch: fetchImpl });
-}
-
-/** The text of a result's `text` blocks, concatenated; used as the span's error description. */
-function textOfBlocks(content: unknown): string {
-  if (!Array.isArray(content)) {
-    return '';
-  }
-  let out = '';
-  for (const block of content as Array<{ type?: unknown; text?: unknown }>) {
-    if (block.type === 'text' && typeof block.text === 'string') {
-      out += block.text;
-    }
-  }
-  return out;
 }
 
 /** Construction options for {@link McpConnection}. */
@@ -326,7 +313,9 @@ export class McpConnection {
           client.callTool({ name, arguments: args }, options),
         );
         if (result.isError === true) {
-          const text = textOfBlocks(result.content);
+          // One line per text block, the same rule the raised failure text is assembled by: a
+          // trace viewer shows the blocks of a failed call as the separate messages they are.
+          const text = mcpErrorText(result.content);
           setMcpSpanError(span, 'tool_error', text === '' ? undefined : text);
         }
         return result;

--- a/packages/mcp/src/content.ts
+++ b/packages/mcp/src/content.ts
@@ -99,10 +99,17 @@ export function fromMcpContent(block: McpContentBlock): Content {
  * Accepts both raw MCP content blocks and the framework content converted from them, so the two
  * descriptions of a failure — the exception the caller raises and the message on the client
  * span — are assembled by this one rule instead of a copy of it each.
+ *
+ * Takes `unknown` and reads nothing it has not checked. One caller hands it a field straight off
+ * the wire, and a server that answers with something other than a list must not turn a tool failure
+ * into a failure to describe the failure. Anything that is not a list of blocks reads as no text.
  */
-export function mcpErrorText(items: readonly unknown[] | undefined): string {
+export function mcpErrorText(items: unknown): string {
+  if (!Array.isArray(items)) {
+    return '';
+  }
   const lines: string[] = [];
-  for (const item of items ?? []) {
+  for (const item of items) {
     if (typeof item !== 'object' || item === null) {
       continue;
     }

--- a/packages/mcp/src/content.ts
+++ b/packages/mcp/src/content.ts
@@ -85,6 +85,36 @@ export function fromMcpContent(block: McpContentBlock): Content {
 }
 
 /**
+ * The failure text an MCP `isError` result carries: its text, one block per line.
+ *
+ * The text blocks of a failed call are separate messages — a summary and its detail, one line per
+ * item that failed — so running them together produces `...rejected itretry after 30s`. Blocks
+ * that carry no text contribute nothing rather than a blank line. Anything that is not text is
+ * skipped: an image or an embedded blob has no place in an exception message.
+ *
+ * This is the MCP layer's own rule, not the meaning of the shared `textOfContents`, which answers
+ * what a message *said* and must stay a verbatim concatenation — a streamed response splits text
+ * at arbitrary token boundaries, where an inserted newline would land inside a word.
+ *
+ * Accepts both raw MCP content blocks and the framework content converted from them, so the two
+ * descriptions of a failure — the exception the caller raises and the message on the client
+ * span — are assembled by this one rule instead of a copy of it each.
+ */
+export function mcpErrorText(items: readonly unknown[] | undefined): string {
+  const lines: string[] = [];
+  for (const item of items ?? []) {
+    if (typeof item !== 'object' || item === null) {
+      continue;
+    }
+    const block = item as { type?: unknown; text?: unknown };
+    if (block.type === 'text' && typeof block.text === 'string' && block.text !== '') {
+      lines.push(block.text);
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
  * The `additionalProperties` an MCP result's `_meta` envelope contributes, or `undefined`.
  *
  * A server may attach `_meta` to a tool result — Information Flow Control labels, for instance.


### PR DESCRIPTION
## What this changes

Part of #113 — completes the **mcp / `isError` text** item.

An MCP result flagged `isError` had its text blocks concatenated with nothing between them, so two
blocks reached the model as one run-on sentence. A new MCP-side helper puts each on its own line,
skips empty and non-text blocks, and keeps `structuredContent` as the last line. The shared
`textOfContents` is untouched — it stays a verbatim concatenation, and a core guard test now fails
if that ever changes.

The `tools/call` span status message was assembling the same text a second way. Both now share one
helper, so the failure a caller reads and the failure a trace shows cannot drift apart.

## Parity

- Reference checked: Python `_mcp.py` joins with `"\n"` at all three `isError` sites and skips empty
  text. .NET's `TaskAwareMcpClientAIFunction.ProjectResult` and Go's
  `mcpCallToolResultToAgentContent` never raise on `isError` at all — they hand the model the whole
  `CallToolResult` as a JSON envelope — so neither has a separator to compare. Python has four tests
  on this path and every one uses a single text block, so the join rule is unpinned upstream; this
  adds seven.
- Deliberate divergence: a result with no text keeps this framework's own message naming the tool
  that failed, rather than Python's `str(parsed)`, which is a Python repr rather than a portable
  fact.
- Wire format affected: no
- Public API affected: no
- Breaking change: no

Known residual difference, deliberately not papered over: the span message is built from the raw
blocks and so omits the `structuredContent` line the exception text carries. Python builds both from
one list. It is pre-existing and outside this item.

`FoundryToolbox` assembles this text a third way and diverges in four places; sharing the helper
needs a package-surface decision, so it is filed as #137 rather than folded in here.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
