### PR TITLE
Refuse a blank skill resource name before it becomes a read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,16 @@ contain breaking changes**; patch releases are fixes only.
   still deliberately emitted by nothing, on spans and on metric dimensions alike, and its absence
   is now pinned by tests.
 
+- **`@polymind-inc/agent-framework-mcp`** — a skill discovered over MCP no longer asks the server
+  for a resource whose name is empty or only whitespace. Such a name was appended to the skill root
+  unchanged, so `getResource('')` issued a `resources/read` for the skill's namespace URI and handed
+  back whatever the server serves there — content the caller never named. The name is now refused
+  before the request goes out and the call answers `undefined`, the same answer a name that fails
+  the traversal checks already got. The skills provider's `read_skill_resource` tool rejected blank
+  names before reaching the skill, so this is visible only to code calling the `Skill` API directly.
+  Whitespace decides blankness alone: a name with content in it is still requested exactly as the
+  server listed it, untrimmed and undecoded.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/packages/mcp/src/skills.test.ts
+++ b/packages/mcp/src/skills.test.ts
@@ -222,6 +222,56 @@ describe('loading', () => {
     await connection.close();
   });
 
+  it.each([[''], [' '], ['\t'], ['\n  '], ['\u00a0']])(
+    'refuses the blank resource name %j without asking the server',
+    async (name) => {
+      // The skill root is served here, so a request that did go out would come back with content
+      // instead of nothing — the refusal has to happen before the read, not after it.
+      const { server, connection } = serverWith([
+        indexOf(unitConverterEntry),
+        { uri: 'skill://unit-converter/', text: 'namespace root' },
+      ]);
+      const [skill] = await mcpSkillsSource(connection).getSkills(context());
+
+      expect(await skill?.getResource?.(name)).toBeUndefined();
+      expect(server.reads).toEqual([INDEX_URI]);
+      await connection.close();
+    },
+  );
+
+  it('issues no resources/read at all for blank names reaching the skill api directly', async () => {
+    const uris: string[] = [];
+    const reader: McpResourceReader = {
+      readResource: async (uri): Promise<ReadResourceResult> => {
+        uris.push(uri);
+        const text = uri === INDEX_URI ? JSON.stringify({ skills: [unitConverterEntry] }) : 'served';
+        return { contents: [{ uri, text }] };
+      },
+    };
+
+    const [skill] = await mcpSkillsSource(reader).getSkills(context());
+    const results = await Promise.all(['', '   ', '\t\n'].map((name) => skill?.getResource?.(name)));
+
+    expect(results).toEqual([undefined, undefined, undefined]);
+    expect(uris.filter((uri) => uri !== INDEX_URI)).toEqual([]);
+  });
+
+  it('reads a name that only looks blank at the edges at the uri the server listed', async () => {
+    // Surrounding whitespace decides nothing but blankness: a name with content in it is requested
+    // exactly as the server listed it, untrimmed.
+    const { server, connection } = serverWith([
+      indexOf(unitConverterEntry),
+      { uri: 'skill://unit-converter/ notes.md ', text: 'notes' },
+    ]);
+
+    const [skill] = await mcpSkillsSource(connection).getSkills(context());
+    const resource = await skill?.getResource?.(' notes.md ');
+
+    expect(server.reads).toContain('skill://unit-converter/ notes.md ');
+    expect(await resource?.read({ skill: skill as Skill, callId: 'c1' })).toBe('notes');
+    await connection.close();
+  });
+
   it('fetches a resource whose listed name contains a literal percent-escape at that exact uri', async () => {
     // The traversal check decodes the name to inspect it, but the name the server listed is the
     // name it serves: the request must go out undecoded.

--- a/packages/mcp/src/skills.test.ts
+++ b/packages/mcp/src/skills.test.ts
@@ -232,8 +232,10 @@ describe('loading', () => {
         { uri: 'skill://unit-converter/', text: 'namespace root' },
       ]);
       const [skill] = await mcpSkillsSource(connection).getSkills(context());
+      const getResource = skill?.getResource;
+      expect(getResource).toBeTypeOf('function');
 
-      expect(await skill?.getResource?.(name)).toBeUndefined();
+      expect(await getResource?.call(skill, name)).toBeUndefined();
       expect(server.reads).toEqual([INDEX_URI]);
       await connection.close();
     },
@@ -250,22 +252,27 @@ describe('loading', () => {
     };
 
     const [skill] = await mcpSkillsSource(reader).getSkills(context());
-    const results = await Promise.all(['', '   ', '\t\n'].map((name) => skill?.getResource?.(name)));
+    const getResource = skill?.getResource;
+    expect(getResource).toBeTypeOf('function');
+    const results = await Promise.all(['', '   ', '\t\n'].map((name) => getResource?.call(skill, name)));
 
     expect(results).toEqual([undefined, undefined, undefined]);
     expect(uris.filter((uri) => uri !== INDEX_URI)).toEqual([]);
   });
 
   it('reads a name that only looks blank at the edges at the uri the server listed', async () => {
-    // Surrounding whitespace decides nothing but blankness: a name with content in it is requested
-    // exactly as the server listed it, untrimmed.
+    // Surrounding whitespace decides blankness and nothing else: a name with content in it keeps
+    // the spaces around it rather than being trimmed. Backslashes are still normalized, so this
+    // says nothing about a name that carries one.
     const { server, connection } = serverWith([
       indexOf(unitConverterEntry),
       { uri: 'skill://unit-converter/ notes.md ', text: 'notes' },
     ]);
 
     const [skill] = await mcpSkillsSource(connection).getSkills(context());
-    const resource = await skill?.getResource?.(' notes.md ');
+    const getResource = skill?.getResource;
+    expect(getResource).toBeTypeOf('function');
+    const resource = await getResource?.call(skill, ' notes.md ');
 
     expect(server.reads).toContain('skill://unit-converter/ notes.md ');
     expect(await resource?.read({ skill: skill as Skill, callId: 'c1' })).toBe('notes');

--- a/packages/mcp/src/skills.ts
+++ b/packages/mcp/src/skills.ts
@@ -258,8 +258,8 @@ function skillRootUri(url: string): string {
  *
  * A name that is empty or only whitespace names nothing. Appending it to the skill root would
  * request the root itself, so it is refused here rather than answered with whatever the server
- * happens to serve at that URI. Whitespace decides blankness only: a name with content in it is
- * requested exactly as the server listed it, untrimmed.
+ * happens to serve at that URI. Whitespace decides blankness and nothing else: surrounding spaces
+ * inside a name that has content are kept, not trimmed away.
  *
  * Past that, the server resolves the URI and is the authority on what it will serve, but a name the
  * model composed should not be forwarded when it is visibly an escape attempt: an absolute path, an

--- a/packages/mcp/src/skills.ts
+++ b/packages/mcp/src/skills.ts
@@ -254,13 +254,21 @@ function skillRootUri(url: string): string {
 }
 
 /**
- * Normalizes a resource name, refusing the shapes that would leave the skill's namespace.
+ * Normalizes a resource name, refusing the shapes that must not become a request.
  *
- * The server resolves the URI and is the authority on what it will serve, but a name the model
- * composed should not be forwarded when it is visibly an escape attempt: an absolute path, an
+ * A name that is empty or only whitespace names nothing. Appending it to the skill root would
+ * request the root itself, so it is refused here rather than answered with whatever the server
+ * happens to serve at that URI. Whitespace decides blankness only: a name with content in it is
+ * requested exactly as the server listed it, untrimmed.
+ *
+ * Past that, the server resolves the URI and is the authority on what it will serve, but a name the
+ * model composed should not be forwarded when it is visibly an escape attempt: an absolute path, an
  * embedded scheme, or a `..` segment.
  */
 function safeResourceName(name: string): string | undefined {
+  if (name.trim() === '') {
+    return undefined;
+  }
   const normalized = name.replaceAll('\\', '/');
   // A downstream server or URI library may decode once or more before resolving the path. Run the
   // same checks over every decoded stage so `%2e%2e` and double-encoded variants cannot become


### PR DESCRIPTION
## What this changes

Part of #113 — completes the **mcp / blank skill resource names** item.

`getResource('')` appended the name to the skill root unchanged, so it requested the namespace URI
itself and returned whatever the server serves there as if it were the named resource. Whitespace-only
names did the same. Both are now refused before any request goes out.

The guard sits at the top of the name normalization, ahead of the traversal and decoding stages, so
nothing about those changes. Blankness is the only thing whitespace decides: a name with content in
it is still requested exactly as the server listed it, untrimmed — pinned by its own test so the
guard cannot quietly become name normalization.

The defect never appeared in an end-to-end test because the tool path rejects blank arguments before
they reach a skill. It is visible only to code calling the `Skill` API directly, which is where the
new tests drive it.

## Parity

- Reference checked: .NET `AgentMcpSkill.GetResourceAsync` guards with `string.IsNullOrWhiteSpace`
  before building the URI; Python `MCPSkill.get_resource` guards with `if not name or not
  name.strip()`, ahead of its traversal validation and its read. Go has no MCP skills source.
- Wire format affected: no
- Public API affected: no
- Breaking change: no

The core in-memory `Skill` keeps no such check and is deliberately left alone: it is a
case-insensitive lookup with no I/O, and Python's code-defined skill has no check either.

Two independent tests prove no request goes out — one counts every `resources/read` URI the test
server received, the other spies on the resource reader — and the fixture deliberately serves the
skill root, so a request that escaped would return content.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
