### PR TITLE
Declare the run_skill_script args default and name its script runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,16 @@ contain breaking changes**; patch releases are fixes only.
   still deliberately emitted by nothing, on spans and on metric dimensions alike, and its absence
   is now pinned by tests.
 
+- **`@polymind-inc/agent-framework-core`** — the `run_skill_script` tool now declares
+  `"default": null` on its `args` parameter and says that how the arguments reach the script is
+  "determined by the script implementation or configured runner". Both are model-visible schema
+  text: without the default, a model reading the schema had no statement that omitting `args`
+  is a supported call, and the description named only the in-process case even though a
+  file-based script is run by the `scriptRunner` its source was given. The default is advertised,
+  not applied — a script still receives `undefined` for an omitted `args` and `null` for an
+  explicit one, so nothing about execution changes. The whole published schema is now pinned by an
+  exact assertion.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/packages/core/src/skills/provider.test.ts
+++ b/packages/core/src/skills/provider.test.ts
@@ -10,7 +10,7 @@ import type { AnyFunctionTool, Tool, ToolContext } from '../tools/tool.js';
 import { isFunctionTool } from '../tools/tool.js';
 import { textContent } from '../types/content.js';
 import { SKILL_TOOL_NAMES, skillsProvider } from './provider.js';
-import type { Skill } from './skill.js';
+import type { Skill, SkillScriptArguments } from './skill.js';
 import { inlineSkill, skillResource, skillScript } from './skill.js';
 import type { SkillLoadFailure, SkillsSource } from './source.js';
 
@@ -193,6 +193,79 @@ describe('skillsProvider tools', () => {
         args: { value: 2, factor: 3 },
       }),
     ).toBe(6);
+  });
+
+  it('publishes the exact run_skill_script parameter schema', async () => {
+    // The whole schema, not a spot check: it is public surface the model reads, so any drift in a
+    // description or a keyword should fail here rather than change how a model calls the tool.
+    const contribution = await runProvider(skillsProvider([unitConverter]));
+
+    expect(toolNamed(contribution, SKILL_TOOL_NAMES.runSkillScript).jsonSchema).toEqual({
+      type: 'object',
+      properties: {
+        skill_name: { type: 'string', description: 'The name of the skill.' },
+        script_name: {
+          type: 'string',
+          description:
+            'The name of the script to run as listed in the skill, preserving any directory ' +
+            'prefix exactly as shown. Do not add or remove path prefixes.',
+        },
+        args: {
+          oneOf: [
+            {
+              type: 'object',
+              additionalProperties: true,
+              description: 'Named arguments as key-value pairs (e.g. {"length": 24, "uppercase": true}).',
+            },
+            {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                'Positional CLI arguments as a string array (e.g. ["input.docx", "--output", "result.idx"]).',
+            },
+            { type: 'null' },
+          ],
+          default: null,
+          description:
+            'Arguments to pass to the script. Use an array of strings for CLI-style positional ' +
+            'arguments (e.g. ["input.docx", "--output", "result.idx"]), or an object for named ' +
+            'parameters (e.g. {"length": 24, "uppercase": true}). How these values are mapped to ' +
+            'the underlying script is determined by the script implementation or configured runner.',
+        },
+      },
+      required: ['skill_name', 'script_name'],
+    });
+  });
+
+  it('hands the script exactly what the model sent for args, never the advertised default', async () => {
+    // `default` tells the model what omitting `args` means; it is not a value the tool substitutes.
+    // A script therefore still sees `undefined` for an omitted argument and `null` for an explicit
+    // one, and can tell the two apart.
+    const seen: unknown[] = [];
+    const probe = inlineSkill({
+      name: 'probe-skill',
+      description: 'Records the arguments a script was handed.',
+      instructions: 'Run probe.',
+      scripts: [
+        {
+          name: 'probe',
+          run: (args: SkillScriptArguments): string => {
+            seen.push(args);
+            return 'recorded';
+          },
+        },
+      ],
+    });
+    const contribution = await runProvider(skillsProvider([probe]));
+
+    for (const input of [
+      { skill_name: 'probe-skill', script_name: 'probe' },
+      { skill_name: 'probe-skill', script_name: 'probe', args: null },
+      { skill_name: 'probe-skill', script_name: 'probe', args: ['--json'] },
+    ]) {
+      expect(await invoke(contribution, SKILL_TOOL_NAMES.runSkillScript, input)).toBe('recorded');
+    }
+    expect(seen).toStrictEqual([undefined, null, ['--json']]);
   });
 
   it.each([

--- a/packages/core/src/skills/provider.ts
+++ b/packages/core/src/skills/provider.ts
@@ -316,6 +316,11 @@ function skillTools(skills: readonly Skill[], approvals: SkillApprovalModes): To
       if (script === undefined) {
         return `Error: Script '${scriptName}' not found in skill '${skillName}'.`;
       }
+      // The cast is wider than the truth: the schema's null branch means a model can send an
+      // explicit `null`, which reaches the script even though the declared type excludes it. The
+      // test driving all three shapes through this call pins that. Reconciling the two — widening
+      // the type or folding `null` into `undefined` — changes the published surface or what a
+      // script observes, so it is decided separately rather than here.
       return await script.run(input.args as SkillScriptArguments, invocationContext(skill, toolCtx));
     },
   });

--- a/packages/core/src/skills/provider.ts
+++ b/packages/core/src/skills/provider.ts
@@ -286,11 +286,15 @@ function skillTools(skills: readonly Skill[], approvals: SkillApprovalModes): To
             },
             { type: 'null' },
           ],
+          // Advertised only: omitting `args` is a supported call, and saying so keeps the model
+          // from inventing a placeholder for a script that takes nothing. The tool never
+          // substitutes the value — a script still sees `undefined` for an omitted argument.
+          default: null,
           description:
             'Arguments to pass to the script. Use an array of strings for CLI-style positional ' +
             'arguments (e.g. ["input.docx", "--output", "result.idx"]), or an object for named ' +
             'parameters (e.g. {"length": 24, "uppercase": true}). How these values are mapped to ' +
-            'the underlying script is determined by the script implementation.',
+            'the underlying script is determined by the script implementation or configured runner.',
         },
       },
       required: ['skill_name', 'script_name'],

--- a/packages/openai/src/strict-schema.test.ts
+++ b/packages/openai/src/strict-schema.test.ts
@@ -217,6 +217,9 @@ describe('toStrictJsonSchema', () => {
         described: { type: 'string', description: 'A value', default: 'fallback' },
         bare: { type: 'integer', default: 7 },
         nulled: { type: 'string', description: null, default: 'x' },
+        // A declared `default: null` is a default like any other — "absent" is spelled by leaving
+        // the keyword out, so the null has to survive as prose rather than be read as no default.
+        nullDefault: { type: ['string', 'null'], default: null },
       },
     });
 
@@ -224,6 +227,7 @@ describe('toStrictJsonSchema', () => {
       described: { type: 'string', description: 'A value (Default value: "fallback")' },
       bare: { type: 'integer', description: 'Default value: 7' },
       nulled: { type: 'string', description: 'Default value: "x"' },
+      nullDefault: { type: ['string', 'null'], description: 'Default value: null' },
     });
   });
 


### PR DESCRIPTION
## What this changes

Part of #113 — completes the **core / `run_skill_script` schema** item.

The `args` parameter of the `run_skill_script` tool published neither the `default: null` nor the
"or configured runner" clause its reference counterpart does. Both are model-visible: the default
tells the model that omitting `args` is a supported call, and the clause names the other thing that
can decide how a script is invoked.

The default is advertised only. The tool never substitutes it — an omitted `args` still reaches a
script as `undefined` — and a test drives the tool three times to pin exactly that, since the code
comment says so.

## Parity

- Reference checked: Python's skills provider is the only implementation sharing this parameter's
  `args` + `oneOf` shape, and it carries both. .NET generates its schema from a delegate signature
  with a differently named parameter; Go from a struct field. Everything else in the schema already
  matched byte-for-byte; these were the only two gaps.
- The clause is true of this implementation on its own terms: a file-based script discovered by the
  directory skills source is executed by that source's configured runner.
- Wire format affected: yes
- Public API affected: no
- Breaking change: no

The tool's JSON Schema gains one keyword and one clause. No exported symbol or TypeScript type
changes, and runtime execution is untouched.

Measured while checking the downstream path: the OpenAI strict-schema transform is never applied to
function-tool parameters — it runs only for response formats, and tool declarations go out with
`strict: false` — so the new keyword reaches the wire verbatim. That a `default: null` survives the
transform is now pinned where the transform lives, rather than asserted here.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
