### PR TITLE
Resolve the agentserver request id from the trace before the incoming header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,21 @@ contain breaking changes**; patch releases are fixes only.
   still deliberately emitted by nothing, on spans and on metric dimensions alike, and its absence
   is now pinned by tests.
 
+- **`@polymind-inc/agent-framework-agentserver`** — the `x-request-id` a response carries is now
+  the trace the request belongs to, when it names one. The value was the caller's `x-request-id`
+  header or a minted UUID, never the trace id, so the id on the response led nowhere in a trace
+  backend; both reference servers resolve the same three sources in the same order (.NET
+  `RequestIdMiddleware.ResolveRequestId`, Python `_request_id._resolve_request_id`). The trace id
+  is taken from the span active around the request, else from a registered propagator's extraction
+  — so a non-W3C format is honored — else from the `traceparent` header read directly, which keeps
+  the answer identical whether or not an OTel SDK was registered in the process. A trace id that is
+  not 32 hex digits, or is all zeros, names no trace and is skipped, as is an empty `x-request-id`
+  (previously echoed back as an empty header). The resolved value is the one already shared by the
+  response header, the `request_id` in an error body and `HostedAgentContext.requestId`, so all
+  three continue to agree. The `azure.ai.agentserver.x-request-id` baggage entry and the
+  `x_request_id` baggage the server propagates are unchanged: both still carry the header exactly
+  as the caller sent it, and are absent when the caller sent none.
+
 ## 0.4.0
 
 A hardening and consolidation release: ten breaking changes tighten types, credentials, telemetry

--- a/packages/agentserver/src/context.test.ts
+++ b/packages/agentserver/src/context.test.ts
@@ -191,6 +191,20 @@ describe('request id resolution', () => {
     },
   );
 
+  it('accepts a traceparent the caller padded with spaces', async () => {
+    // The grammar has no room for surrounding whitespace, and the matcher takes it literally. This
+    // still resolves because the header API strips the padding before either path reads the value —
+    // which is the assumption that lets the matcher stay exact. If that ever stops being true, this
+    // fails and the assumption gets revisited rather than silently costing callers their trace.
+    registerSdk();
+
+    const response = await makeServer().handle(
+      post({ input: 'x' }, { traceparent: `  ${TRACEPARENT}  `, [HEADERS.requestId]: 'req-123' }),
+    );
+
+    expect(requestIdOf(response)).toBe(TRACE_ID);
+  });
+
   it('answers a valid traceparent the same way with and without an SDK', async () => {
     // The other half of the same property: agreement has to hold for the values that do name a
     // trace, or the rule above would be satisfied by rejecting everything.

--- a/packages/agentserver/src/context.test.ts
+++ b/packages/agentserver/src/context.test.ts
@@ -1,0 +1,175 @@
+import type { Context, TextMapGetter, TextMapPropagator, TextMapSetter } from '@opentelemetry/api';
+import {
+  context as contextApi,
+  isValidTraceId,
+  metrics,
+  propagation,
+  ROOT_CONTEXT,
+  TraceFlags,
+  trace,
+} from '@opentelemetry/api';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { afterEach, assert, describe, expect, it } from 'vitest';
+import { HEADERS } from './context.js';
+import { makeServer, post } from './test-helpers.js';
+
+const TRACE_ID = '0123456789abcdef0123456789abcdef';
+const SPAN_ID = '0123456789abcdef';
+const TRACEPARENT = `00-${TRACE_ID}-${SPAN_ID}-01`;
+const ZERO_TRACEPARENT = '00-00000000000000000000000000000000-0000000000000000-00';
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/** A header carrying a trace id in a format no W3C propagator reads. */
+const CUSTOM_TRACE_HEADER = 'x-test-trace-id';
+const CUSTOM_TRACE_ID = 'aaaaaaaabbbbbbbbccccccccdddddddd';
+
+/**
+ * A propagator for {@link CUSTOM_TRACE_HEADER}, standing in for any non-W3C trace format a
+ * deployment might register (B3, Jaeger, a vendor's own).
+ */
+const customPropagator: TextMapPropagator = {
+  inject(_context: Context, _carrier: unknown, _setter: TextMapSetter): void {},
+  extract(context: Context, carrier: unknown, getter: TextMapGetter): Context {
+    const traceId = getter.get(carrier, CUSTOM_TRACE_HEADER);
+    if (typeof traceId !== 'string' || !isValidTraceId(traceId)) {
+      return context;
+    }
+    return trace.setSpanContext(context, {
+      traceId,
+      spanId: SPAN_ID,
+      traceFlags: TraceFlags.SAMPLED,
+      isRemote: true,
+    });
+  },
+  fields(): string[] {
+    return [CUSTOM_TRACE_HEADER];
+  },
+};
+
+/** Registers an SDK, which is what makes `context.with` and the global propagator take effect. */
+function registerSdk(propagator?: TextMapPropagator): void {
+  const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(new InMemorySpanExporter())],
+  });
+  provider.register(propagator === undefined ? {} : { propagator });
+}
+
+function requestIdOf(response: Response): string {
+  const value = response.headers.get(HEADERS.requestId);
+  assert.exists(value);
+  return value;
+}
+
+describe('request id resolution', () => {
+  afterEach(() => {
+    trace.disable();
+    metrics.disable();
+    propagation.disable();
+    contextApi.disable();
+  });
+
+  it('answers with the trace the caller named, over the correlation id it sent', async () => {
+    registerSdk();
+
+    const response = await makeServer().handle(
+      post({ input: 'x' }, { traceparent: TRACEPARENT, [HEADERS.requestId]: 'req-123' }),
+    );
+
+    expect(requestIdOf(response)).toBe(TRACE_ID);
+  });
+
+  it('reads the trace id off the header when no SDK is registered', async () => {
+    // Whether a deployment installed an OTel SDK is not something a calling service can see, so
+    // the id it gets back must not depend on it.
+    const response = await makeServer().handle(
+      post({ input: 'x' }, { traceparent: TRACEPARENT, [HEADERS.requestId]: 'req-123' }),
+    );
+
+    expect(requestIdOf(response)).toBe(TRACE_ID);
+  });
+
+  it('takes the trace id from a registered non-W3C propagator', async () => {
+    registerSdk(customPropagator);
+
+    const response = await makeServer().handle(
+      post(
+        { input: 'x' },
+        { [CUSTOM_TRACE_HEADER]: CUSTOM_TRACE_ID, traceparent: TRACEPARENT, [HEADERS.requestId]: 'req-123' },
+      ),
+    );
+
+    expect(requestIdOf(response)).toBe(CUSTOM_TRACE_ID);
+  });
+
+  it('prefers the trace already active over the one the request names', async () => {
+    registerSdk();
+    const active = trace.setSpanContext(ROOT_CONTEXT, {
+      traceId: CUSTOM_TRACE_ID,
+      spanId: SPAN_ID,
+      traceFlags: TraceFlags.SAMPLED,
+    });
+
+    const response = await contextApi.with(active, () =>
+      makeServer().handle(post({ input: 'x' }, { traceparent: TRACEPARENT })),
+    );
+
+    expect(requestIdOf(response)).toBe(CUSTOM_TRACE_ID);
+  });
+
+  it.each([
+    // Nothing like a traceparent, a well-shaped one whose trace id is not hex, and one truncated
+    // to fewer fields than the format defines.
+    'not-a-traceparent',
+    `00-nothex${'0'.repeat(26)}-${SPAN_ID}-01`,
+    `00-${TRACE_ID}`,
+  ])(
+    'falls back to the correlation id the caller sent when the traceparent is malformed (%s)',
+    async (traceparent) => {
+      registerSdk();
+
+      const response = await makeServer().handle(
+        post({ input: 'x' }, { traceparent, [HEADERS.requestId]: 'req-123' }),
+      );
+
+      expect(requestIdOf(response)).toBe('req-123');
+    },
+  );
+
+  it('treats an all-zero trace id as no trace at all', async () => {
+    registerSdk();
+
+    const response = await makeServer().handle(
+      post({ input: 'x' }, { traceparent: ZERO_TRACEPARENT, [HEADERS.requestId]: 'req-123' }),
+    );
+
+    expect(requestIdOf(response)).toBe('req-123');
+  });
+
+  it('mints an id when the only trace id offered is all zeros and no correlation id was sent', async () => {
+    const response = await makeServer().handle(post({ input: 'x' }, { traceparent: ZERO_TRACEPARENT }));
+
+    const requestId = requestIdOf(response);
+    expect(requestId).not.toContain('0000000000000000');
+    expect(requestId).toMatch(UUID);
+  });
+
+  it('echoes an empty correlation id as a minted one rather than an empty header', async () => {
+    const response = await makeServer().handle(post({ input: 'x' }, { [HEADERS.requestId]: '' }));
+
+    expect(requestIdOf(response)).toMatch(UUID);
+  });
+
+  it('reports one resolved id on the response header and in the error body', async () => {
+    registerSdk();
+
+    const response = await makeServer().handle(
+      new Request('http://localhost:8088/nope', { headers: { traceparent: TRACEPARENT } }),
+    );
+    const body = (await response.json()) as { error: { additionalInfo: { request_id: string } } };
+
+    expect(response.status).toBe(404);
+    expect(requestIdOf(response)).toBe(TRACE_ID);
+    expect(body.error.additionalInfo.request_id).toBe(requestIdOf(response));
+  });
+});

--- a/packages/agentserver/src/context.test.ts
+++ b/packages/agentserver/src/context.test.ts
@@ -136,6 +136,76 @@ describe('request id resolution', () => {
     },
   );
 
+  // Every field of a traceparent decides whether the value names a trace, not the trace id alone.
+  // A header that breaks the format is not a trace this request belongs to, so it must not displace
+  // the correlation id the caller sent — nor mint one over it.
+  const MALFORMED_TRACEPARENTS: ReadonlyArray<[string, string]> = [
+    ['an all-zero parent id', `00-${TRACE_ID}-0000000000000000-01`],
+    ['a non-hex parent id', `00-${TRACE_ID}-nothexnothexnoth-01`],
+    ['a short parent id', `00-${TRACE_ID}-0123456789abcde-01`],
+    ['a long parent id', `00-${TRACE_ID}-0123456789abcdef0-01`],
+    ['non-hex flags', `00-${TRACE_ID}-${SPAN_ID}-zz`],
+    ['short flags', `00-${TRACE_ID}-${SPAN_ID}-1`],
+    ['long flags', `00-${TRACE_ID}-${SPAN_ID}-011`],
+    ['the reserved version ff', `ff-${TRACE_ID}-${SPAN_ID}-01`],
+    ['a short version', `0-${TRACE_ID}-${SPAN_ID}-01`],
+    ['a long version', `000-${TRACE_ID}-${SPAN_ID}-01`],
+    ['a non-hex version', `zz-${TRACE_ID}-${SPAN_ID}-01`],
+    ['a fifth field on version 00', `00-${TRACE_ID}-${SPAN_ID}-01-extra`],
+  ];
+
+  it.each(MALFORMED_TRACEPARENTS)(
+    'keeps the correlation id the caller sent when the traceparent has %s',
+    async (_label, traceparent) => {
+      // Both paths, because the header read here has to agree with what a propagator extracts:
+      // the calling service cannot see whether this deployment installed an SDK, so the id it
+      // gets back must not depend on that. Registering one exercises the extract path; the second
+      // call leaves the propagation API a no-op and exercises the direct read.
+      registerSdk();
+      const withSdk = await makeServer().handle(
+        post({ input: 'x' }, { traceparent, [HEADERS.requestId]: 'req-123' }),
+      );
+      expect(requestIdOf(withSdk)).toBe('req-123');
+    },
+  );
+
+  it.each(MALFORMED_TRACEPARENTS)(
+    'keeps the correlation id with no SDK registered when the traceparent has %s',
+    async (_label, traceparent) => {
+      const response = await makeServer().handle(
+        post({ input: 'x' }, { traceparent, [HEADERS.requestId]: 'req-123' }),
+      );
+
+      expect(requestIdOf(response)).toBe('req-123');
+    },
+  );
+
+  it.each(MALFORMED_TRACEPARENTS)(
+    'mints an id when the traceparent has %s and no correlation id was sent',
+    async (_label, traceparent) => {
+      registerSdk();
+
+      const response = await makeServer().handle(post({ input: 'x' }, { traceparent }));
+
+      expect(requestIdOf(response)).toMatch(UUID);
+    },
+  );
+
+  it('answers a valid traceparent the same way with and without an SDK', async () => {
+    // The other half of the same property: agreement has to hold for the values that do name a
+    // trace, or the rule above would be satisfied by rejecting everything.
+    const withoutSdk = await makeServer().handle(
+      post({ input: 'x' }, { traceparent: TRACEPARENT, [HEADERS.requestId]: 'req-123' }),
+    );
+    registerSdk();
+    const withSdk = await makeServer().handle(
+      post({ input: 'x' }, { traceparent: TRACEPARENT, [HEADERS.requestId]: 'req-123' }),
+    );
+
+    expect(requestIdOf(withoutSdk)).toBe(TRACE_ID);
+    expect(requestIdOf(withSdk)).toBe(TRACE_ID);
+  });
+
   it('treats an all-zero trace id as no trace at all', async () => {
     registerSdk();
 

--- a/packages/agentserver/src/context.ts
+++ b/packages/agentserver/src/context.ts
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { context as otelContext, propagation } from '@opentelemetry/api';
+import { inboundTraceId } from './observability/trace-context.js';
 
 /** The HTTP header names that make up the platform contract (protocol v2.0.0). */
 export const HEADERS = {
@@ -33,6 +34,13 @@ export interface RequestContext {
   readonly userId: string | undefined;
   /** The platform's per-request call id, when protocol v2.0.0 is in play. */
   readonly foundryCallId: string | undefined;
+  /**
+   * The correlation id for this request, in priority order: the trace this request belongs to,
+   * the non-empty `x-request-id` the caller sent, or one minted here.
+   *
+   * One value serves every place the id surfaces — the response header and the error body — so a
+   * log line naming it identifies exactly one turn.
+   */
   readonly requestId: string;
   /** `x-client-*` headers the caller sent. */
   readonly clientHeaders: Readonly<Record<string, string>>;
@@ -69,11 +77,36 @@ function collectClientHeaders(headers: Headers): Record<string, string> {
   return collected;
 }
 
+/**
+ * The correlation id one request answers under, resolved once.
+ *
+ * In order: the trace this request belongs to, then a non-empty `x-request-id` the caller sent,
+ * then a fresh id.
+ *
+ * The trace id leads because it is the only candidate that also names the spans this turn
+ * produced: an operator holding it can move between the response, the platform's logs and the
+ * trace without a second lookup. A caller's `x-request-id` correlates only with that caller, and
+ * a minted id with nothing at all — each is what remains when the richer source is absent. An
+ * empty header is not a correlation id, so it is treated as no header rather than echoed back as
+ * an empty one.
+ */
+function resolveRequestId(headers: Headers): string {
+  const traceId = inboundTraceId(headers);
+  if (traceId !== undefined) {
+    return traceId;
+  }
+  const incoming = headers.get(HEADERS.requestId);
+  if (incoming !== null && incoming !== '') {
+    return incoming;
+  }
+  return crypto.randomUUID();
+}
+
 /** Builds the context for one inbound request. */
 export function createRequestContext(headers: Headers): RequestContext {
   const userId = headers.get(HEADERS.userId) ?? undefined;
   const foundryCallId = headers.get(HEADERS.foundryCallId) ?? undefined;
-  const requestId = headers.get(HEADERS.requestId) ?? crypto.randomUUID();
+  const requestId = resolveRequestId(headers);
   const clientHeaders = collectClientHeaders(headers);
   const traceparent = headers.get('traceparent') ?? undefined;
   const tracestate = headers.get('tracestate') ?? undefined;

--- a/packages/agentserver/src/invocations.test.ts
+++ b/packages/agentserver/src/invocations.test.ts
@@ -293,6 +293,17 @@ describe('header contract', () => {
     expect(requestId).toMatch(UUID);
   });
 
+  it('resolves the request id the same way the Responses protocol does', async () => {
+    // Both protocols sit behind one container contract, so the correlation id a caller reads back
+    // must not depend on which route it asked for. See `context.test.ts` for the full precedence.
+    const traceId = '0123456789abcdef0123456789abcdef';
+    const response = await makeServer().handle(
+      invoke('x', { traceparent: `00-${traceId}-0123456789abcdef-01`, [HEADERS.requestId]: 'req-1' }),
+    );
+
+    expect(response.headers.get(HEADERS.requestId)).toBe(traceId);
+  });
+
   it('hands the platform identity to the handler through the request context', async () => {
     const server = makeServer({
       handler: (_request, context) =>

--- a/packages/agentserver/src/observability/trace-context.ts
+++ b/packages/agentserver/src/observability/trace-context.ts
@@ -8,11 +8,13 @@
  * deliberate choice on both sides (.NET `ResponsesActivitySource`, Python
  * `TraceContextMiddleware`).
  *
- * With no SDK registered, `propagation` is a no-op and everything here returns the root context.
+ * With no SDK registered, `propagation` is a no-op and every context built here is the root
+ * context. {@link inboundTraceId} is the exception: what it answers reaches the caller on a
+ * response header, so it reads the inbound `traceparent` itself rather than going quiet.
  */
 
 import type { Context, TextMapGetter } from '@opentelemetry/api';
-import { propagation, ROOT_CONTEXT } from '@opentelemetry/api';
+import { isValidTraceId, context as otelContext, propagation, ROOT_CONTEXT, trace } from '@opentelemetry/api';
 
 const HEADERS_GETTER: TextMapGetter<Headers> = {
   get(carrier: Headers, key: string): string | undefined {
@@ -37,6 +39,49 @@ export function extractTraceContext(headers: Headers): Context {
     extracted = propagation.setBaggage(extracted, bag.setEntry('x_request_id', { value: requestId }));
   }
   return extracted;
+}
+
+/**
+ * The trace-id field of a W3C `traceparent`, when the value carries a usable one.
+ *
+ * The format is `version-traceid-parentid-flags`; a later version may append fields, so only the
+ * leading four are required.
+ */
+function traceparentTraceId(traceparent: string | null): string | undefined {
+  if (traceparent === null) {
+    return undefined;
+  }
+  const fields = traceparent.trim().split('-');
+  const traceId = fields.length >= 4 ? fields[1] : undefined;
+  return traceId !== undefined && isValidTraceId(traceId) ? traceId : undefined;
+}
+
+/**
+ * The trace this request already belongs to, or `undefined` when it belongs to none.
+ *
+ * Three sources, in priority order: the span active around the call — an outer instrumentation's
+ * server span, when the host created one — then the context a registered propagator extracts from
+ * the request, which is what carries a non-W3C format, and finally the `traceparent` header read
+ * directly.
+ *
+ * That last source is what keeps the answer the same whether or not an OTel SDK was ever
+ * registered: with none, the propagation API is a no-op. A value the caller reads back off the
+ * response is part of the contract with that caller, so it must not change because of a
+ * telemetry choice made inside this process.
+ *
+ * A trace id that is not 32 hex digits, or is all zeros — the value W3C reserves for "no trace",
+ * which a broken instrumentation does emit — names no trace and is rejected at every source.
+ */
+export function inboundTraceId(headers: Headers): string | undefined {
+  const active = trace.getSpanContext(otelContext.active())?.traceId;
+  if (active !== undefined && isValidTraceId(active)) {
+    return active;
+  }
+  const extracted = trace.getSpanContext(propagation.extract(ROOT_CONTEXT, headers, HEADERS_GETTER))?.traceId;
+  if (extracted !== undefined && isValidTraceId(extracted)) {
+    return extracted;
+  }
+  return traceparentTraceId(headers.get('traceparent'));
 }
 
 /**

--- a/packages/agentserver/src/observability/trace-context.ts
+++ b/packages/agentserver/src/observability/trace-context.ts
@@ -42,18 +42,40 @@ export function extractTraceContext(headers: Headers): Context {
 }
 
 /**
- * The trace-id field of a W3C `traceparent`, when the value carries a usable one.
+ * The W3C `traceparent` grammar: `version-traceid-parentid-flags`, lowercase hex throughout.
  *
- * The format is `version-traceid-parentid-flags`; a later version may append fields, so only the
- * leading four are required.
+ * `ff` is reserved and is never a version. Neither id may be all zeros — that is the value the
+ * format defines as "no trace". A version this build does not know may append further fields, so
+ * the trailing group is allowed and checked against the version below.
+ */
+const TRACEPARENT =
+  /^\s?((?!ff)[\da-f]{2})-((?![0]{32})[\da-f]{32})-(?![0]{16})[\da-f]{16}-[\da-f]{2}(-.*)?\s?$/;
+
+/**
+ * The trace-id field of a W3C `traceparent`, when the whole value is one.
+ *
+ * Every field decides this, not the trace id alone: a header whose parent id is all zeros, whose
+ * flags are not two hex digits, or whose version is the reserved `ff` does not name a trace this
+ * request belongs to, and reading an id out of it would let a malformed header displace the
+ * correlation id the caller sent.
+ *
+ * The rule is the grammar itself, which is also what a conforming propagator applies — so the
+ * answer here and the answer from an extracted context agree on the same header, and that
+ * agreement is what the tests pin rather than the wording of this comment.
  */
 function traceparentTraceId(traceparent: string | null): string | undefined {
   if (traceparent === null) {
     return undefined;
   }
-  const fields = traceparent.trim().split('-');
-  const traceId = fields.length >= 4 ? fields[1] : undefined;
-  return traceId !== undefined && isValidTraceId(traceId) ? traceId : undefined;
+  const match = TRACEPARENT.exec(traceparent);
+  if (match === null) {
+    return undefined;
+  }
+  // Extra fields belong to versions that define them; version `00` is exactly four.
+  if (match[1] === '00' && match[3] !== undefined) {
+    return undefined;
+  }
+  return match[2];
 }
 
 /**

--- a/packages/agentserver/src/observability/trace-context.ts
+++ b/packages/agentserver/src/observability/trace-context.ts
@@ -47,9 +47,12 @@ export function extractTraceContext(headers: Headers): Context {
  * `ff` is reserved and is never a version. Neither id may be all zeros — that is the value the
  * format defines as "no trace". A version this build does not know may append further fields, so
  * the trailing group is allowed and checked against the version below.
+ *
+ * Exact, with no allowance for surrounding whitespace: the header API has already stripped it by
+ * the time a value is read, on this path and on the propagator's alike, so tolerating it here would
+ * only widen the grammar past what it says.
  */
-const TRACEPARENT =
-  /^\s?((?!ff)[\da-f]{2})-((?![0]{32})[\da-f]{32})-(?![0]{16})[\da-f]{16}-[\da-f]{2}(-.*)?\s?$/;
+const TRACEPARENT = /^((?!ff)[\da-f]{2})-((?![0]{32})[\da-f]{32})-(?![0]{16})[\da-f]{16}-[\da-f]{2}(-.*)?$/;
 
 /**
  * The trace-id field of a W3C `traceparent`, when the whole value is one.

--- a/packages/agentserver/src/server.ts
+++ b/packages/agentserver/src/server.ts
@@ -588,8 +588,10 @@ export class ResponsesServer {
       responseId,
       conversationId,
       streaming: created.stream === true,
-      // The header as sent, not `context.requestId`: that falls back to a generated id, and the
-      // reference sets this entry only when the caller actually supplied one.
+      // The header as sent, not `context.requestId`: this entry records what the caller supplied,
+      // and the resolved id is a different value — it prefers the trace id and otherwise mints
+      // one. A span already carries its trace, so stamping that back on as baggage would say
+      // nothing, while an entry present on every turn could not be told from a real one.
       requestId: request.headers.get(HEADERS.requestId) ?? undefined,
     });
 


### PR DESCRIPTION
## What this changes

Part of #113 — completes the **agentserver / request-ID precedence** item.

`x-request-id` was answered from the incoming header alone, so a request that named a trace got a
correlation id unrelated to it, and an empty incoming header was echoed back as an empty one. The id
now resolves in three steps: a valid trace id first, then a non-empty incoming `x-request-id`, then
a minted one.

The trace id is looked for in three places — the active span, a registered propagator's extraction,
then the `traceparent` header read directly. The last matters because the response header is a
contract with the caller: its value must not depend on whether an OpenTelemetry SDK happens to be
registered in the process.

A trace id that is not 32 hex characters, or is all zeros, counts as no trace at all, at every source.

## Parity

- Reference checked: .NET `RequestIdMiddleware.ResolveRequestId` and Python `_resolve_request_id`,
  branch for branch — the same three steps, the same all-zero rejection, and the same single resolved
  value reaching both the response header and the error body. Go has no agentserver. Reference test
  counts: .NET 4, Python 6; this adds 12.
- Deliberate divergences, both recorded in code: the two baggage entries carrying `x-request-id` stay
  on the **raw** header, matching .NET's propagator — stamping the resolved id there would put the
  span's own trace back on the span and erase the "the caller sent one" signal. And the minted
  fallback stays a dashed UUID where the references mint dashless hex; it is an opaque correlator and
  the item does not ask for it.
- Wire format affected: yes
- Public API affected: no
- Breaking change: no

The `x-request-id` response header and the `request_id` in an error body now carry the trace id when
the request names one, and an empty incoming header no longer echoes back empty.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
