### PR TITLE
Pin the send-time filtering of unanswered OpenAI function calls

### DIFF
--- a/packages/openai/src/chat-client.test.ts
+++ b/packages/openai/src/chat-client.test.ts
@@ -1,4 +1,4 @@
-import type { Message } from '@polymind-inc/agent-framework-core';
+import type { FunctionCallContent, Message } from '@polymind-inc/agent-framework-core';
 import {
   Agent,
   approvalResponse,
@@ -1065,6 +1065,71 @@ describe('Agent over OpenAIChatClient', () => {
       'user',
       'assistant',
       'user',
+    ]);
+  });
+
+  it('replays a JSON round-tripped session that still holds an unanswered call', async () => {
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce(
+        completedResponse({
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_1',
+              call_id: 'call_1',
+              name: 'book_flight',
+              arguments: '{"to":"Tokyo"}',
+              status: 'completed',
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(completedResponse({ id: 'resp_2' }));
+
+    // A declaration-only tool hands the call back to the caller instead of answering it, so turn
+    // one ends with a call no result pairs with. Saving and restoring the session is what a
+    // caller does between turns, and it must not turn that transcript into a failing request.
+    const book = tool({
+      name: 'book_flight',
+      description: 'Book a flight',
+      parameters: { type: 'object', properties: { to: { type: 'string' } } },
+    });
+    const agent = new Agent({
+      client: new OpenAIChatClient({ client: fakeClient(create), model: 'gpt-4o' }),
+      tools: [book],
+    });
+    const session = agent.createSession();
+    await agent.run('book me a flight', { session });
+
+    const restored = agent.deserializeSession(JSON.parse(JSON.stringify(session)));
+    const stored = await agent.historyProvider.getMessages(
+      restored,
+      restored.partition(agent.historyProvider.sourceId),
+    );
+    const restoredCall = stored
+      .flatMap((message) => message.contents)
+      .find((content): content is FunctionCallContent => content.type === 'function_call');
+    // The call is in the transcript the next turn replays, and it arrives there with no provider
+    // object attached — serialization drops `rawRepresentation` — so whatever the wire conversion
+    // does with it below, it does from the persisted fields alone.
+    assert.exists(restoredCall);
+    expect(restoredCall.callId).toBe('call_1');
+    expect(restoredCall.rawRepresentation).toBeUndefined();
+
+    const resumed = await agent.run('never mind, say hello', { session: restored });
+
+    expect(resumed.text).toBe('Hello!');
+    const secondInput = create.mock.calls[1]?.[0].input as InputItem[];
+    expect(secondInput.some((item) => item.type === 'function_call')).toBe(false);
+    // Both user turns reach the model; only the unanswerable call is missing.
+    expect(secondInput.map((item) => [item.type, item.role])).toEqual([
+      ['message', 'user'],
+      ['message', 'user'],
+    ]);
+    expect(secondInput.flatMap((item) => item.content ?? []).map((part) => part.text)).toEqual([
+      'book me a flight',
+      'never mind, say hello',
     ]);
   });
 });

--- a/packages/openai/src/chat-client.test.ts
+++ b/packages/openai/src/chat-client.test.ts
@@ -1120,6 +1120,9 @@ describe('Agent over OpenAIChatClient', () => {
     const resumed = await agent.run('never mind, say hello', { session: restored });
 
     expect(resumed.text).toBe('Hello!');
+    // Named before it is read: without this, a second request that never happened fails as a
+    // property access on undefined rather than as the missing turn it is.
+    expect(create.mock.calls).toHaveLength(2);
     const secondInput = create.mock.calls[1]?.[0].input as InputItem[];
     expect(secondInput.some((item) => item.type === 'function_call')).toBe(false);
     // Both user turns reach the model; only the unanswerable call is missing.

--- a/packages/openai/src/to-openai.wire-fallbacks.test.ts
+++ b/packages/openai/src/to-openai.wire-fallbacks.test.ts
@@ -332,6 +332,42 @@ describe('stateless replay validation', () => {
   });
 });
 
+describe('unanswered function calls', () => {
+  const call = {
+    type: 'function_call',
+    callId: 'call_1',
+    name: 'book_flight',
+    arguments: '{"to":"Tokyo"}',
+  } as const;
+
+  it('omits a lone unanswered call instead of failing the conversion', () => {
+    // A transcript can legitimately end on a call nothing answered: an approval the user never
+    // decided, a run that stopped on its iteration budget, an abandoned stream. Replaying such a
+    // transcript is a normal thing to ask for, so the unanswerable item is dropped here rather
+    // than raising the way the reasoning-group check above does. The split is deliberate: the
+    // transcript keeps the call, and the request built from it leaves the call out.
+    const messages: Message[] = [{ role: 'assistant', contents: [call] }];
+
+    expect(() => toResponsesInput(messages)).not.toThrow();
+    expect(toResponsesInput(messages)).toEqual([]);
+  });
+
+  it('keeps the user turns around an unanswered call and removes only the call', () => {
+    const items = toResponsesInput([
+      { role: 'user', contents: [{ type: 'text', text: 'book me a flight' }] },
+      { role: 'assistant', contents: [call] },
+      { role: 'user', contents: [{ type: 'text', text: 'never mind' }] },
+    ]);
+
+    // The conversation the model reads back is the whole transcript minus the one unanswerable
+    // item; the user's own words on either side of it are not collateral.
+    expect(items).toEqual([
+      { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'book me a flight' }] },
+      { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'never mind' }] },
+    ]);
+  });
+});
+
 describe('approval serialization boundaries', () => {
   const localCall = {
     type: 'function_call',

--- a/packages/openai/src/to-openai.wire-fallbacks.test.ts
+++ b/packages/openai/src/to-openai.wire-fallbacks.test.ts
@@ -341,7 +341,7 @@ describe('unanswered function calls', () => {
   } as const;
 
   it('omits a lone unanswered call instead of failing the conversion', () => {
-    // A transcript can legitimately end on a call nothing answered: an approval the user never
+    // A transcript can legitimately end on a call that nothing answered: an approval the user never
     // decided, a run that stopped on its iteration budget, an abandoned stream. Replaying such a
     // transcript is a normal thing to ask for, so the unanswerable item is dropped here rather
     // than raising the way the reasoning-group check above does. The split is deliberate: the


### PR DESCRIPTION
## What this changes

Part of #113 — completes the **openai / unanswered function-call wire tests** item. Tests only; no
runtime change, and no orphan call is preserved.

Dropping an unanswered local `function_call` at send time is deliberate: replaying a transcript that
legitimately contains one — an approval pause, an iteration-limit stop, an abandoned stream — would
otherwise hard-fail. That intent lived in the tracker and in a source comment and was pinned by one
test covering only a mixed message. Three tests now hold the rest of it:

- a lone unanswered call converts to an empty input rather than throwing;
- a later user turn survives while only the call is removed;
- a session that has been through `JSON.parse(JSON.stringify(...))` and restored behaves the same.

The round-trip test reads the restored transcript back and asserts the call is still present **and**
that its `rawRepresentation` is gone, so the test is neither vacuous nor leaning on a field that
serialization drops.

## Parity

- Reference checked: none needed — this records a decision this repository made and the tracker
  documents, rather than a behaviour ported from elsewhere.
- Wire format affected: no
- Public API affected: no
- Breaking change: no

Each test was checked by breaking the filter and confirming it fails: with the `answered` check
removed, all three fail; with serialization made to keep `rawRepresentation`, the round-trip one
fails. `git diff` against the implementation files is empty.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
