### PR TITLE
Carry non-object Anthropic tool arguments under raw instead of erasing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **[BREAKING] `@polymind-inc/agent-framework-anthropic`** — tool arguments that are not an object
+  are sent to the Messages API under a single `raw` key instead of being replaced with `{}`. A
+  JSON scalar, array or `null` becomes `{ raw: <value> }`, and text JSON cannot parse becomes
+  `{ raw: "<the original characters>" }`, untrimmed; only an empty string still maps to `{}`. This
+  matches Python, whose Anthropic client sends `parse_arguments()` straight through as
+  `tool_use.input`. Normal responses are unaffected — the fallback is reached by interrupted
+  streams, restored or hand-built transcripts, and arguments another provider produced. Erasing
+  them was measurably worse than keeping them: for a tool whose parameters are all optional, `{}`
+  is byte-for-byte a valid no-argument call, so a corrupted payload became a different, plausible
+  invocation that nothing downstream could detect, and the API does not catch it either — it does
+  not validate a replayed `tool_use.input` against the tool's schema, not even with `strict` and
+  `additionalProperties: false`. A tool that declares a `raw` parameter of its own now sees a name
+  collision in what the model reads; rename that parameter if the ambiguity matters. Separately, a
+  value that is neither a string nor an object — reachable from a session restored from JSON,
+  which is not validated — no longer passes through to the wire, where the API rejected it with
+  `400 tool_use.input: Input should be an object`. `FunctionCallContent.arguments` and serialized
+  sessions are unchanged.
+
 - **[BREAKING] `@polymind-inc/agent-framework-a2a`** — a remote task's status message becomes a
   response message only when the task is waiting for input (`input-required`). Previously an
   awaited `run()` also materialized the status message of a `completed`, `failed`, `canceled` or

--- a/packages/anthropic/README.md
+++ b/packages/anthropic/README.md
@@ -36,11 +36,23 @@ one, but a transcript can reach the conversion from elsewhere — an interrupted
 or hand-built history, arguments another provider wrote — and carry a scalar, an array, or text
 that is not valid JSON.
 
-Those are sent as `{ raw: <the value> }` rather than replaced with `{}`, matching Python. Only an
-empty string maps to `{}`. Preserving them keeps the corruption visible: for a tool whose
-parameters are all optional, `{}` is byte-for-byte a valid no-argument call, and the API does not
-validate a replayed `tool_use.input` against the tool's schema, so an erased payload becomes a
-plausible invocation that nothing downstream can detect.
+Those are sent as `{ raw: … }` rather than replaced with `{}`, matching Python. What lands under
+`raw` depends on whether the text was JSON at all — valid JSON is parsed first, and anything else
+keeps its original characters, untrimmed, so a truncated payload can still be read back as it
+arrived:
+
+| `arguments` | `tool_use.input` |
+| --- | --- |
+| `'{"city":"Osaka"}'` | `{ city: 'Osaka' }` |
+| `''` | `{}` |
+| `'42'` / `'null'` / `'[1,2]'` | `{ raw: 42 }` / `{ raw: null }` / `{ raw: [1, 2] }` |
+| `'{"city":"Os'` | `{ raw: '{"city":"Os' }` |
+| `'   '` | `{ raw: '   ' }` |
+
+Preserving them keeps the corruption visible: for a tool whose parameters are all optional, `{}` is
+byte-for-byte a valid no-argument call, and the API does not validate a replayed `tool_use.input`
+against the tool's schema, so an erased payload becomes a plausible invocation that nothing
+downstream can detect.
 
 If one of your tools declares a parameter named `raw`, a corrupted call for that tool will look to
 the model like a call with `raw` set. Rename the parameter if that ambiguity matters.

--- a/packages/anthropic/README.md
+++ b/packages/anthropic/README.md
@@ -29,6 +29,25 @@ const response = await agent.run('Summarize the Messages API in one sentence.');
 console.log(response.text);
 ```
 
+## Tool arguments that are not an object
+
+The Messages API requires `tool_use.input` to be a JSON object. A normal response always produces
+one, but a transcript can reach the conversion from elsewhere — an interrupted stream, a restored
+or hand-built history, arguments another provider wrote — and carry a scalar, an array, or text
+that is not valid JSON.
+
+Those are sent as `{ raw: <the value> }` rather than replaced with `{}`, matching Python. Only an
+empty string maps to `{}`. Preserving them keeps the corruption visible: for a tool whose
+parameters are all optional, `{}` is byte-for-byte a valid no-argument call, and the API does not
+validate a replayed `tool_use.input` against the tool's schema, so an erased payload becomes a
+plausible invocation that nothing downstream can detect.
+
+If one of your tools declares a parameter named `raw`, a corrupted call for that tool will look to
+the model like a call with `raw` set. Rename the parameter if that ambiguity matters.
+
+`FunctionCallContent.arguments` and serialized sessions are never rewritten — this applies only to
+what goes on the wire.
+
 ---
 
 Part of [Agent Framework for TypeScript](https://github.com/polymind-inc/agent-framework-js) — an

--- a/packages/anthropic/src/chat-client.test.ts
+++ b/packages/anthropic/src/chat-client.test.ts
@@ -403,9 +403,10 @@ describe('beta namespace routing', () => {
 });
 
 describe('message conversion', () => {
-  it('coerces non-object tool arguments to an empty input object', () => {
+  it('carries non-object tool arguments under `raw` instead of erasing them', () => {
     // `tool_use.input` must be a JSON object on the wire; a replayed transcript can carry a
-    // stringified array or scalar, and neither may pass through as `input`.
+    // stringified array or scalar, and neither may pass through as `input`. Sending `{}` in their
+    // place would read as a valid no-argument call for any tool whose parameters are optional.
     const calls: Message = {
       role: 'assistant',
       contents: [
@@ -418,8 +419,8 @@ describe('message conversion', () => {
       {
         role: 'assistant',
         content: [
-          { type: 'tool_use', id: 'c1', name: 'search', input: {} },
-          { type: 'tool_use', id: 'c2', name: 'search', input: {} },
+          { type: 'tool_use', id: 'c1', name: 'search', input: { raw: [] } },
+          { type: 'tool_use', id: 'c2', name: 'search', input: { raw: 'text' } },
         ],
       },
     ]);

--- a/packages/anthropic/src/to-anthropic.ts
+++ b/packages/anthropic/src/to-anthropic.ts
@@ -43,24 +43,41 @@ const ASSISTANT_BLOCKS = new Set(['tool_use', 'mcp_tool_use', 'server_tool_use']
 /** Blocks that only make sense on a user turn. */
 const USER_BLOCKS = new Set(['tool_result', 'mcp_tool_result']);
 
-/** Messages API wants `input` as an object, so a string payload is parsed back. */
+/**
+ * The object the Messages API wants as `tool_use.input`.
+ *
+ * Anything that is not an object is carried under a single `raw` key rather than erased. A
+ * transcript reaches this function from places the model never wrote — an interrupted stream, a
+ * restored session, arguments another provider produced — and there an empty object is not the
+ * safe reading: a tool whose parameters are all optional receives `{}` as a legitimately valid
+ * call, so erasing a corrupted payload turns it into a different invocation that nothing
+ * downstream can tell apart from the real one. Keeping the payload makes the corruption visible
+ * to whoever reads the transcript, and the API accepts the extra key: it does not validate a
+ * replayed `tool_use.input` against the tool's schema, not even with `strict` and
+ * `additionalProperties: false`.
+ *
+ * A tool that declares `raw` as a parameter of its own is the one case where this is ambiguous to
+ * the model. That is a naming collision in what the model reads, not a transport error.
+ *
+ * The empty string maps to `{}` because a call with no arguments at all is not corrupted. Every
+ * other unparseable text keeps its original characters, untrimmed.
+ */
 function toolInput(args: Record<string, unknown> | string): Record<string, unknown> {
-  if (typeof args !== 'string') {
-    return args;
+  if (typeof args === 'string') {
+    if (args === '') {
+      return {};
+    }
+    try {
+      const parsed: unknown = JSON.parse(args);
+      return isRecord(parsed) ? parsed : { raw: parsed };
+    } catch {
+      return { raw: args };
+    }
   }
-  const trimmed = args.trim();
-  if (trimmed === '') {
-    return {};
-  }
-  try {
-    const parsed: unknown = JSON.parse(trimmed);
-    // Arrays and scalars are valid JSON but not a valid `input`; they degrade the same way.
-    return isRecord(parsed) ? parsed : {};
-  } catch {
-    // A half-streamed fragment can reach here after a fold; an empty object is closer to the
-    // model's intent than a 400 from the API.
-    return {};
-  }
+  // The declared type says this is already an object, but nothing validates it: a session
+  // deserialized from JSON can hold an array or a number here, and the API answers a non-object
+  // `input` with 400 `Input should be an object`.
+  return isRecord(args) ? args : { raw: args };
 }
 
 /** The base64 payload of a `data:` URI, or `undefined` when it is not base64-encoded. */

--- a/packages/anthropic/src/to-anthropic.wire-fallbacks.test.ts
+++ b/packages/anthropic/src/to-anthropic.wire-fallbacks.test.ts
@@ -32,17 +32,41 @@ describe('tool_use input parsing', () => {
     expect(inputOf({ city: 'Osaka' })).toEqual({ city: 'Osaka' });
   });
 
-  it('maps empty and blank argument strings to an empty object', () => {
+  it('maps an empty argument string to an empty object', () => {
     expect(inputOf('')).toEqual({});
-    expect(inputOf('   ')).toEqual({});
   });
 
-  it('maps a JSON scalar to an empty object rather than sending a non-object input', () => {
-    expect(inputOf('"just a string"')).toEqual({});
+  it('preserves a JSON scalar, array or null under `raw`', () => {
+    expect(inputOf('"just a string"')).toEqual({ raw: 'just a string' });
+    expect(inputOf('42')).toEqual({ raw: 42 });
+    expect(inputOf('true')).toEqual({ raw: true });
+    expect(inputOf('null')).toEqual({ raw: null });
+    expect(inputOf('[1,2]')).toEqual({ raw: [1, 2] });
   });
 
-  it('maps a half-streamed fragment to an empty object instead of a 400', () => {
-    expect(inputOf('{"city":"Os')).toEqual({});
+  it('preserves text JSON cannot parse under `raw`, unchanged', () => {
+    // A half-streamed fragment and a blank string are both corrupted calls, and both keep their
+    // original text: trimming or erasing them would make the corruption unreadable.
+    expect(inputOf('{"city":"Os')).toEqual({ raw: '{"city":"Os' });
+    expect(inputOf('   ')).toEqual({ raw: '   ' });
+  });
+
+  it('never sends a non-object input, whatever the transcript holds', () => {
+    // `arguments` is typed `Record<string, unknown> | string`, but a session restored from JSON is
+    // not validated: an array or a number satisfies that type at compile time only. The Messages
+    // API rejects a non-object `tool_use.input` with 400 `Input should be an object`.
+    for (const value of [[1, 2], 42, true] as unknown[]) {
+      const input = inputOf(value as Record<string, unknown>);
+      expect(Array.isArray(input)).toBe(false);
+      expect(typeof input).toBe('object');
+      expect(input).toEqual({ raw: value });
+    }
+  });
+
+  it('leaves the source content untouched', () => {
+    const content = { type: 'function_call', callId: 'c1', name: 'f', arguments: '[1,2]' } as const;
+    blocksOf([{ ...content }]);
+    expect(content.arguments).toBe('[1,2]');
   });
 });
 


### PR DESCRIPTION
## What this changes

Closes #106. Tool arguments that are not an object are sent to the Messages API under a single
`raw` key instead of being replaced with `{}`.

For a tool whose parameters are all optional, `{}` is byte-for-byte a valid no-argument call, so an
interrupted stream, a restored transcript, or arguments another provider produced became a
different, plausible invocation that nothing downstream could detect. Measured against the live API
across 22 cases: it does not validate a replayed `tool_use.input` against the tool's schema — not
with `strict`, not with `additionalProperties: false`, not with a required property missing — so the
provider does not catch the corruption either.

Separately, a value that is neither a string nor an object reached the wire verbatim. `arguments` is
typed `Record<string, unknown> | string`, but a session restored from JSON is not validated, so an
array or a number satisfies that type at compile time only. The API answers those with
`400 tool_use.input: Input should be an object`.

A tool that declares a `raw` parameter of its own now sees a name collision in what the model reads.
That is ambiguity in the prompt, not a transport error; rename the parameter if it matters.

## Parity

- Reference checked: Python `Content.parse_arguments` (`_types.py:1642-1657`), whose result is sent
  verbatim as `tool_use.input` by `agent_framework_anthropic/_chat_client.py:896` and `:945`. **.NET
  has no Anthropic wire conversion at all** — `Microsoft.Agents.AI.Anthropic` is 268 lines of agent
  construction extensions over the external Anthropic SDK — so Python is the only authority here. Go
  raises an explicit error for non-object arguments; not adopted, because failing the caller when a
  stored session is replayed is too strong for a send-time conversion.
- Deliberate divergence from Python: a non-string, non-object value is wrapped rather than passed
  through. Python's `return self.arguments` leaves the same hole, and it is the one the API rejects.
- Whitespace-only strings follow Python (`{ raw: "   " }`), not the previous `{}`. The issue text
  claiming Python maps whitespace to `{}` was wrong.
- Wire format affected: yes
- Public API affected: no
- Breaking change: yes

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`
