### PR TITLE
Settle structured output semantics: parse source and the failure boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **[BREAKING] `@polymind-inc/agent-framework-core`** — a structured answer is read from the last
+  assistant message that says anything, not from every message of the response joined together. A
+  run that called a tool leaves more than one assistant message behind, and the earlier ones can
+  hold an answer the model then corrected; reading the whole response put the superseded one first
+  and handed it back with every field present and every check passing, so nothing downstream could
+  tell. Python fixed the same defect in July 2026; .NET still joins, and its file has not been
+  touched since February. Non-assistant messages are no longer a source at all — JSON in a tool
+  result is data the model was given, not something it said — so a schema that used to be filled
+  from a tool result now fails with "the model returned no text". Within the chosen message the
+  behaviour is unchanged: several text parts still concatenate, and only the first top-level JSON
+  value is read.
+
+- **[BREAKING] `@polymind-inc/agent-framework-core`** — structured-output failures now reject with
+  `StructuredOutputError`, a new subclass of `ChatClientError`, so existing `catch` blocks keep
+  working. Everything that can fail once a response is in hand reports through it with the original
+  failure on `cause`: unparseable or truncated text, a validator that reported issues, a validator
+  that threw or rejected instead (an async refinement calling out and failing, for one — previously
+  that escaped raw), and a schema that could not be converted. `error.response` is the completed
+  response, so the text, usage, finish reason and ids of the turn you were billed for stay
+  reachable; the reference implementations parse lazily and leave their callers holding the
+  response object, which an eager parse would otherwise take away. It is non-enumerable, so a
+  logger that serializes the error does not write the whole conversation into the log line — read
+  it by name. This also settles a semantic that was never written down: a parse failure reaches
+  context and history providers as a **success**, and the exchange is stored, because the model did
+  answer and dropping the turn would leave a hole the next request replays.
+
 - **[BREAKING] `@polymind-inc/agent-framework-a2a`** — a remote task's status message becomes a
   response message only when the task is waiting for input (`input-required`). Previously an
   awaited `run()` also materialized the status message of a `completed`, `failed`, `canceled` or

--- a/packages/core/src/client/structured-output.test.ts
+++ b/packages/core/src/client/structured-output.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { ChatClientError } from '../errors.js';
+import { ChatClientError, StructuredOutputError } from '../errors.js';
 import { textContent } from '../types/content.js';
+import type { Message } from '../types/message.js';
 import { chatResponse } from '../types/response.js';
 import { applyStructuredOutput, resolveResponseFormat, withStructuredOutput } from './structured-output.js';
 import { MockChatClient } from './test-support.js';
@@ -26,6 +27,146 @@ function textResponse(text: string): ReturnType<typeof chatResponse<unknown>> {
     messages: [{ role: 'assistant', contents: [textContent(text)] }],
   });
 }
+
+/** A response whose messages are given as `[role, text]` pairs, in order. */
+function messagesResponse(pairs: [Message['role'], string][]): ReturnType<typeof chatResponse<unknown>> {
+  return chatResponse<unknown>({
+    messages: pairs.map(([role, text]) => ({ role, contents: [textContent(text)] })),
+  });
+}
+
+describe('parse source', () => {
+  it('reads the last assistant message, not every message joined', async () => {
+    // A tool round leaves the model's first answer in the transcript. Joining the whole response
+    // put that first answer ahead of the corrected one, and the caller was handed it silently.
+    const response = await applyStructuredOutput(
+      messagesResponse([
+        ['assistant', '{"name":"Taro"}'],
+        ['tool', '{"name":"Hanako"}'],
+        ['assistant', '{"name":"Jiro"}'],
+      ]),
+      schema as never,
+    );
+    expect(response.value).toEqual({ name: 'Jiro' });
+  });
+
+  it('never reads a non-assistant message', async () => {
+    // Asserting the message, not just the type: before this rule the user message parsed cleanly,
+    // so a bare `ChatClientError` check would have passed for the wrong reason.
+    await expect(
+      applyStructuredOutput(
+        messagesResponse([
+          ['user', '{"name":"Taro"}'],
+          ['tool', '{"name":"Hanako"}'],
+        ]),
+        schema as never,
+      ),
+    ).rejects.toThrow(/returned no text/);
+  });
+
+  it('skips a trailing assistant message that is blank', async () => {
+    const response = await applyStructuredOutput(
+      messagesResponse([
+        ['assistant', '{"name":"Jiro"}'],
+        ['assistant', '   \n '],
+      ]),
+      schema as never,
+    );
+    expect(response.value).toEqual({ name: 'Jiro' });
+  });
+
+  it('joins the text contents inside the message it chose', async () => {
+    const response = await applyStructuredOutput(
+      chatResponse<unknown>({
+        messages: [{ role: 'assistant', contents: [textContent('{"name":'), textContent('"Jiro"}')] }],
+      }),
+      schema as never,
+    );
+    expect(response.value).toEqual({ name: 'Jiro' });
+  });
+
+  it('throws when the run produced no assistant text at all', async () => {
+    await expect(
+      applyStructuredOutput(messagesResponse([['user', 'anything']]), schema as never),
+    ).rejects.toThrow(/returned no text/);
+  });
+});
+
+describe('failure boundary', () => {
+  /** The rejection of `applyStructuredOutput`, typed. */
+  async function rejection(
+    response: ReturnType<typeof chatResponse<unknown>>,
+    format: unknown = schema,
+  ): Promise<StructuredOutputError> {
+    try {
+      await applyStructuredOutput(response, format as never);
+    } catch (error) {
+      return error as StructuredOutputError;
+    }
+    throw new Error('expected a rejection');
+  }
+
+  it('reports every post-response failure as one type, keeping the answer reachable', async () => {
+    // Four shapes, one boundary: unparseable text, a truncated answer, a validator that reported
+    // issues, and a validator that threw instead of reporting them.
+    const asyncThrowing = {
+      '~standard': {
+        version: 1 as const,
+        vendor: 'test',
+        validate: async () => {
+          throw new Error('lookup service is down');
+        },
+      },
+      toJsonSchema: () => ({ type: 'object' }),
+    };
+    const cases: [string, ReturnType<typeof chatResponse<unknown>>, unknown][] = [
+      ['not JSON', textResponse('not json at all'), schema],
+      ['cut off', textResponse('{"name":"Ji'), schema],
+      ['issues', textResponse('{"other":1}'), schema],
+      ['validator threw', textResponse('{"name":"Jiro"}'), asyncThrowing],
+    ];
+
+    for (const [label, response, format] of cases) {
+      const error = await rejection(response, format);
+      expect(error, label).toBeInstanceOf(StructuredOutputError);
+      // Still a ChatClientError, so code catching the old type keeps working.
+      expect(error, label).toBeInstanceOf(ChatClientError);
+      expect(error.response, label).toBe(response);
+    }
+  });
+
+  it('carries the underlying failure on `cause`', async () => {
+    const error = await rejection(textResponse('{"name":"Ji'));
+    expect(error.cause).toBeInstanceOf(SyntaxError);
+
+    const thrown = new Error('lookup service is down');
+    const throwing = {
+      '~standard': {
+        version: 1 as const,
+        vendor: 'test',
+        validate: async () => {
+          throw thrown;
+        },
+      },
+      toJsonSchema: () => ({ type: 'object' }),
+    };
+    expect((await rejection(textResponse('{"name":"Jiro"}'), throwing)).cause).toBe(thrown);
+  });
+
+  it('keeps the response out of anything that serializes the error', async () => {
+    // A logger that writes a caught error would otherwise put the whole conversation in the line.
+    const error = await rejection(textResponse('{"secret":"conversation text"}'));
+    expect(Object.keys(error)).not.toContain('response');
+    expect(JSON.stringify({ ...error })).not.toContain('conversation text');
+    expect(error.response).toBeDefined();
+  });
+
+  it('leaves value unset on the response it hands back', async () => {
+    const response = textResponse('{"other":1}');
+    const error = await rejection(response);
+    expect(error.response.value).toBeUndefined();
+  });
+});
 
 describe('applyStructuredOutput', () => {
   it('parses and validates the response text into value', async () => {

--- a/packages/core/src/client/structured-output.ts
+++ b/packages/core/src/client/structured-output.ts
@@ -1,10 +1,10 @@
-import { ChatClientError } from '../errors.js';
+import { errorMessageOf, StructuredOutputError } from '../errors.js';
 import { createResponseStream } from '../streaming/response-stream.js';
 import type { JsonSchema } from '../tools/json-schema.js';
 import { resolveJsonSchema } from '../tools/json-schema.js';
-import type { StandardSchemaV1 } from '../tools/standard-schema.js';
+import type { StandardSchemaResult, StandardSchemaV1 } from '../tools/standard-schema.js';
 import { formatSchemaIssues, isStandardSchema } from '../tools/standard-schema.js';
-import { isUserInputRequest } from '../types/content.js';
+import { isUserInputRequest, textOfContents } from '../types/content.js';
 import type { ResponseBase } from '../types/response.js';
 import type {
   ChatClient,
@@ -102,12 +102,43 @@ function isSuspended(response: ResponseBase<unknown>): boolean {
 }
 
 /**
+ * The text the structured answer is read from: the last assistant message that says anything.
+ *
+ * A run that called a tool leaves more than one assistant message behind, and the earlier ones can
+ * hold an answer the model then corrected. Reading the whole response as one string puts the first
+ * of those ahead of the last, so the caller is handed a superseded value with no way to tell —
+ * every field is present and every check passes. The answer is the final one, so that is the only
+ * message read.
+ *
+ * Non-assistant messages are never a source. A tool result is data the model was given, not
+ * something it said, and JSON in a tool result is a very ordinary thing to find.
+ *
+ * Text contents *within* the chosen message still concatenate: one message split across several
+ * text parts is one utterance.
+ *
+ * @returns The message's text, or `undefined` when no assistant message carries any.
+ */
+function structuredAnswerText(response: ResponseBase<unknown>): string | undefined {
+  for (let index = response.messages.length - 1; index >= 0; index--) {
+    const message = response.messages[index];
+    if (message === undefined || message.role !== 'assistant') {
+      continue;
+    }
+    const text = textOfContents(message.contents);
+    if (text.trim() !== '') {
+      return text;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Extracts the first complete top-level JSON object or array from `text`.
  *
- * Mirrors .NET `AgentResponse{T}.DeserializeFirstTopLevelObject` (`AllowMultipleValues`): some
- * model backends emit a second top-level object — or trailing prose — after the structured answer,
- * and the reference implementation reads the first value and ignores the rest. Leading non-JSON
- * text is *not* tolerated, also matching .NET (its reader starts at position zero).
+ * Some model backends emit a second top-level object — or trailing prose — after the structured
+ * answer, and the first value is the answer. Leading non-JSON text is *not* tolerated: text before
+ * the value means the model wrote prose where a bare value was asked for, and guessing which of
+ * several values it meant would be a different kind of answer than the one requested.
  *
  * @returns The substring holding the first value, or `undefined` when none can be found.
  */
@@ -176,16 +207,39 @@ export async function applyStructuredOutput<TResponse extends ResponseBase<unkno
   if (isSuspended(response)) {
     return response;
   }
-  const resolved = resolveResponseFormat(format);
-  const text = response.text;
-  if (text.trim() === '') {
-    throw new ChatClientError('Structured output was requested but the model returned no text.');
+
+  /**
+   * Every failure from here on is the same kind of failure, and carries the same evidence.
+   *
+   * The response exists and was billed; what went wrong is downstream of it. A caller who catches
+   * this needs the model's own words to act — to retry, to show the user, or to hand the output
+   * back to the model — and the original throw to diagnose, so both travel: the response by name,
+   * the cause on `cause`.
+   */
+  const failed = (message: string, cause?: unknown): StructuredOutputError =>
+    new StructuredOutputError(message, response, cause === undefined ? undefined : { cause });
+
+  let resolved: ResolvedResponseFormat;
+  try {
+    resolved = resolveResponseFormat(format);
+  } catch (error) {
+    // The schema is the caller's, and converting it can fail — but only once a response is in
+    // hand does that failure lose an answer, so it is reported like the others.
+    throw failed(
+      `Structured output was requested but its schema could not be resolved: ${errorMessageOf(error)}`,
+      error,
+    );
   }
 
-  const invalidJson = (cause: unknown): ChatClientError =>
-    new ChatClientError(
+  const text = structuredAnswerText(response);
+  if (text === undefined) {
+    throw failed('Structured output was requested but the model returned no text.');
+  }
+
+  const invalidJson = (cause: unknown): StructuredOutputError =>
+    failed(
       `Structured output was requested but the model returned text that is not valid JSON: ${text.slice(0, 200)}`,
-      { cause },
+      cause,
     );
   let parsed: unknown;
   try {
@@ -203,11 +257,17 @@ export async function applyStructuredOutput<TResponse extends ResponseBase<unkno
   }
 
   if (resolved.validator !== undefined) {
-    const validation = await resolved.validator['~standard'].validate(parsed);
+    let validation: StandardSchemaResult<unknown>;
+    try {
+      validation = await resolved.validator['~standard'].validate(parsed);
+    } catch (error) {
+      // A validator may throw or reject instead of reporting issues — an async refinement that
+      // calls out and fails, for one. That is still a validation failure, and reporting it as one
+      // keeps a single type at this boundary.
+      throw failed(`Structured output failed schema validation: ${errorMessageOf(error)}`, error);
+    }
     if (validation.issues !== undefined) {
-      throw new ChatClientError(
-        `Structured output failed schema validation: ${formatSchemaIssues(validation.issues)}`,
-      );
+      throw failed(`Structured output failed schema validation: ${formatSchemaIssues(validation.issues)}`);
     }
     parsed = validation.value;
   }

--- a/packages/core/src/context/context-provider.ts
+++ b/packages/core/src/context/context-provider.ts
@@ -115,6 +115,15 @@ function sourceTypeOf(provider: ContextProvider): MessageSourceType {
  * fixing an omission. A run the caller abandoned partway *does* have a response, so it is stored
  * like any other; see the note on stopping early in `AgentRunStream`.
  *
+ * **A structured-output failure is not one of those failures.** When the model answered but its
+ * text could not be parsed or validated against the caller's schema, this hook is called with the
+ * `response` and no `error`, and the exchange is stored — even though `run()` then rejects with a
+ * `StructuredOutputError`. The model said something, and it was billed; what failed is the
+ * caller's contract with their own schema, which is downstream of the conversation. Dropping the
+ * turn instead would leave a hole the next request replays, so the model could not even be asked
+ * to correct itself. A provider that wants to know a run ended badly for the caller cannot learn
+ * it here — the reference implementations parse lazily and never reach this state at all.
+ *
  * What reaches the store beyond the caller's input and the response is
  * {@link HistoryStoreOptions.storeContextMessages}.
  */

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,4 +1,5 @@
 import type { UserInputRequestContent } from './types/content.js';
+import type { ResponseBase } from './types/response.js';
 
 /** Base class for every error the framework raises. */
 export class AgentFrameworkError extends Error {
@@ -62,6 +63,36 @@ export class ChatClientError extends AgentFrameworkError {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
     this.name = 'ChatClientError';
+  }
+}
+
+/**
+ * A response arrived, but it could not be turned into the caller's structured type.
+ *
+ * The model answered and the turn was billed and persisted; what failed is the caller's contract
+ * with the schema. {@link StructuredOutputError.response} is that answer, so a caller can read the
+ * text, usage, finish reason and ids of the turn they paid for, retry against them, or show the
+ * model its own output. The reference implementations parse lazily, so their callers still hold
+ * the response object when the parse throws; this framework parses eagerly and rejects the run, so
+ * the response has to travel on the error to stay reachable at all.
+ *
+ * `response` is **non-enumerable**: a logger that serializes a caught error would otherwise write
+ * the whole conversation — every message of the turn, and whatever the tools returned — into the
+ * log line. Read it by name.
+ */
+export class StructuredOutputError extends ChatClientError {
+  /** The completed response whose text could not be parsed or validated. */
+  declare readonly response: ResponseBase<unknown>;
+
+  constructor(message: string, response: ResponseBase<unknown>, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'StructuredOutputError';
+    Object.defineProperty(this, 'response', {
+      value: response,
+      enumerable: false,
+      writable: false,
+      configurable: true,
+    });
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,6 +64,7 @@ export {
   NotImplementedError,
   SchemaResolutionError,
   StreamConsumedError,
+  StructuredOutputError,
   ToolInvocationError,
   UserInputRequiredError,
 } from './errors.js';


### PR DESCRIPTION
## What this changes

Closes #105, both halves.

**Parse source.** A structured answer is read from the last assistant message that says anything,
not from every message of the response joined together. A run that called a tool leaves more than
one assistant message behind, and the earlier ones can hold an answer the model then corrected —
reading the whole response put the superseded one first and handed it back with every field present
and every check passing, so nothing downstream could tell. Non-assistant messages are no longer a
source: JSON in a tool result is data the model was given, not something it said.

**Failure boundary.** Everything that can fail once a response is in hand rejects with
`StructuredOutputError` (a subclass of `ChatClientError`, so existing `catch` blocks keep working)
carrying the original failure on `cause` and the completed response on `error.response`. A validator
that threw or rejected instead of reporting issues previously escaped raw. `response` is
non-enumerable so a logger that serializes the error does not write the whole conversation into the
log line.

It also writes down a semantic that was never recorded: a parse failure reaches context and history
providers as a **success** and the exchange is stored, because the model did answer.

## Parity

- Reference checked, parse source: Python `_last_non_empty_assistant_message_text`
  (`_types.py:2209`) and Go `agent/structuredoutput.go`. .NET concatenates every message
  (`AgentResponse.cs:142`) and produces the same wrong value, but has not settled this: Python's
  change is `fix: parse structured response value from final message (#6383)` (2026-07-09) while
  .NET's `AgentResponse{T}.cs` has not been touched since 2026-02-13. Following the side upstream
  settled, per the repository owner's decision.
- Unchanged on purpose: reading only the first top-level JSON value within the chosen message. That
  is .NET's deliberate `AllowMultipleValues` allowance for backends that emit a second object, and
  upstream has not settled it either way.
- Reference checked, failure boundary: .NET `AgentResponse{T}.Result` and Python
  `AgentResponse.value` are both lazy, so their run never fails and their providers see a success —
  the same observable outcome this PR pins down. Go is eager and does not persist
  (`agent/history.go:138`); not adopted.
- Deliberate divergence: the eager parse itself. A Standard Schema validator may return
  `Result<Output> | Promise<Result<Output>>` with no static flag saying which, so a lazy `value`
  getter cannot await it. .NET runs no validator at all and Python's Pydantic validation is
  synchronous, so neither faces the constraint. `error.response` exists to restore the access those
  lazy implementations give their callers for free.
- Wire format affected: no
- Public API affected: yes (`StructuredOutputError` added)
- Breaking change: yes

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`
