### PR TITLE
Adopt the conversation id a stored response reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **[BREAKING] `@polymind-inc/agent-framework-core`** — a session now takes the conversation id the
+  first response reports, which hands the transcript to the service. From the next turn the request
+  carries that id instead of the whole history, the framework's own history provider stands down,
+  and the provider's prompt cache starts paying off. All three reference implementations do this;
+  the guard that refused it was ours alone. Measured against the live API over six turns:
+  `previous_response_id` does **not** reduce billed input tokens — both modes sent about 9,000 —
+  but only the service-managed side gets cache hits (the framework-managed side reported zero
+  cached tokens on every turn), which came out 23–29% cheaper and 25–38% faster. To keep the
+  framework in charge of history — for a message filter, a summarizing provider, or a persisted
+  local transcript — set `store: false`: nothing is kept service-side, so no id is reported and
+  none is adopted. Hosted agents already set it, because the hosting platform replays the
+  transcript itself; leaving it unset there sends the transcript twice. An agent configured with an
+  explicit `historyProvider` still fails with `ConfigurationError` when the service claims the
+  transcript, unchanged and matching .NET.
+
 - **[BREAKING] `@polymind-inc/agent-framework-a2a`** — a remote task's status message becomes a
   response message only when the task is waiting for input (`input-required`). Previously an
   awaited `run()` also materialized the status message of a `completed`, `failed`, `canceled` or

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -784,12 +784,15 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
      * A session with no conversation id yet takes the first one a response reports, which hands
      * the transcript to the service: from the next turn the request carries the id instead of the
      * whole history, the framework's own history provider stands down, and the provider's prompt
-     * cache — which only ever sees a stable prefix this way — starts paying off. A provider that
-     * reports no id keeps the framework's transcript, and so does a caller who asks for one:
-     * `store: false` means nothing is kept service-side, so nothing is reported and nothing is
-     * adopted. That is the switch for a caller who needs the framework to stay in charge of
-     * history — a message filter, a summarizing provider, a persisted local transcript — and it is
-     * what a hosted agent sets, since the hosting platform replays the transcript itself.
+     * cache — which only ever sees a stable prefix this way — starts paying off.
+     *
+     * Nothing is adopted when nothing is reported, which is the case for a provider that keeps no
+     * conversation at all. `store: false` is how a caller arranges the same thing deliberately: it
+     * tells the provider not to keep the turn, so there is no stored conversation to report an id
+     * for, and the framework stays in charge of the transcript. That is the switch to reach for
+     * when it has to stay in charge — a message filter, a summarizing provider, a persisted local
+     * transcript — and it is what a hosted agent sets, since the hosting platform replays the
+     * transcript itself.
      */
     const stableConversationId = this.#client.metadata.stableConversationId;
     const propagateConversationId = (update: ChatResponseUpdate): void => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -775,33 +775,34 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
     const agentId = this.id;
 
     /**
-     * Keeps a service-managed session pointing at the newest turn.
+     * Points the session at the conversation the service is keeping, and keeps it on the newest
+     * turn from then on.
      *
      * Runs per update rather than at the end (Python `_propagate_conversation_id`) so a caller
      * who abandons a stream still holds a session that can continue the conversation.
      *
-     * A session that is *not* already service-managed is never promoted here: with `store`
-     * defaulting to on, every response carries an id, and adopting one would silently move the
-     * transcript from the framework to the provider. Handing the framework a conversation id is
-     * the caller's decision to make.
+     * A session with no conversation id yet takes the first one a response reports, which hands
+     * the transcript to the service: from the next turn the request carries the id instead of the
+     * whole history, the framework's own history provider stands down, and the provider's prompt
+     * cache — which only ever sees a stable prefix this way — starts paying off. A provider that
+     * reports no id keeps the framework's transcript, and so does a caller who asks for one:
+     * `store: false` means nothing is kept service-side, so nothing is reported and nothing is
+     * adopted. That is the switch for a caller who needs the framework to stay in charge of
+     * history — a message filter, a summarizing provider, a persisted local transcript — and it is
+     * what a hosted agent sets, since the hosting platform replays the transcript itself.
      */
     const stableConversationId = this.#client.metadata.stableConversationId;
     const propagateConversationId = (update: ChatResponseUpdate): void => {
       const conversationId = update.conversationId;
       const current = session.serviceSessionId;
-      if (
-        conversationId === undefined ||
-        conversationId === '' ||
-        current === undefined ||
-        current === conversationId
-      ) {
+      if (conversationId === undefined || conversationId === '' || current === conversationId) {
         return;
       }
       // An anchor the provider declares stable stays the session's id: a per-response id
       // reported mid-run must not unhook the session from the stored conversation. The same
       // guard the function-calling loop applies between tool rounds, applied where the
       // reference puts it — on the session update itself (Go `updateConversationID`).
-      if (stableConversationId?.(current) === true) {
+      if (current !== undefined && stableConversationId?.(current) === true) {
         return;
       }
       session.serviceSessionId = conversationId;

--- a/packages/core/src/agent/service-history.test.ts
+++ b/packages/core/src/agent/service-history.test.ts
@@ -31,12 +31,15 @@ class StoringClient implements ChatClient<ChatOptions> {
     const conversationId = this.#conversationIds[Math.min(this.#turn, this.#conversationIds.length - 1)];
     assert.exists(conversationId);
     this.#turn++;
+    // A provider reports a conversation id only when it kept the turn, so `store: false` reports
+    // none — the same rule every provider mapping applies.
+    const kept = options?.store !== false;
     const update = chatResponseUpdate({
       contents: [textContent(`answer ${this.calls.length}`)],
       role: 'assistant',
       messageId: `msg_${this.calls.length}`,
       finishReason: 'stop',
-      conversationId,
+      ...(kept ? { conversationId } : {}),
     });
     return createResponseStream<ChatResponseUpdate, ChatResponse<undefined>>({
       start: async function* () {
@@ -100,7 +103,7 @@ describe('service-managed history', () => {
     expect(session.serviceSessionId).toBe('stable_1');
   });
 
-  it('keeps the framework transcript when the session is not service-managed', async () => {
+  it('adopts the conversation id the first response reports', async () => {
     const client = new StoringClient(['resp_1', 'resp_2']);
     const agent = new Agent({ client });
     const session = agent.createSession();
@@ -108,10 +111,26 @@ describe('service-managed history', () => {
     await agent.run('first', { session });
     await agent.run('second', { session });
 
-    // The second call replays the whole conversation locally…
+    // Turn one has nothing to continue from and sends its own input…
+    expect(client.calls[0]?.conversationId).toBeUndefined();
+    // …and from turn two the service holds the history, so only the new input is sent.
+    expect(client.calls[1]?.conversationId).toBe('resp_1');
+    expect(client.calls[1]?.messages).toHaveLength(1);
+    expect(session.serviceSessionId).toBe('resp_2');
+  });
+
+  it('keeps the framework transcript when the caller asks the provider not to store', async () => {
+    // `store: false` is the switch for a caller who needs the framework to stay in charge of
+    // history: nothing is kept service-side, so no id is reported and none is adopted.
+    const client = new StoringClient(['resp_1', 'resp_2']);
+    const agent = new Agent({ client, defaultOptions: { store: false } });
+    const session = agent.createSession();
+
+    await agent.run('first', { session });
+    await agent.run('second', { session });
+
     expect(client.calls[1]?.messages).toHaveLength(3);
     expect(client.calls[1]?.conversationId).toBeUndefined();
-    // …and the response id is never adopted behind the caller's back.
     expect(session.serviceSessionId).toBeUndefined();
   });
 
@@ -166,11 +185,26 @@ describe('service-managed history', () => {
   });
 
   it('still stores locally when nothing promoted the session', async () => {
-    const agent = new Agent({ client: new StoringClient(['resp_1']) });
+    const agent = new Agent({
+      client: new StoringClient(['resp_1']),
+      defaultOptions: { store: false },
+    });
     const session = agent.createSession();
 
     await agent.run('hi', { session });
 
     expect(historyOf(session)).toHaveLength(2);
+  });
+
+  it('stops storing locally from the turn that hands the transcript to the service', async () => {
+    // The run that adopts the id retires the local store for that same run: appending there too
+    // would make the next request replay messages the service is already sending.
+    const agent = new Agent({ client: new StoringClient(['resp_1']) });
+    const session = agent.createSession();
+
+    await agent.run('hi', { session });
+
+    expect(session.serviceSessionId).toBe('resp_1');
+    expect(historyOf(session)).toHaveLength(0);
   });
 });

--- a/packages/foundry/src/hosting/hosted-promotion.test.ts
+++ b/packages/foundry/src/hosting/hosted-promotion.test.ts
@@ -1,0 +1,209 @@
+/**
+ * What a hosted Foundry turn sends once its session is service-managed.
+ *
+ * The platform prefetches the whole transcript and replays it as this turn's input, and the
+ * handler empties the agent's own history slot so nothing is replayed twice. Nothing, however,
+ * empties `serviceSessionId` — it is carried in the session snapshot from turn to turn. A session
+ * that adopted the model API's conversation id therefore sends that id *and* the prefetched
+ * transcript on every later turn, which is one turn's history twice.
+ *
+ * `store: false` — what every hosted agent sets, and what `ResponsesHostServer` prescribes — is
+ * what keeps that from happening: nothing is kept service-side, so no id is reported and none is
+ * adopted. These tests pin both halves, so the pairing cannot come back unnoticed.
+ */
+import type { CreateResponseRequest, ResponseObject } from '@polymind-inc/agent-framework-agentserver';
+import { InMemoryResponseProvider, ResponsesServer } from '@polymind-inc/agent-framework-agentserver';
+import type {
+  ChatClient,
+  ChatClientMetadata,
+  ChatOptions,
+  ChatResponse,
+  ChatResponseStream,
+  ChatResponseUpdate,
+  Message,
+  SerializedAgentSession,
+} from '@polymind-inc/agent-framework-core';
+import {
+  Agent,
+  chatResponse,
+  chatResponseToUpdates,
+  createResponseStream,
+  mergeChatUpdates,
+  textContent,
+} from '@polymind-inc/agent-framework-core';
+import { assert, describe, expect, it } from 'vitest';
+import { InMemoryApprovalStorage } from './approval-storage.js';
+import { createFoundryHandler } from './handler.js';
+import type { AgentSessionStore } from './session-store.js';
+import { InMemoryAgentSessionStore } from './session-store.js';
+
+async function* streamOf<T>(items: readonly T[]): AsyncIterable<T> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+/**
+ * A client that reports a conversation id exactly where the OpenAI one does.
+ *
+ * `parseConversationId` reports nothing when `store` is `false`, and the response id otherwise —
+ * so a client that ignores `store` would make a promotion look reachable where it is not.
+ * `MockChatClient` reports no conversation id at all, so a promotion cannot be observed with it.
+ */
+class StoringChatClient implements ChatClient<ChatOptions> {
+  readonly metadata: ChatClientMetadata = { providerName: 'mock', modelId: 'mock-model' };
+  readonly calls: { messages: Message[]; options: (ChatOptions & { signal?: AbortSignal }) | undefined }[] =
+    [];
+  readonly #texts: readonly string[];
+
+  constructor(texts: readonly string[]) {
+    this.#texts = texts;
+  }
+
+  getResponse(
+    messages: Message[],
+    options?: ChatOptions & { signal?: AbortSignal },
+  ): ChatResponseStream<undefined> {
+    let direct: ChatResponse<undefined> | undefined;
+    return createResponseStream<ChatResponseUpdate, ChatResponse<undefined>>({
+      start: () => {
+        this.calls.push({ messages, options });
+        const turn = this.calls.length;
+        const text = this.#texts[Math.min(turn - 1, this.#texts.length - 1)] ?? '';
+        const stored = (options as { store?: boolean } | undefined)?.store !== false;
+        direct = chatResponse<undefined>({
+          messages: [{ role: 'assistant', contents: [textContent(text)], messageId: `msg_${turn}` }],
+          responseId: `resp_${turn}`,
+          ...(stored ? { conversationId: `resp_${turn}` } : {}),
+          finishReason: 'stop',
+        });
+        return streamOf(chatResponseToUpdates(direct));
+      },
+      finalize: (updates) => direct ?? mergeChatUpdates<undefined>(updates),
+    });
+  }
+}
+
+/**
+ * The state promotion would leave behind: the run adopts the model's conversation id, and the
+ * handler saves the session carrying it.
+ */
+class PromotedSessionStore implements AgentSessionStore {
+  readonly #inner = new InMemoryAgentSessionStore();
+  readonly #conversationId: string;
+
+  constructor(conversationId: string) {
+    this.#conversationId = conversationId;
+  }
+
+  async load(userId: string, key: string): Promise<SerializedAgentSession | undefined> {
+    return this.#inner.load(userId, key);
+  }
+
+  async save(userId: string, key: string, session: SerializedAgentSession): Promise<void> {
+    await this.#inner.save(userId, key, { ...session, serviceSessionId: this.#conversationId });
+  }
+}
+
+function post(body: CreateResponseRequest): Request {
+  return new Request('http://localhost:8088/responses', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function hostedApp(
+  client: ChatClient<ChatOptions>,
+  sessionStore: AgentSessionStore,
+  defaultOptions?: Partial<ChatOptions>,
+): ResponsesServer {
+  return new ResponsesServer({
+    handler: createFoundryHandler({
+      agent: new Agent({
+        client,
+        instructions: 'Be helpful.',
+        ...(defaultOptions === undefined ? {} : { defaultOptions }),
+      }),
+      sessionStore,
+      approvalStorage: new InMemoryApprovalStorage(),
+      hosted: false,
+    }),
+    store: new InMemoryResponseProvider(),
+  });
+}
+
+function textsSent(call: { messages: Message[] }): string[] {
+  return call.messages.flatMap((message) =>
+    message.contents.flatMap((content) => (content.type === 'text' ? [content.text] : [])),
+  );
+}
+
+async function twoHostedTurns(
+  client: StoringChatClient,
+  sessionStore: AgentSessionStore,
+  defaultOptions?: Partial<ChatOptions>,
+): Promise<void> {
+  const app = hostedApp(client, sessionStore, defaultOptions);
+  const first = (await (await app.handle(post({ input: 'one' }))).json()) as ResponseObject;
+  expect(first.status).toBe('completed');
+  const second = (await (
+    await app.handle(post({ input: 'two', previous_response_id: first.id }))
+  ).json()) as ResponseObject;
+  expect(second.status).toBe('completed');
+}
+
+describe('hosted turns and service-managed sessions', () => {
+  it('adopts the model conversation id when the hosted agent leaves store unset', async () => {
+    // The pairing this file exists to document: the platform's prefetched transcript *and* the id
+    // the provider is told to continue from, both in one request. A hosted agent that leaves
+    // `store` unset gets it, which is why every hosted example sets `store: false`.
+    const client = new StoringChatClient(['first', 'second']);
+
+    await twoHostedTurns(client, new InMemoryAgentSessionStore());
+
+    const second = client.calls[1];
+    assert.exists(second);
+    expect(textsSent(second)).toEqual(['one', 'first', 'two']);
+    expect(second.options?.conversationId).toBe('resp_1');
+  });
+
+  it('sends the prefetched transcript AND the conversation id once the session is service-managed', async () => {
+    const client = new StoringChatClient(['first', 'second']);
+
+    await twoHostedTurns(client, new PromotedSessionStore('resp_1'));
+
+    const second = client.calls[1];
+    assert.exists(second);
+    // Both copies of turn one reach the provider: the id it is told to continue from, and the
+    // transcript the platform prefetched.
+    expect(second.options?.conversationId).toBe('resp_1');
+    expect(textsSent(second)).toEqual(['one', 'first', 'two']);
+  });
+
+  it('reports no conversation id to adopt when the hosted agent sets store false', async () => {
+    // What every hosted example configures, and what `ResponsesHostServer`'s own doc prescribes:
+    // the hosting infrastructure owns the transcript, so the provider must not store it too.
+    const client = new StoringChatClient(['first', 'second']);
+
+    await twoHostedTurns(client, new InMemoryAgentSessionStore(), { store: false });
+
+    for (const call of client.calls) {
+      expect(call.options?.store).toBe(false);
+      expect(call.options?.conversationId).toBeUndefined();
+    }
+  });
+
+  it('still sends a conversation id an already-service-managed session holds, store false or not', async () => {
+    // `store: false` stops a session from *becoming* service-managed. It does nothing about one
+    // that already is: the id is forwarded from the session, not derived from the response.
+    const client = new StoringChatClient(['first', 'second']);
+
+    await twoHostedTurns(client, new PromotedSessionStore('resp_1'), { store: false });
+
+    const second = client.calls[1];
+    assert.exists(second);
+    expect(second.options?.conversationId).toBe('resp_1');
+    expect(textsSent(second)).toEqual(['one', 'first', 'two']);
+  });
+});

--- a/packages/openai/src/chat-client.test.ts
+++ b/packages/openai/src/chat-client.test.ts
@@ -1041,7 +1041,7 @@ describe('Agent over OpenAIChatClient', () => {
     expect(resumed.text).toBe('Found three.');
   });
 
-  it('keeps framework-managed history across turns instead of switching to service-side storage', async () => {
+  it('continues from the stored response instead of resending the transcript', async () => {
     const create = vi
       .fn()
       .mockResolvedValueOnce(completedResponse())
@@ -1055,8 +1055,31 @@ describe('Agent over OpenAIChatClient', () => {
     await agent.run('one', { session });
     await agent.run('two', { session });
 
-    // A stored response id must not silently become a serviceSessionId; service-side
-    // conversation state is a separate opt-in.
+    // `store` defaults on, so the first response is one the service kept, and the session takes
+    // its id: the second turn sends only the new input and points at what came before.
+    expect(session.serviceSessionId).toBe('resp_2');
+    const secondCall = create.mock.calls[1];
+    assert.exists(secondCall);
+    expect(secondCall[0].previous_response_id).toBe('resp_1');
+    expect((secondCall[0].input as InputItem[]).map((item) => item.role)).toEqual(['user']);
+  });
+
+  it('keeps framework-managed history when the caller sets store false', async () => {
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce(completedResponse())
+      .mockResolvedValueOnce(completedResponse({ id: 'resp_2' }));
+
+    const agent = new Agent({
+      client: new OpenAIChatClient({ client: fakeClient(create), model: 'gpt-4o' }),
+      defaultOptions: { store: false },
+    });
+    const session = agent.createSession();
+
+    await agent.run('one', { session });
+    await agent.run('two', { session });
+
+    // Nothing is kept service-side, so no conversation id is reported and none is adopted.
     expect(session.serviceSessionId).toBeUndefined();
     expect(create.mock.calls[1]?.[0].previous_response_id).toBeUndefined();
     const secondCall = create.mock.calls[1];
@@ -1098,6 +1121,9 @@ describe('Agent over OpenAIChatClient', () => {
     const agent = new Agent({
       client: new OpenAIChatClient({ client: fakeClient(create), model: 'gpt-4o' }),
       tools: [book],
+      // The framework owns this transcript: the question is what *its* replay does with a call
+      // nothing answered. With the service owning it there is no local transcript to round-trip.
+      defaultOptions: { store: false },
     });
     const session = agent.createSession();
     await agent.run('book me a flight', { session });


### PR DESCRIPTION
## What this changes

Closes #104. A session takes the conversation id the first response reports, which hands the
transcript to the service: from the next turn the request carries that id instead of the whole
history, the framework's own history provider stands down, and the provider's prompt cache starts
paying off.

`store: false` is the opt-out — nothing is kept service-side, so no id is reported and none is
adopted. That is the switch for a caller who needs the framework to stay in charge of history (a
message filter, a summarizing provider, a persisted local transcript), and it is what hosted agents
already set.

Measured over six turns against the live API, two runs per mode, with cache prefixes and ordering
separated so neither mode could inherit the other's cache:

| mode | input tokens | cached | wire bytes | latency | cost |
|---|---|---|---|---|---|
| framework-managed | 8,929–8,956 | **0** | ~46,000 | 13.1–13.4 s | $0.00166 |
| service-managed | 8,996–9,032 | **5,376–6,784** | ~36,800 | 8.3–10.1 s | $0.00119–0.00128 |

`previous_response_id` does **not** reduce billed input tokens — that is worth stating plainly,
because it is the intuition this change is easily mistaken for. What it does is give the provider a
stable prefix to cache, and only the service-managed side ever reported cached tokens. n=2, one
model, one day; hit rate was not stable (one turn missed entirely).

## Parity

- Reference checked: .NET `ChatClientAgent.UpdateSessionConversationId` (`ChatClientAgent.cs:854`)
  assigns unconditionally; Python `_agents.py:1198` excludes only its local-history sentinel; Go
  `provider/openaiprovider/responses.go:113` excludes only a `conv_`-prefixed anchor it is holding.
- The id is derived by the same three-step rule as Python (`_chat_client.py:972`): none when
  `store` is false, else `conversation.id`, else the response id. The inputs already matched; only
  the guard differed.
- Unchanged: an agent configured with an **explicit** `historyProvider` still fails with
  `ConfigurationError` when the service claims the transcript, after the response — which is where
  .NET raises it too (`UpdateSessionConversationIdAtEndOfRun`, called from `:248`/`:397`).
- Foundry hosting: a hosted turn that left `store` unset would send the prefetched transcript *and*
  `previous_response_id`. `hosted-promotion.test.ts` pins both that pairing and the `store: false`
  path that prevents it. Every hosted example and `ResponsesHostServer`'s own documentation set it.
- Wire format affected: yes
- Public API affected: no
- Breaking change: yes

## Notes

`hosting.test.ts`'s `never sends the container response id to the model provider` could not have
caught this: `MockChatClient` reports no conversation id, so there was never one to adopt. The new
file uses a client that reports one where the OpenAI mapping does.

Dangling calls under service-managed history — from an approval pause, an iteration limit, or an
abandoned stream — need settlement, which Python implements (`_tools.py:3096-3130`) and this PR does
not. Filing separately.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`
