### PR TITLE
Make one rule govern every failure in the function-invocation seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **[BREAKING] `@polymind-inc/agent-framework-core`** — a tool body's exception now travels out
+  through the function middleware wrapped around it, so `try { await next() } catch` and
+  `try { await next() } finally` mean what they read. Previously the failure was written to
+  `ctx.error` and `next()` resolved, while an exception from an *inner middleware* did propagate —
+  the same syntax behaved differently depending on which layer threw, and a timing or logging
+  middleware silently skipped exactly the calls worth knowing about. Recover by catching and
+  assigning `ctx.result`; `ctx.error` is still set alongside the throw for a middleware that only
+  wants to look, but clearing it no longer clears the failure. Middleware written as
+  `await next(); if (ctx.error) { … }` must become `try/catch`.
+
+- **[BREAKING] `@polymind-inc/agent-framework-core`** — an exception from a function middleware is
+  reported to the model as that call's `function_result` and the loop continues, instead of failing
+  the run. Tool bodies already behaved this way; middleware did not, and all three reference
+  implementations treat both the same. The round still counts against `maxConsecutiveErrors`
+  (default 3), so a layer that keeps failing still ends the run — this is not a licence to fail
+  forever. **This reversal is silent**: nothing in the type system or the linter will point at
+  middleware that relied on throwing to abort. Throw the new `MiddlewareFailed` where that was the
+  intent — it is never turned into a result, it cancels the rest of the concurrent batch, and it
+  reaches the caller of `run()`. A tool body may throw it too. Cancellation is cooperative: a
+  sibling that watches `ctx.signal` stops at its next suspension point, one that ignores it runs to
+  completion and may still have its effects, and either way its result is discarded.
+
 - **[BREAKING] `@polymind-inc/agent-framework-core`** — a session now takes the conversation id the
   first response reports, which hands the transcript to the service. From the next turn the request
   carries that id instead of the whole history, the framework's own history provider stands down,

--- a/examples/03-extensibility/01-middleware.ts
+++ b/examples/03-extensibility/01-middleware.ts
@@ -48,11 +48,19 @@ const cached = agentMiddleware(async (ctx, next) => {
   await next();
 });
 
-/** Times every tool call, and could just as easily rewrite `ctx.arguments` or `ctx.result`. */
+/**
+ * Times every tool call, and could just as easily rewrite `ctx.arguments` or `ctx.result`.
+ *
+ * `next()` throws when the call fails, so the timing goes in `finally` — a tool that took two
+ * seconds to fail is exactly the one worth knowing about.
+ */
 const timing = functionMiddleware(async (ctx, next) => {
   const started = performance.now();
-  await next();
-  console.log(`  (tool) ${ctx.tool.name} took ${Math.round(performance.now() - started)}ms`);
+  try {
+    await next();
+  } finally {
+    console.log(`  (tool) ${ctx.tool.name} took ${Math.round(performance.now() - started)}ms`);
+  }
 });
 
 const getWeather = tool({

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -26,6 +26,14 @@ service-side should declare which conversation ids are stable anchors via
 propagation consult that predicate, and without it every reported conversation id advances the
 chain between tool rounds.
 
+Function middleware wraps one tool call, and `next()` throws when that call fails — whether the
+tool body threw or an inner middleware did. Catch it and assign `ctx.result` to answer in the
+tool's place; let it out and it is reported to the model as that call's `function_result` while the
+loop carries on, counting against `maxConsecutiveErrors`. Anything that must run either way belongs
+in `finally`. To end the run instead of telling the model, throw `MiddlewareFailed`: it is never
+turned into a result, it cancels the rest of a concurrent batch, and it reaches the caller of
+`run()` — the escape a guardrail wants when it could not decide rather than decided "no".
+
 Requirements: Node.js >= 24, ESM only (no CommonJS build).
 
 Known limitations:

--- a/packages/core/src/client/function-execution.ts
+++ b/packages/core/src/client/function-execution.ts
@@ -349,6 +349,11 @@ async function executeWithMiddleware(
       // `_tools.py`: one `except Exception` around the whole pipeline), and the round still
       // counts against `maxConsecutiveErrors`, so a layer that keeps failing still ends the run.
       ctx.error = error;
+      // A middleware that threw *after* the tool succeeded leaves a result behind that no longer
+      // stands: the call as a whole did not succeed, and the output of a step that never finished
+      // is not the answer. Recovery is unaffected — a middleware that recovers catches the failure
+      // itself, so the chain resolves and never reaches here.
+      ctx.result = undefined;
     }
   }
 

--- a/packages/core/src/client/function-execution.ts
+++ b/packages/core/src/client/function-execution.ts
@@ -1,6 +1,7 @@
 import type { AgentSession } from '../agent/session.js';
 import {
   errorMessageOf,
+  MiddlewareFailed,
   MiddlewareTerminated,
   ToolInvocationError,
   UserInputRequiredError,
@@ -270,15 +271,25 @@ async function invokeOne(
  *
  * Arguments are parsed and validated *before* the chain, so a middleware inspects what the tool
  * would actually receive rather than the model's raw JSON (Python `FunctionInvocationContext`
- * carries the validated arguments). Everything the chain leaves in the context is then read back:
+ * carries the validated arguments).
  *
- * - a `result` with no `error` is what the model is told, whether the tool ran or a middleware
- *   answered for it;
- * - an `error` that no middleware cleared becomes the failure result, so recovery is possible by
- *   assigning `ctx.result`;
+ * The chain is one exception boundary, not two. Whatever it throws — the tool body, a middleware,
+ * either one — is this call's failure and becomes the `function_result` the model reads, and the
+ * round counts against `maxConsecutiveErrors` like any other failure, so a layer that keeps
+ * failing still ends the run. Python draws the boundary in exactly this place: one
+ * `except Exception` around the whole pipeline, with the tool body as its innermost handler.
+ *
+ * Three throws are not that failure and cross unchanged: `terminate()` stops the loop after this
+ * round, {@link UserInputRequiredError} carries a request only the caller can settle, and
+ * {@link MiddlewareFailed} says the run must end now.
+ *
+ * What the chain leaves in the context is then read back:
+ *
+ * - a `result` is what the model is told, whether the tool ran or a middleware answered for it —
+ *   which is how a middleware recovers from a failure it caught;
+ * - an `error` with no `result` becomes the failure result;
  * - a `function_approval_request` is surfaced to the caller instead of the model, which is how
- *   {@link toolApprovalMiddleware} sends a call to a human;
- * - `terminate()` stops the loop after this round.
+ *   {@link toolApprovalMiddleware} sends a call to a human.
  */
 async function executeWithMiddleware(
   call: FunctionCallContent,
@@ -309,20 +320,36 @@ async function executeWithMiddleware(
   let terminated = false;
   const final = async (): Promise<void> => {
     const outcome = await runTool(call, target, ctx.arguments, env);
-    if (outcome.status === 'exception') {
-      ctx.error = outcome.error;
-    } else {
+    if (outcome.status !== 'exception') {
       ctx.result = outcome.result;
+      return;
     }
+    // Recorded *and* thrown. Thrown so `await next()` behaves the way the syntax reads — a
+    // middleware that wraps the call in `try/catch` or `try/finally` sees the tool's failure the
+    // same way it would see its own, which is how .NET and Python's function seams behave. Also
+    // recorded so a middleware that only wants to look does not have to catch, and so one that
+    // recovers by assigning `ctx.result` still leaves the original failure legible.
+    ctx.error = outcome.error;
+    throw outcome.error;
   };
 
   try {
     await runMiddlewareChain(env.middleware, ctx, final);
   } catch (error) {
-    if (!(error instanceof MiddlewareTerminated)) {
+    if (error instanceof MiddlewareTerminated) {
+      terminated = true;
+    } else if (error instanceof MiddlewareFailed || error instanceof UserInputRequiredError) {
+      // The two throws that are not this call's failure: one aborts the run on purpose, the other
+      // is a request only the caller can settle.
       throw error;
+    } else {
+      // Anything else — the tool body, or a middleware — is this call's failure and is reported to
+      // the model, exactly as a tool that threw always has been. A middleware failing is not a
+      // different kind of event to the loop than the tool it wraps failing (Python
+      // `_tools.py`: one `except Exception` around the whole pipeline), and the round still
+      // counts against `maxConsecutiveErrors`, so a layer that keeps failing still ends the run.
+      ctx.error = error;
     }
-    terminated = true;
   }
 
   const terminationFlag = terminated ? { terminated: true } : {};
@@ -407,11 +434,14 @@ async function resolveArguments(
 /**
  * Runs the tool body. A thrown error becomes a result the model reads, never a failed run.
  *
- * The one exception is {@link UserInputRequiredError}: a sub-agent that stopped for a human has no
- * result the model could act on, so it crosses this inner boundary unchanged. {@link invokeOne}
- * converts its contents into the round's user-input requests — or, when it carries none, into an
- * ordinary exception result — matching Python's `_execute_single_function_call`; every other error
- * is still reported to the model. Neither path fails the run.
+ * Two errors cross this boundary unchanged, because neither is something the model could act on:
+ *
+ * - {@link UserInputRequiredError} — a sub-agent stopped for a human. {@link invokeOne} converts
+ *   its contents into the round's user-input requests, or, when it carries none, into an ordinary
+ *   exception result, matching Python's `_execute_single_function_call`. It does not fail the run.
+ * - {@link MiddlewareFailed} — the caller said this failure ends the run. A tool can raise it as
+ *   well as a middleware; Python re-raises it from outside the whole pipeline, which covers the
+ *   tool body the same way.
  */
 async function runTool(
   call: FunctionCallContent,
@@ -436,7 +466,7 @@ async function runTool(
     const execute = target.execute as (input: unknown, ctx: ToolContext) => unknown;
     return { status: 'completed', call, result: await execute(input, ctx) };
   } catch (error) {
-    if (error instanceof UserInputRequiredError) {
+    if (error instanceof UserInputRequiredError || error instanceof MiddlewareFailed) {
       throw error;
     }
     return { status: 'exception', call, error };
@@ -530,7 +560,27 @@ export async function runInvocationRound(
   const captureErrors = errorCount < config.maxConsecutiveErrors;
   let results: SettledInvocation[];
   if (config.allowConcurrentInvocations && calls.length > 1) {
-    results = await Promise.all(calls.map((call) => invokeOne(call, tools, env)));
+    // A batch that is ending must not keep working. `MiddlewareFailed` aborts the run, so the
+    // siblings still in flight are told to stop rather than left to finish into a transcript
+    // nothing will read. Cancellation is cooperative: a call that watches its signal stops at its
+    // next suspension point, one that ignores it runs to completion and may still have its
+    // effects, and either way its result is discarded here.
+    const batch = new AbortController();
+    const signal = env.signal === undefined ? batch.signal : AbortSignal.any([env.signal, batch.signal]);
+    const pending = calls.map((call) =>
+      invokeOne(call, tools, { ...env, signal }).catch((error: unknown) => {
+        if (error instanceof MiddlewareFailed) {
+          batch.abort(error);
+        }
+        throw error;
+      }),
+    );
+    // Every promise carries a handler before the first `await`, so a sibling rejecting after the
+    // batch has already failed is not an unhandled rejection.
+    for (const promise of pending) {
+      void promise.catch(() => undefined);
+    }
+    results = await Promise.all(pending);
   } else {
     results = [];
     for (const call of calls) {

--- a/packages/core/src/client/function-middleware-errors.test.ts
+++ b/packages/core/src/client/function-middleware-errors.test.ts
@@ -1,0 +1,308 @@
+/**
+ * The error contract of the function-invocation seam: where a thrown error surfaces, and what it
+ * does to the run.
+ *
+ * Two rules, and they are the same rule twice. A failure inside the seam travels out through the
+ * middleware wrapped around it, so `try { await next() } catch` means what it reads; and a failure
+ * nothing recovered is reported to the model as this call's result, whether it came from the tool
+ * or from a middleware. {@link MiddlewareFailed} is the one way to say "not that — end the run".
+ */
+import { describe, expect, it } from 'vitest';
+import { MiddlewareFailed } from '../errors.js';
+import { functionMiddleware, tool } from '../index.js';
+import type { FunctionMiddleware } from '../middleware/middleware.js';
+import { textContent } from '../types/content.js';
+import type { Message } from '../types/message.js';
+import { createFunctionInvocationClientFactory } from './function-invocation.js';
+import { MockChatClient } from './test-support.js';
+
+/** A tool that always throws, so the failure has a single known origin. */
+const exploding = tool({
+  name: 'explode',
+  description: 'Always throws',
+  parameters: { type: 'object', properties: {} },
+  execute: () => {
+    throw new Error('tool body failed');
+  },
+});
+
+/** A tool that always succeeds. */
+const quiet = tool({
+  name: 'quiet',
+  description: 'Always succeeds',
+  parameters: { type: 'object', properties: {} },
+  execute: () => 'done',
+});
+
+/** One model turn calling `name`, then a plain answer. */
+function callThen(name: string, answer: string): ConstructorParameters<typeof MockChatClient>[0] {
+  return [
+    {
+      contents: [{ type: 'function_call', callId: 'c1', name, arguments: '{}' }],
+      finishReason: 'tool_calls',
+    },
+    { contents: [textContent(answer)], finishReason: 'stop' },
+  ];
+}
+
+/** Runs one tool round through the function-invocation client and returns the whole transcript. */
+async function run(
+  turns: ConstructorParameters<typeof MockChatClient>[0],
+  middleware: FunctionMiddleware[],
+  tools = [exploding, quiet],
+): Promise<Message[]> {
+  const client = createFunctionInvocationClientFactory(new MockChatClient(turns))(undefined, middleware);
+  const response = await client.getResponse([{ role: 'user', contents: [textContent('go')] }], {
+    tools,
+  } as never);
+  return response.messages;
+}
+
+/** The `exception` text of the first function_result in a transcript, if there is one. */
+function exceptionOf(messages: Message[]): string | undefined {
+  for (const message of messages) {
+    for (const content of message.contents) {
+      if (content.type === 'function_result' && content.exception !== undefined) {
+        return content.exception;
+      }
+    }
+  }
+  return undefined;
+}
+
+/** The `result` text of the first function_result in a transcript. */
+function resultOf(messages: Message[]): unknown {
+  for (const message of messages) {
+    for (const content of message.contents) {
+      if (content.type === 'function_result') {
+        return content.result;
+      }
+    }
+  }
+  return undefined;
+}
+
+describe('a failure travels out through the middleware around it', () => {
+  it('lets a tool body exception reach `await next()`', async () => {
+    const seen: string[] = [];
+    const observer = functionMiddleware(async (_ctx, next) => {
+      try {
+        await next();
+        seen.push('next returned');
+      } catch (error) {
+        seen.push(`caught ${String(error)}`);
+      }
+    });
+
+    await run(callThen('explode', 'ok'), [observer]);
+
+    expect(seen).toEqual(['caught Error: tool body failed']);
+  });
+
+  it('lets an inner middleware exception reach it the same way', async () => {
+    const seen: string[] = [];
+    const observer = functionMiddleware(async (_ctx, next) => {
+      try {
+        await next();
+        seen.push('next returned');
+      } catch (error) {
+        seen.push(`caught ${String(error)}`);
+      }
+    });
+    const thrower = functionMiddleware(async () => {
+      throw new Error('middleware failed');
+    });
+
+    await run(callThen('quiet', 'ok'), [observer, thrower]);
+
+    // Same syntax, same outcome, whichever layer threw.
+    expect(seen).toEqual(['caught Error: middleware failed']);
+  });
+
+  it('runs a `finally` block on the failing path', async () => {
+    const seen: string[] = [];
+    const timing = functionMiddleware(async (ctx, next) => {
+      try {
+        await next();
+      } finally {
+        seen.push(`${ctx.tool.name} done`);
+      }
+    });
+
+    await run(callThen('explode', 'ok'), [timing]);
+
+    expect(seen).toEqual(['explode done']);
+  });
+
+  it('still records the failure on `ctx.error` for a middleware that only observes', async () => {
+    const seen: unknown[] = [];
+    const observer = functionMiddleware(async (ctx, next) => {
+      try {
+        await next();
+      } catch {
+        seen.push(ctx.error);
+      }
+    });
+
+    await run(callThen('explode', 'ok'), [observer]);
+
+    expect(seen).toHaveLength(1);
+    expect((seen[0] as Error).message).toBe('tool body failed');
+  });
+
+  it('lets a middleware recover by assigning a result', async () => {
+    const recovering = functionMiddleware(async (ctx, next) => {
+      try {
+        await next();
+      } catch {
+        ctx.result = 'recovered by middleware';
+      }
+    });
+
+    const messages = await run(callThen('explode', 'ok'), [recovering]);
+
+    expect(resultOf(messages)).toBe('recovered by middleware');
+    expect(exceptionOf(messages)).toBeUndefined();
+  });
+});
+
+describe('a failure nothing recovered is reported to the model', () => {
+  it('reports a tool body exception and keeps the loop running', async () => {
+    const messages = await run(callThen('explode', 'recovered'), []);
+
+    expect(exceptionOf(messages)).toContain('tool body failed');
+    expect(messages.at(-1)?.contents.some((c) => c.type === 'text' && c.text === 'recovered')).toBe(true);
+  });
+
+  it('reports a middleware exception the same way', async () => {
+    const thrower = functionMiddleware(async () => {
+      throw new Error('middleware failed');
+    });
+
+    const messages = await run(callThen('quiet', 'carried on'), [thrower]);
+
+    expect(exceptionOf(messages)).toContain('middleware failed');
+    expect(messages.at(-1)?.contents.some((c) => c.type === 'text' && c.text === 'carried on')).toBe(true);
+  });
+
+  it('reports a value that is not an Error', async () => {
+    const thrower = functionMiddleware(async () => {
+      throw 'a bare string';
+    });
+
+    const messages = await run(callThen('quiet', 'ok'), [thrower]);
+
+    expect(exceptionOf(messages)).toContain('a bare string');
+  });
+
+  it('does not run the tool when a middleware threw before `next()`', async () => {
+    let ran = 0;
+    const counted = tool({
+      name: 'counted',
+      description: 'Counts its invocations',
+      parameters: { type: 'object', properties: {} },
+      execute: () => {
+        ran++;
+        return 'ran';
+      },
+    });
+    const thrower = functionMiddleware(async () => {
+      throw new Error('policy is unreachable');
+    });
+
+    await run(callThen('counted', 'ok'), [thrower], [counted]);
+
+    // Reporting the failure to the model does not let the call through: a check that could not
+    // decide still stopped the tool.
+    expect(ran).toBe(0);
+  });
+});
+
+describe('MiddlewareFailed ends the run', () => {
+  it('propagates to the caller instead of becoming a result', async () => {
+    const guard = functionMiddleware(async () => {
+      throw new MiddlewareFailed('policy service is unreachable');
+    });
+
+    await expect(run(callThen('quiet', 'ok'), [guard])).rejects.toThrow(MiddlewareFailed);
+  });
+
+  it('tells the concurrent siblings to stop', async () => {
+    // Cooperative: the sibling is told, and it is the sibling that stops. What the framework
+    // guarantees is the signal and that the result is discarded, not that the work is interrupted.
+    let released!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      released = resolve;
+    });
+    let sawAbort = false;
+
+    const waiting = tool({
+      name: 'waiting',
+      description: 'Waits until its signal fires',
+      parameters: { type: 'object', properties: {} },
+      execute: async (_input, ctx) => {
+        await new Promise<void>((resolve) => {
+          ctx.signal?.addEventListener(
+            'abort',
+            () => {
+              sawAbort = true;
+              resolve();
+            },
+            { once: true },
+          );
+          void gate.then(resolve);
+        });
+        return 'finished anyway';
+      },
+    });
+    const failing = tool({
+      name: 'failing',
+      description: 'Fails the run',
+      parameters: { type: 'object', properties: {} },
+      execute: () => {
+        throw new MiddlewareFailed('policy service is unreachable');
+      },
+    });
+
+    const client = createFunctionInvocationClientFactory(
+      new MockChatClient([
+        {
+          contents: [
+            { type: 'function_call', callId: 'c1', name: 'waiting', arguments: '{}' },
+            { type: 'function_call', callId: 'c2', name: 'failing', arguments: '{}' },
+          ],
+          finishReason: 'tool_calls',
+        },
+        { contents: [textContent('never reached')], finishReason: 'stop' },
+      ]),
+      { allowConcurrentInvocations: true },
+    )();
+
+    const promise = client.getResponse([{ role: 'user', contents: [textContent('go')] }], {
+      tools: [waiting, failing],
+    } as never);
+
+    await expect(promise).rejects.toThrow(MiddlewareFailed);
+    expect(sawAbort).toBe(true);
+    released();
+  });
+
+  it('is not caught by the seam even when the tool would have succeeded', async () => {
+    let ran = 0;
+    const counted = tool({
+      name: 'counted',
+      description: 'Counts its invocations',
+      parameters: { type: 'object', properties: {} },
+      execute: () => {
+        ran++;
+        return 'ran';
+      },
+    });
+    const guard = functionMiddleware(async () => {
+      throw new MiddlewareFailed('policy service is unreachable');
+    });
+
+    await expect(run(callThen('counted', 'ok'), [guard], [counted])).rejects.toThrow(MiddlewareFailed);
+    expect(ran).toBe(0);
+  });
+});

--- a/packages/core/src/client/function-middleware-errors.test.ts
+++ b/packages/core/src/client/function-middleware-errors.test.ts
@@ -321,6 +321,52 @@ describe('MiddlewareFailed ends the run', () => {
     released();
   });
 
+  it('is what the caller sees even when a sibling fails on the abort', async () => {
+    // A sibling knocked over by the cancellation must not stand in for the failure that caused it.
+    // This one rejects from its abort listener, the earliest a sibling failure can possibly land.
+    const collapsing = tool({
+      name: 'collapsing',
+      description: 'Rejects as soon as it is aborted',
+      parameters: { type: 'object', properties: {} },
+      execute: async (_input, ctx) => {
+        await new Promise<void>((_resolve, reject) => {
+          ctx.signal?.addEventListener('abort', () => reject(new Error('aborted mid-flight')), {
+            once: true,
+          });
+        });
+        return 'never';
+      },
+    });
+    const failing = tool({
+      name: 'failing',
+      description: 'Fails the run',
+      parameters: { type: 'object', properties: {} },
+      execute: () => {
+        throw new MiddlewareFailed('policy service is unreachable');
+      },
+    });
+
+    const client = createFunctionInvocationClientFactory(
+      new MockChatClient([
+        {
+          contents: [
+            { type: 'function_call', callId: 'c1', name: 'collapsing', arguments: '{}' },
+            { type: 'function_call', callId: 'c2', name: 'failing', arguments: '{}' },
+          ],
+          finishReason: 'tool_calls',
+        },
+        { contents: [textContent('never reached')], finishReason: 'stop' },
+      ]),
+      { allowConcurrentInvocations: true },
+    )();
+
+    await expect(
+      client.getResponse([{ role: 'user', contents: [textContent('go')] }], {
+        tools: [collapsing, failing],
+      } as never),
+    ).rejects.toThrow(MiddlewareFailed);
+  });
+
   it('is not caught by the seam even when the tool would have succeeded', async () => {
     let ran = 0;
     const counted = tool({

--- a/packages/core/src/client/function-middleware-errors.test.ts
+++ b/packages/core/src/client/function-middleware-errors.test.ts
@@ -150,6 +150,26 @@ describe('a failure travels out through the middleware around it', () => {
     expect((seen[0] as Error).message).toBe('tool body failed');
   });
 
+  it('leaves `ctx.error` unset when the failure came from another middleware', async () => {
+    // `ctx.error` answers "was it the tool?", not "did something fail?". A middleware's throw
+    // unwinds without passing through the tool seam, so nothing sets it on the way out.
+    const seen: unknown[] = [];
+    const observer = functionMiddleware(async (ctx, next) => {
+      try {
+        await next();
+      } catch {
+        seen.push(ctx.error);
+      }
+    });
+    const thrower = functionMiddleware(async () => {
+      throw new Error('middleware failed');
+    });
+
+    await run(callThen('quiet', 'ok'), [observer, thrower]);
+
+    expect(seen).toEqual([undefined]);
+  });
+
   it('lets a middleware recover by assigning a result', async () => {
     const recovering = functionMiddleware(async (ctx, next) => {
       try {

--- a/packages/core/src/client/function-middleware-errors.test.ts
+++ b/packages/core/src/client/function-middleware-errors.test.ts
@@ -185,6 +185,20 @@ describe('a failure nothing recovered is reported to the model', () => {
     expect(messages.at(-1)?.contents.some((c) => c.type === 'text' && c.text === 'carried on')).toBe(true);
   });
 
+  it('reports a middleware that threw after the tool had already succeeded', async () => {
+    // The tool ran and left a result behind. The middleware then failed, so the call as a whole
+    // did not succeed, and the result of a step that never finished is not the answer.
+    const thrower = functionMiddleware(async (_ctx, next) => {
+      await next();
+      throw new Error('after the tool');
+    });
+
+    const messages = await run(callThen('quiet', 'carried on'), [thrower]);
+
+    expect(exceptionOf(messages)).toContain('after the tool');
+    expect(resultOf(messages)).not.toBe('done');
+  });
+
   it('reports a value that is not an Error', async () => {
     const thrower = functionMiddleware(async () => {
       throw 'a bare string';

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -139,6 +139,31 @@ export class MiddlewareTerminated extends AgentFrameworkError {
   }
 }
 
+/**
+ * A failure that must end the run rather than be reported to the model.
+ *
+ * Everything else a tool or a function middleware throws becomes this call's `function_result`, and
+ * the loop carries on — the right reading for a tool that failed, and the wrong one for a layer
+ * whose whole job is to decide whether the call may happen at all. A guardrail that cannot reach
+ * its policy service has not decided "no"; it has failed to decide, and telling the model the tool
+ * errored invites it to try again against a check that is no longer running.
+ *
+ * Throw this to say so. It is never converted into a result: the current batch of calls is
+ * cancelled, no further call starts, and it reaches the caller of `run()`. The counterpart of
+ * Python's `MiddlewareFailure`.
+ *
+ * Cancellation is cooperative. A sibling call already awaiting something stops at its next
+ * suspension point if it watches `ctx.signal`; one that ignores the signal runs to completion and
+ * may still have its effects, but its result is discarded either way and never reaches the
+ * transcript, the model, or history.
+ */
+export class MiddlewareFailed extends AgentFrameworkError {
+  constructor(message = 'Middleware aborted the run.', options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'MiddlewareFailed';
+  }
+}
+
 /** A feature exists in the API surface but is not implemented by this package. */
 export class NotImplementedError extends AgentFrameworkError {
   constructor(message: string, options?: ErrorOptions) {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -142,7 +142,7 @@ export class MiddlewareTerminated extends AgentFrameworkError {
 /**
  * A failure that must end the run rather than be reported to the model.
  *
- * Everything else a tool or a function middleware throws becomes this call's `function_result`, and
+ * An ordinary error from a tool or a function middleware becomes this call's `function_result` and
  * the loop carries on — the right reading for a tool that failed, and the wrong one for a layer
  * whose whole job is to decide whether the call may happen at all. A guardrail that cannot reach
  * its policy service has not decided "no"; it has failed to decide, and telling the model the tool
@@ -151,6 +151,10 @@ export class MiddlewareTerminated extends AgentFrameworkError {
  * Throw this to say so. It is never converted into a result: the current batch of calls is
  * cancelled, no further call starts, and it reaches the caller of `run()`. The counterpart of
  * Python's `MiddlewareFailure`.
+ *
+ * Two other errors also leave the seam without becoming a failure result, and neither is this:
+ * {@link MiddlewareTerminated} — from `ctx.terminate(result)` — stops the loop *after* reporting
+ * this round, and {@link UserInputRequiredError} carries a request only the caller can settle.
  *
  * Cancellation is cooperative. A sibling call already awaiting something stops at its next
  * suspension point if it watches `ctx.signal`; one that ignores the signal runs to completion and

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,6 +60,7 @@ export {
   ChatClientError,
   ConfigurationError,
   ContentFilterError,
+  MiddlewareFailed,
   MiddlewareTerminated,
   NotImplementedError,
   SchemaResolutionError,

--- a/packages/core/src/middleware/middleware.test.ts
+++ b/packages/core/src/middleware/middleware.test.ts
@@ -443,10 +443,10 @@ describe('function middleware', () => {
       },
     });
     const recover = functionMiddleware(async (ctx, next) => {
-      await next();
-      if (ctx.error !== undefined) {
+      try {
+        await next();
+      } catch {
         ctx.result = 'recovered';
-        ctx.error = undefined;
       }
     });
     const agent = new Agent({

--- a/packages/core/src/middleware/middleware.ts
+++ b/packages/core/src/middleware/middleware.ts
@@ -127,11 +127,15 @@ export interface FunctionMiddlewareContext {
    */
   result?: unknown;
   /**
-   * The error the tool threw, when it threw.
+   * The error the **tool body** threw, when it threw.
    *
    * A mirror, not the channel: the failure is what `next()` throws, and this is set alongside it
    * so a middleware can look without catching. Clearing it does not clear the failure — recover by
    * catching and assigning {@link FunctionMiddlewareContext.result}.
+   *
+   * Only the tool's own failure appears here. A failure thrown by another middleware unwinds
+   * without passing through the tool seam, so this is still unset while your `catch` or `finally`
+   * runs — it answers "was it the tool?", not "did something fail?".
    */
   error?: unknown;
   /**
@@ -194,8 +198,11 @@ function middlewareName(handler: MiddlewareHandler<never>, options?: { name?: st
  * reports it to the model as this call's failure and the loop carries on. To end the run instead,
  * throw {@link MiddlewareFailed} — that one is never turned into a result.
  *
- * The failure is also readable as `ctx.error`, for a middleware that wants to look at it without
- * taking responsibility for it.
+ * A failure from the **tool body** is also readable as `ctx.error`, set before it is thrown, for a
+ * middleware that wants to look at it without catching. A failure thrown by another middleware is
+ * not: it unwinds without passing through the tool seam, so `ctx.error` is still unset while your
+ * `catch` or `finally` runs. What you caught is the failure; `ctx.error` only ever tells you
+ * whether the tool itself was the one that failed.
  */
 export function functionMiddleware(
   handler: MiddlewareHandler<FunctionMiddlewareContext>,

--- a/packages/core/src/middleware/middleware.ts
+++ b/packages/core/src/middleware/middleware.ts
@@ -126,7 +126,13 @@ export interface FunctionMiddlewareContext {
    * the model, which is how {@link toolApprovalMiddleware} defers a call to a human.
    */
   result?: unknown;
-  /** The error the tool threw, when it threw. Set after `next()` returns. */
+  /**
+   * The error the tool threw, when it threw.
+   *
+   * A mirror, not the channel: the failure is what `next()` throws, and this is set alongside it
+   * so a middleware can look without catching. Clearing it does not clear the failure — recover by
+   * catching and assigning {@link FunctionMiddlewareContext.result}.
+   */
   error?: unknown;
   /**
    * Ends this invocation *and* the function-calling loop.
@@ -170,13 +176,26 @@ function middlewareName(handler: MiddlewareHandler<never>, options?: { name?: st
 /**
  * Declares a function middleware.
  *
+ * `next()` throws when the call it wraps fails, whether the tool body threw or an inner middleware
+ * did, so anything that has to happen on both paths belongs in `finally`:
+ *
  * ```ts
  * const timing = functionMiddleware(async (ctx, next) => {
  *   const started = performance.now();
- *   await next();
- *   console.log(ctx.tool.name, performance.now() - started, 'ms');
+ *   try {
+ *     await next();
+ *   } finally {
+ *     console.log(ctx.tool.name, performance.now() - started, 'ms');
+ *   }
  * });
  * ```
+ *
+ * Catching it and assigning `ctx.result` answers the call in the tool's place; letting it out
+ * reports it to the model as this call's failure and the loop carries on. To end the run instead,
+ * throw {@link MiddlewareFailed} — that one is never turned into a result.
+ *
+ * The failure is also readable as `ctx.error`, for a middleware that wants to look at it without
+ * taking responsibility for it.
  */
 export function functionMiddleware(
   handler: MiddlewareHandler<FunctionMiddlewareContext>,


### PR DESCRIPTION
## What this changes

Closes #107, both halves.

**Where a failure surfaces.** A tool body's exception was written to `ctx.error` and `next()`
resolved, so a middleware wrapping the call never saw it — while an exception from an *inner
middleware* propagated normally. The same `try { await next() } catch` behaved differently
depending on which layer threw. The repo's own `examples/03-extensibility/01-middleware.ts` timing
middleware demonstrated the consequence: it silently skipped exactly the calls worth timing.

**Whether a failure is fatal.** A middleware exception failed the whole run; a tool exception did
not. Both now become that call's `function_result` and the loop continues, still counting against
`maxConsecutiveErrors` (default 3, the same number Go uses), so a layer that keeps failing still
ends the run.

`MiddlewareFailed` says a failure must end the run instead: never turned into a result, cancels the
rest of a concurrent batch, reaches the caller. A tool body may throw it too.

## A correction to how this issue was framed

The issue's second half is written as "are tool exceptions fatal", and I carried that framing into
the design notes. Pinning the current behaviour first showed it was wrong: **tool bodies were
already fail-open** (`runTool` catches and returns an exception result — its own comment says "never
a failed run"). Only *middleware* exceptions were fatal. That narrowed the change and made it a
unification rather than a reversal of the tool contract.

It also dissolved the security argument I had for keeping the old behaviour. That argument was that
`toolApprovalMiddleware`'s `rule.when` predicate throwing should abort the run. But the predicate is
evaluated **before** `next()`, so reporting its failure to the model does not let the tool run — the
call is still stopped. What changes is only whether the run dies immediately or after the error
budget. There is a test for that.

## Parity

- Reference checked, unwinding: .NET `AgentHooksFunctionMiddleware` wraps `await next(context, …)`
  in `try/catch` and catches the invocation's exception; Python runs the tool body as
  `final_handler` **inside** `middleware_pipeline.execute` and catches outside it (`_tools.py:1607`).
  Go has no function-middleware seam.
- Reference checked, fail-open: .NET's own comment calls the loop "fail open" — it "converts thrown
  exceptions into tool errors and keeps running", with `context.Terminate` as the only loud escape.
  Python: `except Exception → _function_execution_error_result`, re-raising only `MiddlewareFailure`,
  `MiddlewareTermination` and `UserInputRequiredException` (`_tools.py:1635`). Go: fail-open with
  `MaximumConsecutiveErrorsPerRequest`, default 3.
- `MiddlewareFailed` is Python's `MiddlewareFailure`; the name follows this codebase's existing
  `MiddlewareTerminated`. A tool body may raise it because Python's re-raise sits outside the whole
  pipeline, tool body included.
- Cooperative cancellation reaches exactly as far as Python's, including the limit: a sibling that
  ignores its signal runs to completion and may still have its effects; the result is discarded
  either way.
- TypeScript-specific addition: `ctx.error` stays set alongside the throw, so a middleware can
  observe without catching. The throw is the channel — clearing `ctx.error` does not clear the
  failure.
- Wire format affected: no
- Public API affected: yes (`MiddlewareFailed` added)
- Breaking change: yes

## Notes

Not in scope, filing separately: settlement of dangling calls when the service owns the transcript,
which `MiddlewareFailed` and the iteration limit can both produce. Python implements it
(`_tools.py:3096-3130`) and it is what keeps Anthropic from rejecting the next request — an unanswered
`tool_use` is a measured `400` there.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`
