### PR TITLE
Chain from the id the round reported, not the one the request carried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **`@polymind-inc/agent-framework-core`** — the function-calling loop decides the next round from
+  the conversation id the round that just finished **reported**, not from the id the request
+  happened to carry. A run that started without one and was handed one mid-flight kept resending
+  the whole transcript for the rest of its tool rounds; it now chains from the second round on and
+  carries only the tool results, which is what Python's `_prepare_messages_for_next_iteration` does
+  and what the session-level adoption already assumed. The anchor a provider declares stable is
+  still held. Nothing changes when no id is ever reported, including under `store: false`.
+
 - **[BREAKING] `@polymind-inc/agent-framework-core`** — a session now takes the conversation id the
   first response reports, which hands the transcript to the service. From the next turn the request
   carries that id instead of the whole history, the framework's own history provider stands down,

--- a/packages/core/src/client/function-invocation.test.ts
+++ b/packages/core/src/client/function-invocation.test.ts
@@ -1431,17 +1431,23 @@ describe('conversation chaining between rounds', () => {
   function chainingClient(
     roundIds: [string, string],
     metadata: ChatClientMetadata,
-  ): { client: ChatClient<ChatOptions>; requests: Array<ChatOptions | undefined> } {
+  ): {
+    client: ChatClient<ChatOptions>;
+    requests: Array<ChatOptions | undefined>;
+    sent: Message[][];
+  } {
     const turns: Array<{ contents: Content[]; conversationId: string }> = [
       { contents: [call('c1', 'echo', '{"value":"x"}')], conversationId: roundIds[0] },
       { contents: [textContent('done')], conversationId: roundIds[1] },
     ];
     let index = 0;
     const requests: Array<ChatOptions | undefined> = [];
+    const sent: Message[][] = [];
     const client: ChatClient<ChatOptions> = {
       metadata,
-      getResponse: (_messages, options) => {
+      getResponse: (messages, options) => {
         requests.push(options);
+        sent.push(messages);
         const turn = turns[Math.min(index++, turns.length - 1)] ?? { contents: [], conversationId: '' };
         return createResponseStream({
           start: () =>
@@ -1456,8 +1462,43 @@ describe('conversation chaining between rounds', () => {
         });
       },
     };
-    return { client, requests };
+    return { client, requests, sent };
   }
+
+  it('chains from the id the round reported, even when the request carried none', async () => {
+    // The service stored this round, so it holds the request and the response: the next round
+    // continues from that id and carries only the tool results. Keying the decision off the id the
+    // *request* carried instead would leave the rest of a run that was promoted mid-flight
+    // resending the whole transcript.
+    const { client, requests, sent } = chainingClient(['resp_r1', 'resp_r2'], { providerName: 'mock' });
+
+    await withFunctionInvocation(client).getResponse([{ role: 'user', contents: [textContent('go')] }], {
+      tools: [echo],
+    } as ChatOptions);
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.conversationId).toBeUndefined();
+    expect(requests[1]?.conversationId).toBe('resp_r1');
+
+    // Only the tool results. The user turn and the model's call are already service-side, and
+    // sending them again is how one turn ends up in the conversation twice.
+    const second = sent[1];
+    assert.exists(second);
+    expect(second.map((message) => message.role)).toEqual(['tool']);
+  });
+
+  it('keeps resending the transcript when no id is ever reported', async () => {
+    const { client, requests, sent } = chainingClient(['', ''], { providerName: 'mock' });
+
+    await withFunctionInvocation(client).getResponse([{ role: 'user', contents: [textContent('go')] }], {
+      tools: [echo],
+    } as ChatOptions);
+
+    expect(requests[1]?.conversationId).toBeUndefined();
+    const second = sent[1];
+    assert.exists(second);
+    expect(second.map((message) => message.role)).toEqual(['user', 'assistant', 'tool']);
+  });
 
   it('holds the conversation anchor the provider declares stable', async () => {
     // The provider says which ids are stable service-side anchors; a round that reports a

--- a/packages/core/src/client/function-invocation.ts
+++ b/packages/core/src/client/function-invocation.ts
@@ -246,9 +246,11 @@ function limitFallbackUpdate(response: ChatResponse<unknown>): ChatResponseUpdat
  *   answers by fetching the existing response rather than posting a new one. Carried into round
  *   two, the provider would keep re-fetching the response that asked for the tools instead of
  *   receiving their results, and the loop would spin to `maxIterations` empty-handed;
- * - a service-managed `conversationId` advances to the id of the round that just finished, so the
- *   next request continues from the newest turn rather than from the first one (Python
- *   `_tools.py`, Go `responses.go` `SetServiceID`).
+ * - the `conversationId` becomes whatever id the round that just finished reported, so the next
+ *   request continues from the newest turn rather than from the first one (Python `_tools.py`, Go
+ *   `responses.go` `SetServiceID`). A round that reports an id is a round the service stored, and
+ *   it stored the request along with the response — so a run whose first round carried no id
+ *   chains from the second round on, rather than resending a transcript the service already has.
  *
  * @param roundConversationId - The `conversationId` of the response this round produced.
  * @param stableConversationId - The provider's declaration of which ids are stable anchors
@@ -271,15 +273,11 @@ function optionsForNextIteration<TOptions extends ChatOptions>(
 
   const current = options.conversationId;
   if (
-    // Only a request that *already* uses service-side storage chains: adopting an id here would
-    // silently move a framework-managed transcript to the provider.
-    current !== undefined &&
-    current !== '' &&
     // An id the provider declares stable is an anchor the service resolves across responses;
     // displacing it with a round's reported id would unhook the run from the stored conversation
     // (the provider-side guard Go keeps in `keepConversationID`). Which ids are stable is the
     // provider's knowledge, so the loop only asks — it never inspects the id itself.
-    stableConversationId?.(current) !== true &&
+    (current === undefined || current === '' || stableConversationId?.(current) !== true) &&
     roundConversationId !== undefined &&
     roundConversationId !== '' &&
     roundConversationId !== current
@@ -843,17 +841,21 @@ export function createFunctionInvocationClientFactory<TOptions extends ChatOptio
         return;
       }
 
-      // When the service owns the transcript it already holds this round's request and response,
-      // so the next round carries nothing but the tool results (Python
-      // `_prepare_messages_for_next_iteration`). Sending the rest again is how the same turn ends
-      // up in the conversation twice.
-      const serviceOwnsTranscript = current.conversationId !== undefined && current.conversationId !== '';
-      history = serviceOwnsTranscript ? [toolMessage] : [...history, ...roundResponse.messages, toolMessage];
-      current = optionsForNextIteration(
+      // Both halves of the next round follow one signal: the id it will actually carry. When the
+      // service owns the transcript it already holds this round's request and response, so the
+      // next round carries nothing but the tool results (Python
+      // `_prepare_messages_for_next_iteration`, which reads the id off the *response* for exactly
+      // this reason). Deciding from the id the last request carried instead would split the two —
+      // a run promoted mid-flight would send the id and the whole transcript, which is how the
+      // same turn ends up in the conversation twice.
+      const next = optionsForNextIteration(
         current,
         roundResponse.conversationId,
         client.metadata.stableConversationId,
       );
+      const serviceOwnsTranscript = next.conversationId !== undefined && next.conversationId !== '';
+      history = serviceOwnsTranscript ? [toolMessage] : [...history, ...roundResponse.messages, toolMessage];
+      current = next;
     }
   }
 

--- a/packages/openai/src/chat-client.test.ts
+++ b/packages/openai/src/chat-client.test.ts
@@ -915,7 +915,65 @@ describe('Agent over OpenAIChatClient', () => {
     expect(create).toHaveBeenCalledTimes(2);
     expect(response.text).toBe('Tokyo is sunny.');
 
-    // The follow-up request replays the call and its result as top-level items.
+    // `store` defaults on, so the first response is one the service kept: the follow-up continues
+    // from it and carries the tool result alone.
+    expect(create.mock.calls[1]?.[0].previous_response_id).toBe('resp_1');
+    const secondInput = create.mock.calls[1]?.[0].input as InputItem[];
+    expect(secondInput.map((item) => item.type)).toEqual(['function_call_output']);
+    expect(secondInput[0]?.output).toBe('Tokyo is sunny');
+    expect(create.mock.calls[1]?.[0].instructions).toBe('Be helpful.');
+  });
+
+  it('replays the call and its result inline when nothing is stored service-side', async () => {
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce(
+        completedResponse({
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_1',
+              call_id: 'call_1',
+              name: 'get_weather',
+              arguments: '{"location":"Tokyo"}',
+              status: 'completed',
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        completedResponse({
+          id: 'resp_2',
+          output: [
+            {
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: 'Tokyo is sunny.', annotations: [] }],
+            },
+          ],
+        }),
+      );
+
+    const weather = tool({
+      name: 'get_weather',
+      description: 'Get the weather',
+      parameters: { type: 'object', properties: { location: { type: 'string' } }, required: ['location'] },
+      execute: async ({ location }) => `${location} is sunny`,
+    });
+
+    const agent = new Agent({
+      client: new OpenAIChatClient({ client: fakeClient(create), model: 'gpt-4o' }),
+      instructions: 'Be helpful.',
+      tools: [weather],
+      defaultOptions: { store: false },
+    });
+
+    const response = await agent.run('weather in Tokyo?');
+
+    expect(response.text).toBe('Tokyo is sunny.');
+    // Nothing is kept service-side, so there is no id to continue from and the whole exchange
+    // travels as top-level items.
+    expect(create.mock.calls[1]?.[0].previous_response_id).toBeUndefined();
     const secondInput = create.mock.calls[1]?.[0].input as InputItem[];
     expect(secondInput.map((item) => item.type)).toEqual([
       'message',
@@ -923,7 +981,6 @@ describe('Agent over OpenAIChatClient', () => {
       'function_call_output',
     ]);
     expect(secondInput[2]?.output).toBe('Tokyo is sunny');
-    expect(create.mock.calls[1]?.[0].instructions).toBe('Be helpful.');
   });
 
   it('chains the response id and stops re-sending stored items across a tool round', async () => {


### PR DESCRIPTION
## What this changes

Follow-up to #146, from its review. Adopting the reported conversation id at the session level left
the same rule it replaced sitting one layer down: `optionsForNextIteration` still refused to chain
unless the request *already* carried an id — the justification #146 withdrew, still in force for
tool rounds. A run promoted mid-flight kept resending the whole transcript for the rest of its
rounds, so the session said service-managed while the loop behaved framework-managed.

Not a correctness bug — the model saw the conversation once — but a divergence and a missed
optimization in exactly the run that pays for it.

**Removing the guard alone would have made it one.** `serviceOwnsTranscript` was computed from
`current.conversationId` *before* `optionsForNextIteration` advanced it, so the second round would
have sent `previous_response_id` **and** the full transcript. The negative control for that is in
the tests: reverting the ordering produces `['user', 'assistant', 'tool']` where `['tool']` is
expected.

Both decisions now follow one signal: the id the next round will actually carry.

## Parity

- Reference checked: Python `_prepare_messages_for_next_iteration` (`_tools.py:2768`) —
  `if response.conversation_id is None: extend else: prepared_messages[:] = response.messages[-1:]`.
  It reads the id off the **response**, which is the distinction this PR adopts.
- Unchanged: an anchor the provider declares stable is still held rather than displaced by a
  round's reported id (Go `keepConversationID`).
- Unchanged when no id is ever reported, including under `store: false`, with a test for it.
- Wire format affected: yes (a promoted run's later tool rounds now carry `previous_response_id`
  and only the tool results)
- Public API affected: no
- Breaking change: no — the transcript the model sees is the same either way

## Notes

The existing `runs a full tool round trip` test now chains, because `store` defaults on. Its
assertions are updated and a paired `store: false` test pins the inline-replay path it used to
cover.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`
