### PR TITLE
Let a chat client ask for a view bound to the run's session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **`@polymind-inc/agent-framework-core`** — a chat client can now implement
+  `SessionScopedChatClient` to be asked, once per run, for a view of itself bound to that run's
+  session. The bound client wraps every service call of the run — later rounds of a tool loop as
+  much as the first, awaited and streamed alike — which is what a provider needs when its service
+  mints an identifier during a run that the session then has to echo on every later request. There
+  was nowhere to put such a value before: on the client it leaks between sessions, and a caller
+  cannot supply it because it does not exist until a run is already under way. `Agent` reads the
+  capability off the client it was constructed with, the same way it collects that client's
+  middleware; a client that does not implement it is unaffected and takes the same path as before.
+
 - **`@polymind-inc/agent-framework-core`** — the function-calling loop decides the next round from
   the conversation id the round that just finished **reported**, not from the id the request
   happened to carry. A run that started without one and was handed one mid-flight kept resending

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -26,6 +26,27 @@ service-side should declare which conversation ids are stable anchors via
 propagation consult that predicate, and without it every reported conversation id advances the
 chain between tool rounds.
 
+A client whose service mints an identifier *during* a run — one the session then has to send on
+every later request — can also implement `SessionScopedChatClient`. `Agent` asks it once per run
+for a view of itself bound to that run's session, and that view wraps every service call of the
+run, later tool rounds included, on awaited and streamed runs alike:
+
+```ts
+class MyChatClient implements ChatClient<MyOptions>, SessionScopedChatClient<MyOptions> {
+  forSession(session: AgentSession): ChatClient<MyOptions> {
+    return {
+      metadata: this.metadata,
+      getResponse: (messages, options) =>
+        this.getResponse(messages, withTicket(options, session.state.myTicket)),
+    };
+  }
+}
+```
+
+Keep the value in `session.state` rather than on the client — that is what keeps one session from
+seeing another's, and what survives session serialization — and copy the options rather than
+mutating what the caller passed in.
+
 Function middleware wraps one tool call, and `next()` throws when that call fails — whether the
 tool body threw or an inner middleware did. Catch it and assign `ctx.result` to answer in the
 tool's place; let it out and it is reported to the model as that call's `function_result` while the

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1,4 +1,10 @@
-import type { ChatClient, ChatOptions, ChatResponseStream, ResponseFormat } from '../client/chat-client.js';
+import type {
+  ChatClient,
+  ChatOptions,
+  ChatResponseStream,
+  ResponseFormat,
+  SessionScopedChatClient,
+} from '../client/chat-client.js';
 import type { FunctionInvocationConfig } from '../client/function-invocation.js';
 import { createFunctionInvocationClientFactory } from '../client/function-invocation.js';
 import { applyStructuredOutput } from '../client/structured-output.js';
@@ -235,6 +241,10 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
     session?: AgentSession,
     middleware?: readonly FunctionMiddleware[],
   ) => ChatClient<TOptions>;
+  /** Kept so the loop can be prepared again for a run whose client is bound to its session. */
+  readonly #loopConfig: FunctionInvocationConfig;
+  /** The provider's {@link SessionScopedChatClient} hook, already bound to the client. */
+  readonly #forSession: ((session: AgentSession) => ChatClient<TOptions>) | undefined;
   readonly #tools: Tool[];
   readonly #defaultOptions: Partial<TOptions>;
   /**
@@ -295,10 +305,38 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
     // that round's tools run.
     this.#functionInvocation = config.functionInvocation ?? {};
     this.#client = withChatTelemetry(config.client);
-    this.#functionClient = createFunctionInvocationClientFactory(this.#client, {
+    this.#loopConfig = {
       ...this.#functionInvocation,
       middleware: [...(this.#functionInvocation.middleware ?? []), ...collected.function],
-    });
+    };
+    this.#functionClient = createFunctionInvocationClientFactory(this.#client, this.#loopConfig);
+    // Read where the client's middleware is read from, and for the same reason: a capability the
+    // client offers is declared on the client the caller handed over, not on a wrapper of it.
+    const scoped = (config.client as Partial<SessionScopedChatClient<TOptions>>).forSession;
+    this.#forSession = typeof scoped === 'function' ? scoped.bind(config.client) : undefined;
+  }
+
+  /**
+   * The client stack for one run, with the session bound in when the provider asked for it.
+   *
+   * The bound wrapper takes the leaf's place: inside the chat span, so whatever it does is
+   * measured as part of the call it wraps, and inside the function-calling loop, so it wraps every
+   * round rather than only the first. The span still reports the request as the framework issued
+   * it — what a provider layer adds below is the provider's business, the same as it already is
+   * for anything the leaf client puts on the wire.
+   *
+   * Preparing the loop a second time is the price of binding per run, and only a provider that
+   * asked for it pays: without the capability this returns the layer prepared at construction.
+   */
+  #loopClient(
+    session: AgentSession,
+    functionMiddleware: readonly FunctionMiddleware[],
+  ): ChatClient<TOptions> {
+    if (this.#forSession === undefined) {
+      return this.#functionClient(session, functionMiddleware);
+    }
+    const bound = withChatTelemetry(this.#forSession(session));
+    return createFunctionInvocationClientFactory(bound, this.#loopConfig)(session, functionMiddleware);
   }
 
   /** Fails fast when two providers would write to the same slot of {@link AgentSession.state}. */
@@ -721,15 +759,11 @@ export class Agent<TOptions extends ChatOptions = ChatOptions> implements AgentL
     session: AgentSession,
     functionMiddleware: readonly FunctionMiddleware[],
   ): ChatClient<TOptions> {
-    return withToolApproval(
-      this.#functionClient(session, functionMiddleware),
-      sessionApprovalStore(session),
-      {
-        ...(this.#functionInvocation.additionalTools === undefined
-          ? {}
-          : { additionalTools: this.#functionInvocation.additionalTools }),
-      },
-    );
+    return withToolApproval(this.#loopClient(session, functionMiddleware), sessionApprovalStore(session), {
+      ...(this.#functionInvocation.additionalTools === undefined
+        ? {}
+        : { additionalTools: this.#functionInvocation.additionalTools }),
+    });
   }
 
   /** This agent's identity as handed to middleware and context providers. */

--- a/packages/core/src/client/chat-client.ts
+++ b/packages/core/src/client/chat-client.ts
@@ -145,6 +145,17 @@ export interface ChatClient<TOptions extends ChatOptions = ChatOptions> {
  *   serialization.
  * - **Do not mutate the caller's options.** Copy, then add.
  * - Return a client, not a promise: this runs on the hot path of every round.
+ *
+ * ## Declaring it through a wrapper
+ *
+ * `Agent` looks for this on the client it was constructed with, so a wrapper stands between them.
+ * `withMiddleware` carries it over, as it already carries the hosted-tool capability methods —
+ * that is the wrapper meant for wrapping a client on the way in.
+ *
+ * The other exported client layers (`withChatTelemetry`, `withToolApproval`,
+ * `withFunctionInvocation`, `withStructuredOutput`) do not, and are not meant to: `Agent` applies
+ * each of them itself, so applying one before constructing an agent doubles a layer rather than
+ * adding one. A client wrapped that way loses this capability along with its hosted-tool ones.
  */
 export interface SessionScopedChatClient<TOptions extends ChatOptions = ChatOptions> {
   /**

--- a/packages/core/src/client/chat-client.ts
+++ b/packages/core/src/client/chat-client.ts
@@ -1,3 +1,4 @@
+import type { AgentSession } from '../agent/session.js';
 import type { ResponseStream } from '../streaming/response-stream.js';
 import type { JsonSchema, SchemaInput } from '../tools/json-schema.js';
 import type { Tool } from '../tools/tool.js';
@@ -101,4 +102,56 @@ export interface ChatClient<TOptions extends ChatOptions = ChatOptions> {
     messages: Message[],
     options?: TOptions & { signal?: AbortSignal },
   ): ChatResponseStream<unknown>;
+}
+
+/**
+ * An optional capability of a {@link ChatClient}: a view of itself bound to one run's session.
+ *
+ * A chat client is shared by every session that uses the agent, and `getResponse` is handed
+ * messages and options — never the session. That is right for a provider that only translates a
+ * request, and not enough for one whose service mints an identifier the *session* has to keep and
+ * echo on every later request. There is nowhere in a plain client to put such a value: on the
+ * client it would leak between sessions, and the caller cannot supply it because the service only
+ * issues it once a run is already under way.
+ *
+ * A client that implements this is asked, once per run, for a client bound to that run's session.
+ * The returned client sits inside the function-calling loop, so it wraps **every** service call of
+ * the run — the second and third rounds of a tool loop as much as the first — on awaited and
+ * streamed runs alike. `Agent` reads this capability off the client it was constructed with, the
+ * same way it collects that client's middleware.
+ *
+ * Write the bound client as an ordinary wrapper. Nothing else is required of it:
+ *
+ * ```ts
+ * class MyChatClient implements ChatClient<MyOptions>, SessionScopedChatClient<MyOptions> {
+ *   forSession(session: AgentSession): ChatClient<MyOptions> {
+ *     return {
+ *       metadata: this.metadata,
+ *       getResponse: (messages, options) => {
+ *         const kept = session.state.myServiceTicket;
+ *         const stream = this.getResponse(messages, withTicket(options, kept));
+ *         // …record a ticket the response carries back onto `session.state`
+ *         return stream;
+ *       },
+ *     };
+ *   }
+ * }
+ * ```
+ *
+ * ## What the bound client owes
+ *
+ * - **Keep per-session state on the session**, in {@link AgentSession.state}, not on the client.
+ *   Two sessions must never see each other's values, and session state is what survives
+ *   serialization.
+ * - **Do not mutate the caller's options.** Copy, then add.
+ * - Return a client, not a promise: this runs on the hot path of every round.
+ */
+export interface SessionScopedChatClient<TOptions extends ChatOptions = ChatOptions> {
+  /**
+   * Returns a client bound to `session`, called once per run before the first service call.
+   *
+   * @param session - The run's session. Always resolved — a run without an explicit session still
+   * has one.
+   */
+  forSession(session: AgentSession): ChatClient<TOptions>;
 }

--- a/packages/core/src/client/session-scoped-client.test.ts
+++ b/packages/core/src/client/session-scoped-client.test.ts
@@ -138,7 +138,7 @@ describe('SessionScopedChatClient', () => {
   it('survives being wrapped with withMiddleware, which the agent still collects from', async () => {
     // `withMiddleware` is the documented way to wrap any client, and the agent reads both the
     // middleware and this capability off the client it was handed. A wrapper that carried only the
-    // first would turn a session-scoped provider into an ordinary one with nothing to say so.
+    // first would silently turn a session-scoped provider into an ordinary one.
     const client = new StampingClient(twoRounds());
     const seen: string[] = [];
     const observer = functionMiddleware(async (ctx, next) => {

--- a/packages/core/src/client/session-scoped-client.test.ts
+++ b/packages/core/src/client/session-scoped-client.test.ts
@@ -1,0 +1,160 @@
+/**
+ * The {@link SessionScopedChatClient} capability: a provider asking for a view of itself bound to
+ * the run's session.
+ *
+ * What the tests pin is where that view sits — around every service call of the run, on both
+ * consumption modes, with the run's own session and nobody else's.
+ */
+import { describe, expect, it } from 'vitest';
+import { Agent } from '../agent/agent.js';
+import type { AgentSession } from '../agent/session.js';
+import { tool } from '../index.js';
+import { textContent } from '../types/content.js';
+import type { ChatClient, ChatOptions, ChatResponseStream, SessionScopedChatClient } from './chat-client.js';
+import { MockChatClient } from './test-support.js';
+
+const echo = tool({
+  name: 'echo',
+  description: 'Echoes',
+  parameters: { type: 'object', properties: {} },
+  execute: () => 'ok',
+});
+
+/** Two rounds: a tool call, then an answer. Needs `echo` registered, or the call goes unanswered. */
+function twoRounds(): ConstructorParameters<typeof MockChatClient>[0] {
+  return [
+    {
+      contents: [{ type: 'function_call', callId: 'c1', name: 'echo', arguments: '{}' }],
+      finishReason: 'tool_calls',
+    },
+    { contents: [textContent('done')], finishReason: 'stop' },
+  ];
+}
+
+/** One round, for the tests that are about runs rather than about rounds. */
+function oneRound(): ConstructorParameters<typeof MockChatClient>[0] {
+  return [{ contents: [textContent('done')], finishReason: 'stop' }];
+}
+
+/**
+ * A client that stamps a per-session counter onto every request it makes.
+ *
+ * Stands in for a provider whose service hands back an identifier the session has to keep: the
+ * value lives on the session, the wrapper is an ordinary client, and nothing is held on `this`.
+ */
+class StampingClient extends MockChatClient implements SessionScopedChatClient<ChatOptions> {
+  /** Every `ticket` value seen on an outgoing request, in order, across all sessions. */
+  readonly stamps: (string | undefined)[] = [];
+  /** Sessions this client was asked to bind to, in order. */
+  readonly bound: AgentSession[] = [];
+
+  forSession(session: AgentSession): ChatClient<ChatOptions> {
+    this.bound.push(session);
+    return {
+      metadata: this.metadata,
+      getResponse: (messages, options): ChatResponseStream<unknown> => {
+        const held = session.state.ticket;
+        this.stamps.push(typeof held === 'string' ? held : undefined);
+        // Copy, never mutate what the caller handed over.
+        const next = {
+          ...options,
+          additionalProperties: { ...options?.additionalProperties, ticket: held },
+        } as ChatOptions & { signal?: AbortSignal };
+        const stream = this.getResponse(messages, next);
+        // What a service that mints the value on the first call would leave behind.
+        session.state.ticket ??= `ticket-${session.sessionId}`;
+        return stream;
+      },
+    };
+  }
+}
+
+describe('SessionScopedChatClient', () => {
+  it('binds once per run and wraps every round of it', async () => {
+    const client = new StampingClient(twoRounds());
+    const agent = new Agent({ client, tools: [echo] });
+    const session = agent.createSession({ sessionId: 's1' });
+
+    await agent.run('go', { session });
+
+    // One binding for the run, one stamp per service call.
+    expect(client.bound).toHaveLength(1);
+    // Round one had nothing yet; round two carries what round one left on the session — the case
+    // a caller outside the run cannot reach, because the value did not exist when the run started.
+    expect(client.stamps).toEqual([undefined, 'ticket-s1']);
+  });
+
+  it('wraps every round of an awaited run and a streamed one alike', async () => {
+    const streamed = new StampingClient(twoRounds());
+    const agent = new Agent({ client: streamed, tools: [echo] });
+    const session = agent.createSession({ sessionId: 's2' });
+
+    for await (const _ of agent.run('go', { session })) {
+      // drain
+    }
+
+    expect(streamed.stamps).toEqual([undefined, 'ticket-s2']);
+  });
+
+  it('carries the value into later runs of the same session', async () => {
+    const client = new StampingClient(oneRound());
+    const agent = new Agent({ client });
+    const session = agent.createSession({ sessionId: 's3' });
+
+    await agent.run('one', { session });
+    await agent.run('two', { session });
+
+    expect(client.stamps).toEqual([undefined, 'ticket-s3']);
+    expect(client.bound).toHaveLength(2);
+  });
+
+  it('never lets one session see the value another one holds', async () => {
+    const client = new StampingClient(oneRound());
+    const agent = new Agent({ client });
+    const a = agent.createSession({ sessionId: 'a' });
+    const b = agent.createSession({ sessionId: 'b' });
+
+    await agent.run('one', { session: a });
+    await agent.run('two', { session: b });
+
+    // `b`'s run starts empty rather than inheriting `a`'s ticket.
+    expect(client.stamps).toEqual([undefined, undefined]);
+    expect(a.state.ticket).toBe('ticket-a');
+    expect(b.state.ticket).toBe('ticket-b');
+  });
+
+  it('survives a session round-trip, because the value lives in session state', async () => {
+    const client = new StampingClient(oneRound());
+    const agent = new Agent({ client });
+    const session = agent.createSession({ sessionId: 's4' });
+
+    await agent.run('one', { session });
+    const restored = agent.deserializeSession(JSON.parse(JSON.stringify(session)));
+    await agent.run('two', { session: restored });
+
+    expect(client.stamps).toEqual([undefined, 'ticket-s4']);
+  });
+
+  it('leaves a client without the capability on the layer prepared once', async () => {
+    const plain = new MockChatClient(twoRounds());
+    const agent = new Agent({ client: plain, tools: [echo] });
+
+    const response = await agent.run('go');
+
+    // Nothing to bind, nothing to change: the ordinary path still runs both rounds.
+    expect(plain.callCount).toBe(2);
+    expect(response.text).toBe('done');
+  });
+
+  it('does not mutate the options the caller handed over', async () => {
+    const client = new StampingClient(oneRound());
+    const agent = new Agent({ client });
+    const session = agent.createSession({ sessionId: 's5' });
+    const options = { temperature: 0.5 } as Partial<ChatOptions>;
+
+    await agent.run('one', { session, options });
+    await agent.run('two', { session, options });
+
+    expect(options).toEqual({ temperature: 0.5 });
+  });
+});

--- a/packages/core/src/client/session-scoped-client.test.ts
+++ b/packages/core/src/client/session-scoped-client.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, it } from 'vitest';
 import { Agent } from '../agent/agent.js';
 import type { AgentSession } from '../agent/session.js';
-import { tool } from '../index.js';
+import { functionMiddleware, tool, withMiddleware } from '../index.js';
 import { textContent } from '../types/content.js';
 import type { ChatClient, ChatOptions, ChatResponseStream, SessionScopedChatClient } from './chat-client.js';
 import { MockChatClient } from './test-support.js';
@@ -133,6 +133,25 @@ describe('SessionScopedChatClient', () => {
     await agent.run('two', { session: restored });
 
     expect(client.stamps).toEqual([undefined, 'ticket-s4']);
+  });
+
+  it('survives being wrapped with withMiddleware, which the agent still collects from', async () => {
+    // `withMiddleware` is the documented way to wrap any client, and the agent reads both the
+    // middleware and this capability off the client it was handed. A wrapper that carried only the
+    // first would turn a session-scoped provider into an ordinary one with nothing to say so.
+    const client = new StampingClient(twoRounds());
+    const seen: string[] = [];
+    const observer = functionMiddleware(async (ctx, next) => {
+      seen.push(ctx.tool.name);
+      await next();
+    });
+    const agent = new Agent({ client: withMiddleware(client, [observer]), tools: [echo] });
+    const session = agent.createSession({ sessionId: 'w1' });
+
+    await agent.run('go', { session });
+
+    expect(client.stamps).toEqual([undefined, 'ticket-w1']);
+    expect(seen).toEqual(['echo']);
   });
 
   it('leaves a client without the capability on the layer prepared once', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export type {
   ChatResponseStream,
   JsonSchemaResponseFormat,
   ResponseFormat,
+  SessionScopedChatClient,
   ToolChoice,
 } from './client/chat-client.js';
 export type { ClientErrorNormalizer, ClientErrorNormalizerOptions } from './client/client-errors.js';

--- a/packages/core/src/middleware/middleware.ts
+++ b/packages/core/src/middleware/middleware.ts
@@ -1,5 +1,5 @@
 import type { AgentSession } from '../agent/session.js';
-import type { ChatClient, ChatOptions } from '../client/chat-client.js';
+import type { ChatClient, ChatOptions, SessionScopedChatClient } from '../client/chat-client.js';
 import { ConfigurationError, MiddlewareTerminated } from '../errors.js';
 import { HOSTED_TOOL_CAPABILITY_METHODS } from '../tools/hosted.js';
 import type { AnyFunctionTool, Tool } from '../tools/tool.js';
@@ -334,6 +334,13 @@ export function terminateMiddleware(): never {
  * The client keeps working as a plain {@link ChatClient} — the middleware only takes effect for an
  * agent, which is the layer that owns runs and tool invocations.
  */
+/**
+ * The {@link SessionScopedChatClient} method name, checked against the interface rather than
+ * spelled twice: `HOSTED_TOOL_CAPABILITY_METHODS` is derived from a compiler-checked record for the
+ * same reason, and a name only a string literal knows about would go quietly stale on a rename.
+ */
+const SESSION_SCOPE_METHOD = 'forSession' satisfies keyof SessionScopedChatClient;
+
 export function withMiddleware<TOptions extends ChatOptions>(
   client: ChatClient<TOptions>,
   middleware: readonly Middleware[],
@@ -346,7 +353,7 @@ export function withMiddleware<TOptions extends ChatOptions>(
   // it silently turns a session-scoped provider into an ordinary one — nothing fails, and nothing
   // reports the loss.
   const capabilities: Record<string, unknown> = {};
-  for (const method of [...HOSTED_TOOL_CAPABILITY_METHODS, 'forSession']) {
+  for (const method of [...HOSTED_TOOL_CAPABILITY_METHODS, SESSION_SCOPE_METHOD]) {
     const fn = (client as unknown as Record<string, unknown>)[method];
     if (typeof fn === 'function') {
       // Bound to the wrapped client, which loses nothing: this wrapper's `getResponse` only

--- a/packages/core/src/middleware/middleware.ts
+++ b/packages/core/src/middleware/middleware.ts
@@ -341,11 +341,16 @@ export function withMiddleware<TOptions extends ChatOptions>(
   const existing = (client as { middleware?: readonly Middleware[] }).middleware ?? [];
   // The hosted-tool capability protocol is duck-typed on method presence, so the wrapper
   // has to carry the underlying client's capability methods or `supportsMcp` and friends would
-  // report a capable client as incapable after wrapping.
+  // report a capable client as incapable after wrapping. `forSession` is a different capability
+  // with the same hazard: `Agent` reads it off the client it was handed, so a wrapper that drops
+  // it turns a session-scoped provider into an ordinary one with nothing to say so.
   const capabilities: Record<string, unknown> = {};
-  for (const method of HOSTED_TOOL_CAPABILITY_METHODS) {
+  for (const method of [...HOSTED_TOOL_CAPABILITY_METHODS, 'forSession']) {
     const fn = (client as unknown as Record<string, unknown>)[method];
     if (typeof fn === 'function') {
+      // Bound to the wrapped client, which loses nothing: this wrapper's `getResponse` only
+      // delegates, and the middleware it carries travels on `middleware` for the agent to collect,
+      // not through the call.
       capabilities[method] = fn.bind(client);
     }
   }

--- a/packages/core/src/middleware/middleware.ts
+++ b/packages/core/src/middleware/middleware.ts
@@ -343,7 +343,8 @@ export function withMiddleware<TOptions extends ChatOptions>(
   // has to carry the underlying client's capability methods or `supportsMcp` and friends would
   // report a capable client as incapable after wrapping. `forSession` is a different capability
   // with the same hazard: `Agent` reads it off the client it was handed, so a wrapper that drops
-  // it turns a session-scoped provider into an ordinary one with nothing to say so.
+  // it silently turns a session-scoped provider into an ordinary one — nothing fails, and nothing
+  // reports the loss.
   const capabilities: Record<string, unknown> = {};
   for (const method of [...HOSTED_TOOL_CAPABILITY_METHODS, 'forSession']) {
     const fn = (client as unknown as Record<string, unknown>)[method];


### PR DESCRIPTION
## What this changes

Groundwork for #111 track A, which the maintainer approved along with track B. This PR is the core
capability only; the Foundry sticky hosted session id follows in its own PR, per the one-concern
rule in that issue.

A provider whose service mints an identifier **during** a run — one the session then has to echo on
every later request — had nowhere to keep it. The client is shared by every session that uses the
agent, so holding it there leaks between them; `getResponse` is never handed the session; and the
caller cannot supply it, because it does not exist until a run is already under way.

`SessionScopedChatClient` is an optional capability. A client that implements it is asked, once per
run, for a view of itself bound to that run's session. The bound view takes the leaf's place inside
the function-calling loop, so it wraps **every** service call of the run rather than only the first,
on awaited and streamed runs alike.

```ts
class MyChatClient implements ChatClient<MyOptions>, SessionScopedChatClient<MyOptions> {
  forSession(session: AgentSession): ChatClient<MyOptions> {
    return { metadata: this.metadata, getResponse: (messages, options) => /* … */ };
  }
}
```

## Parity

- Reference checked: **.NET** solves this with `PerServiceCallChatHistoryPersistingChatClient`, a
  `DelegatingChatClient` whose own documentation places it "between the `FunctionInvokingChatClient`
  and the leaf `IChatClient`" and which reaches the session through the **ambient**
  `AIAgent.CurrentRunContext` (an `AsyncLocal`, `AIAgent.cs:40`). **Python** solves it with
  `FoundryAgent._update_function_invocation_continuation_state` (`_tools.py:3061`), which receives
  the session and options as **explicit parameters**. Both put the seam in the same place — around
  each service call, inside the loop — and differ on how the session arrives.
- **Deliberately not ported: Python's third middleware kind.** Python has `ChatContext` /
  `ChatMiddleware` and a `{"agent", "function", "chat"}` category map, and `ChatContext` carries the
  session. That shape exists because Python has no structural typing and .NET's decorator base
  exists because C# has no first-class function composition over interfaces. This codebase already
  composes chat behaviour with `withX(client) => client` in four places
  (`withChatTelemetry`, `withToolApproval`, `withFunctionInvocation`, `withMiddleware`), so a
  context bag plus a registry would re-implement in framework machinery what the language already
  expresses — at the largest surface cost of the options considered. One optional capability,
  detected structurally like `ClientWithMiddleware` already is, does the same work.
- **Ambient not adopted**: every other context in this codebase (`FunctionMiddlewareContext`,
  `ProviderRunContext`) is passed explicitly, and an `AsyncLocal` would add a runtime failure mode
  (.NET throws when no run context is present).
- Wire format affected: no
- Public API affected: yes (`SessionScopedChatClient` added; `ChatClient` unchanged)
- Breaking change: no

## Notes

The loop is prepared a second time for a run whose client is bound — that is the price of binding
per run, and only a provider that asked for it pays. A client without the capability takes the layer
prepared once at construction, unchanged.

Placement: the bound view sits inside the chat span, so what it does is measured as part of the call
it wraps. The span still reports the request as the framework issued it, the same as it already does
for anything the leaf client puts on the wire.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`
