### PR TITLE
Carry the Foundry hosted-agent session id with the session that owns it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **`@polymind-inc/agent-framework-foundry`** — `FoundryChatClient` now carries the Foundry
+  hosted-agent session id. The service mints one on the first request that carries none and reports
+  it back; every later request of that session sends it, including later rounds of the same run — a
+  round that omitted it could land on a different sandbox and lose the persistent `$HOME` the
+  sandbox exists to provide. The id is kept in `session.state` under
+  `FOUNDRY_HOSTED_SESSION_STATE_KEY`, so it survives serializing and restoring a session and one
+  session never sees another's. A hosted-agent session is a sandbox and is **not** the conversation
+  the transcript lives in, which is still `AgentSession.serviceSessionId`. Attach to an existing
+  sandbox by putting `agent_session_id` in `additionalProperties`; naming one that differs from what
+  the session already holds fails with a `ConfigurationError` before the request goes out rather
+  than picking one. Foundry owns the sandbox's lifecycle — nothing here creates or releases one.
+
 - **`@polymind-inc/agent-framework-core`** — a chat client can now implement
   `SessionScopedChatClient` to be asked, once per run, for a view of itself bound to that run's
   session. The bound client wraps every service call of the run — later rounds of a tool loop as

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -16,6 +16,7 @@ export {
   safeStringify,
   setIfDefined,
   topLevelMediaType,
+  updatesOf,
   withoutUndefined,
 } from './client/provider-utils.js';
 export { errorMessageOf, validateSafeInteger } from './errors.js';

--- a/packages/foundry/README.md
+++ b/packages/foundry/README.md
@@ -33,6 +33,35 @@ project over MCP. A toolbox publishes two independent things and the class expos
 the same connection, so skills need no separate credential — and `loadTools: false` gives an agent
 the skills without exposing the tools.
 
+## Hosted-agent sessions
+
+Foundry has two service-side identifiers, and they are not the same thing:
+
+- a **conversation** holds the transcript, and the framework tracks it as
+  `AgentSession.serviceSessionId`;
+- a **hosted-agent session** is a sandbox — compute plus a persistent `$HOME` — that a hosted agent
+  runs in.
+
+`FoundryChatClient` carries the sandbox id for you. The service mints one on the first request that
+carries none and reports it back; from then on every request of that session sends it, including
+later rounds of the same run — a round that omitted it could land on a different sandbox and lose
+the `$HOME` the sandbox exists to provide. The id is kept in `session.state` under
+`FOUNDRY_HOSTED_SESSION_STATE_KEY`, so it survives serializing and restoring a session, and one
+session never sees another's.
+
+To attach to a sandbox you already have, put it on the request:
+
+```ts
+await agent.run('hello', {
+  session,
+  options: { additionalProperties: { agent_session_id: 'existing-sandbox-id' } },
+});
+```
+
+Naming an id that differs from the one the session already holds fails with a `ConfigurationError`
+before the request goes out, rather than silently picking one. Foundry owns the sandbox's lifecycle
+— provisioning, idle suspend, TTL — and nothing here creates or releases one.
+
 Known limitations:
 
 - `FoundryToolbox.asSkillsProvider()` discovers skills inside the run rather than while the agent

--- a/packages/foundry/src/chat-client.ts
+++ b/packages/foundry/src/chat-client.ts
@@ -1,5 +1,8 @@
+import type { AgentSession, ChatClient, SessionScopedChatClient } from '@polymind-inc/agent-framework-core';
+import type { OpenAIChatOptions } from '@polymind-inc/agent-framework-openai';
 import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
 import OpenAI from 'openai';
+import { withHostedSessionId } from './hosted-session.js';
 import type { FoundryProject } from './project.js';
 import type { FoundryTarget } from './target.js';
 import { isModelTarget, resolveEndpoint } from './target.js';
@@ -55,8 +58,21 @@ export type FoundryChatClientConfig = FoundryChatClientConfigBase &
  *   configuration; never build it from user input.
  * - The OpenAI notes apply unchanged: messages leave the process, and `store` is pass-through.
  */
-export class FoundryChatClient extends OpenAIChatClient {
+export class FoundryChatClient
+  extends OpenAIChatClient
+  implements SessionScopedChatClient<OpenAIChatOptions>
+{
   readonly #baseURL: string;
+
+  /**
+   * Binds this client to one run's session so the Foundry hosted-agent session id travels with it.
+   *
+   * `Agent` calls this; a caller does not. See {@link withHostedSessionId} for what the bound
+   * client does and how a hosted-agent session differs from a conversation.
+   */
+  forSession(session: AgentSession): ChatClient<OpenAIChatOptions> {
+    return withHostedSessionId(this, session);
+  }
 
   constructor(config: FoundryChatClientConfig) {
     // A server agent is addressed by its endpoint, and the agent definition picks the model, so

--- a/packages/foundry/src/hosted-session.test.ts
+++ b/packages/foundry/src/hosted-session.test.ts
@@ -1,0 +1,302 @@
+/**
+ * The Foundry hosted-agent session id: sent, captured, and kept for the session that owns it.
+ *
+ * The id names a Foundry sandbox — compute and a persistent `$HOME` — and is a different thing
+ * from the conversation the transcript lives in. The service mints one on the first request that
+ * carries none, and hands out a different sandbox for a later request that carries none again, so
+ * what these tests pin is *when* the id goes out and *where* it is kept.
+ */
+import type {
+  AgentSession,
+  ChatClient,
+  ChatClientMetadata,
+  ChatResponse,
+  ChatResponseStream,
+  ChatResponseUpdate,
+  Message,
+} from '@polymind-inc/agent-framework-core';
+import {
+  Agent,
+  ConfigurationError,
+  chatResponse,
+  chatResponseToUpdates,
+  createResponseStream,
+  mergeChatUpdates,
+  textContent,
+  tool,
+} from '@polymind-inc/agent-framework-core';
+import type { OpenAIChatOptions } from '@polymind-inc/agent-framework-openai';
+import { assert, describe, expect, it } from 'vitest';
+import { FOUNDRY_HOSTED_SESSION_STATE_KEY, withHostedSessionId } from './hosted-session.js';
+
+const echo = tool({
+  name: 'echo',
+  description: 'Echoes',
+  parameters: { type: 'object', properties: {} },
+  execute: () => 'ok',
+});
+
+async function* streamOf<T>(items: readonly T[]): AsyncIterable<T> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+/** What one scripted turn answers with. */
+interface Turn {
+  contents: ChatResponse<unknown>['messages'][number]['contents'];
+  /** The `agent_session_id` Foundry reports on this turn's raw payload, if any. */
+  reports?: string;
+}
+
+/**
+ * A Foundry-shaped client: it reports `agent_session_id` on the raw response the way the service
+ * does, and records the id each request carried.
+ */
+class FoundryLikeClient implements ChatClient<OpenAIChatOptions> {
+  readonly metadata: ChatClientMetadata = { providerName: 'azure.ai.foundry', modelId: 'gpt-4o' };
+  /** The `agent_session_id` on each outgoing request, in order. */
+  readonly sent: (string | undefined)[] = [];
+  #index = 0;
+  readonly #turns: readonly Turn[];
+
+  constructor(turns: readonly Turn[]) {
+    this.#turns = turns;
+  }
+
+  getResponse(
+    _messages: Message[],
+    options?: OpenAIChatOptions & { signal?: AbortSignal },
+  ): ChatResponseStream<unknown> {
+    const carried = options?.additionalProperties?.agent_session_id;
+    this.sent.push(typeof carried === 'string' ? carried : undefined);
+    const turn = this.#turns[Math.min(this.#index, this.#turns.length - 1)] ?? { contents: [] };
+    this.#index++;
+    const n = this.sent.length;
+    let direct: ChatResponse<unknown> | undefined;
+    return createResponseStream<ChatResponseUpdate, ChatResponse<unknown>>({
+      start: (ctx) => {
+        direct = chatResponse<unknown>({
+          messages: [{ role: 'assistant', contents: turn.contents, messageId: `msg_${n}` }],
+          responseId: `resp_${n}`,
+          finishReason: turn.contents.some((c) => c.type === 'function_call') ? 'tool_calls' : 'stop',
+          // The Responses object itself, which is where the service stamps the id.
+          rawRepresentation: {
+            id: `resp_${n}`,
+            ...(turn.reports === undefined ? {} : { agent_session_id: turn.reports }),
+          },
+        });
+        if (!ctx.stream) {
+          return streamOf(chatResponseToUpdates(direct));
+        }
+        // Streaming reports it on the event's `response`, not at the top level.
+        return streamOf(
+          chatResponseToUpdates(direct).map((update) => ({
+            ...update,
+            rawRepresentation: {
+              type: 'response.completed',
+              response: {
+                id: `resp_${n}`,
+                ...(turn.reports === undefined ? {} : { agent_session_id: turn.reports }),
+              },
+            },
+          })),
+        );
+      },
+      finalize: (updates) => direct ?? mergeChatUpdates<unknown>(updates),
+    });
+  }
+
+  forSession(session: AgentSession): ChatClient<OpenAIChatOptions> {
+    return withHostedSessionId(this, session);
+  }
+}
+
+/** A tool round followed by an answer; the first turn is where the service mints the id. */
+function mintingThenAnswer(id: string): Turn[] {
+  return [
+    { contents: [{ type: 'function_call', callId: 'c1', name: 'echo', arguments: '{}' }], reports: id },
+    { contents: [textContent('done')], reports: id },
+  ];
+}
+
+describe('the hosted session id on the wire', () => {
+  it('sends the id from the round after the service minted it, within one run', async () => {
+    // The case no caller-side code can reach: the id does not exist when the run starts.
+    const client = new FoundryLikeClient(mintingThenAnswer('sess_1'));
+    const agent = new Agent({ client, tools: [echo] });
+    const session = agent.createSession();
+
+    await agent.run('go', { session });
+
+    expect(client.sent).toEqual([undefined, 'sess_1']);
+    expect(session.state[FOUNDRY_HOSTED_SESSION_STATE_KEY]).toBe('sess_1');
+  });
+
+  it('does the same on a streamed run, where the id arrives on the event', async () => {
+    const client = new FoundryLikeClient(mintingThenAnswer('sess_2'));
+    const agent = new Agent({ client, tools: [echo] });
+    const session = agent.createSession();
+
+    for await (const _ of agent.run('go', { session })) {
+      // drain
+    }
+
+    expect(client.sent).toEqual([undefined, 'sess_2']);
+    expect(session.state[FOUNDRY_HOSTED_SESSION_STATE_KEY]).toBe('sess_2');
+  });
+
+  it('sends it on every later run of the session', async () => {
+    const client = new FoundryLikeClient([{ contents: [textContent('done')], reports: 'sess_3' }]);
+    const agent = new Agent({ client });
+    const session = agent.createSession();
+
+    await agent.run('one', { session });
+    await agent.run('two', { session });
+
+    expect(client.sent).toEqual([undefined, 'sess_3']);
+  });
+
+  it('survives serializing and restoring the session', async () => {
+    const client = new FoundryLikeClient([{ contents: [textContent('done')], reports: 'sess_4' }]);
+    const agent = new Agent({ client });
+    const session = agent.createSession();
+
+    await agent.run('one', { session });
+    const restored = agent.deserializeSession(JSON.parse(JSON.stringify(session)));
+    await agent.run('two', { session: restored });
+
+    expect(client.sent).toEqual([undefined, 'sess_4']);
+  });
+
+  it('keeps one session out of another session sandbox', async () => {
+    const client = new FoundryLikeClient([{ contents: [textContent('done')], reports: 'sess_a' }]);
+    const agent = new Agent({ client });
+    const a = agent.createSession();
+    const b = agent.createSession();
+
+    await agent.run('one', { session: a });
+    await agent.run('two', { session: b });
+
+    // `b` starts without a sandbox rather than borrowing `a`'s.
+    expect(client.sent).toEqual([undefined, undefined]);
+  });
+
+  it('sends nothing when the service never reports one', async () => {
+    const client = new FoundryLikeClient([{ contents: [textContent('done')] }]);
+    const agent = new Agent({ client });
+    const session = agent.createSession();
+
+    await agent.run('one', { session });
+    await agent.run('two', { session });
+
+    expect(client.sent).toEqual([undefined, undefined]);
+    expect(session.state[FOUNDRY_HOSTED_SESSION_STATE_KEY]).toBeUndefined();
+  });
+});
+
+describe('an id the caller supplies', () => {
+  it('is sent as given when the session holds none', async () => {
+    const client = new FoundryLikeClient([{ contents: [textContent('done')] }]);
+    const agent = new Agent({ client });
+    const session = agent.createSession();
+
+    await agent.run('one', {
+      session,
+      options: { additionalProperties: { agent_session_id: 'pinned_by_caller' } },
+    });
+
+    expect(client.sent).toEqual(['pinned_by_caller']);
+  });
+
+  it('is accepted when it names the same sandbox the session already holds', async () => {
+    const client = new FoundryLikeClient([{ contents: [textContent('done')], reports: 'same' }]);
+    const agent = new Agent({ client });
+    const session = agent.createSession();
+
+    await agent.run('one', { session });
+    await expect(
+      agent.run('two', { session, options: { additionalProperties: { agent_session_id: 'same' } } }),
+    ).resolves.toBeDefined();
+  });
+
+  it('fails before sending when it names a different sandbox', async () => {
+    // Either choice would be a guess, and the wrong guess reaches a different `$HOME`.
+    const client = new FoundryLikeClient([{ contents: [textContent('done')], reports: 'held' }]);
+    const agent = new Agent({ client });
+    const session = agent.createSession();
+
+    await agent.run('one', { session });
+    const before = client.sent.length;
+
+    await expect(
+      agent.run('two', { session, options: { additionalProperties: { agent_session_id: 'other' } } }),
+    ).rejects.toThrow(ConfigurationError);
+    expect(client.sent).toHaveLength(before);
+  });
+});
+
+describe('what the layer leaves alone', () => {
+  it('does not mutate the options the caller handed over', async () => {
+    const client = new FoundryLikeClient(mintingThenAnswer('sess_5'));
+    const agent = new Agent({ client, tools: [echo] });
+    const session = agent.createSession();
+    const options = { additionalProperties: { trace: 'keep' } } as Partial<OpenAIChatOptions>;
+
+    await agent.run('go', { session, options });
+
+    expect(options).toEqual({ additionalProperties: { trace: 'keep' } });
+  });
+
+  it('leaves other additionalProperties on the request untouched', async () => {
+    const client = new FoundryLikeClient([{ contents: [textContent('done')], reports: 'sess_6' }]);
+    const agent = new Agent({ client });
+    const session = agent.createSession();
+
+    await agent.run('one', { session, options: { additionalProperties: { trace: 'keep' } } });
+    await agent.run('two', { session, options: { additionalProperties: { trace: 'keep' } } });
+
+    expect(client.sent).toEqual([undefined, 'sess_6']);
+  });
+
+  it('does not touch the conversation id, which is a different Foundry concept', async () => {
+    const client = new FoundryLikeClient([{ contents: [textContent('done')], reports: 'sess_7' }]);
+    const agent = new Agent({ client });
+    const session = agent.createSession();
+
+    await agent.run('one', { session });
+
+    expect(session.state[FOUNDRY_HOSTED_SESSION_STATE_KEY]).toBe('sess_7');
+    // The sandbox id is not a conversation id and must not be mistaken for one.
+    expect(session.serviceSessionId).toBeUndefined();
+  });
+
+  it('keeps an id already reported when the run fails afterwards', async () => {
+    const failing = tool({
+      name: 'boom',
+      description: 'Fails',
+      parameters: { type: 'object', properties: {} },
+      execute: () => {
+        throw new Error('tool failed');
+      },
+    });
+    const client = new FoundryLikeClient([
+      {
+        contents: [{ type: 'function_call', callId: 'c1', name: 'boom', arguments: '{}' }],
+        reports: 'sess_8',
+      },
+      { contents: [textContent('done')], reports: 'sess_8' },
+    ]);
+    const agent = new Agent({ client, tools: [failing] });
+    const session = agent.createSession();
+
+    await agent.run('go', { session });
+
+    // The tool failed and was reported to the model; the sandbox the service already minted is
+    // still the session's, and the second round used it.
+    const second = client.sent[1];
+    assert.exists(second);
+    expect(second).toBe('sess_8');
+    expect(session.state[FOUNDRY_HOSTED_SESSION_STATE_KEY]).toBe('sess_8');
+  });
+});

--- a/packages/foundry/src/hosted-session.test.ts
+++ b/packages/foundry/src/hosted-session.test.ts
@@ -182,6 +182,25 @@ describe('the hosted session id on the wire', () => {
     expect(client.sent).toEqual([undefined, undefined]);
   });
 
+  it('follows the service to a new sandbox when it reports a different id', async () => {
+    // Foundry owns provisioning, idle suspend and TTL: a recycled sandbox comes back under a new
+    // id, and a session still sending the old one would be asking for something that is gone.
+    const client = new FoundryLikeClient([
+      { contents: [textContent('one')], reports: 'sess_old' },
+      { contents: [textContent('two')], reports: 'sess_new' },
+      { contents: [textContent('three')], reports: 'sess_new' },
+    ]);
+    const agent = new Agent({ client });
+    const session = agent.createSession();
+
+    await agent.run('one', { session });
+    await agent.run('two', { session });
+    await agent.run('three', { session });
+
+    expect(client.sent).toEqual([undefined, 'sess_old', 'sess_new']);
+    expect(session.state[FOUNDRY_HOSTED_SESSION_STATE_KEY]).toBe('sess_new');
+  });
+
   it('sends nothing when the service never reports one', async () => {
     const client = new FoundryLikeClient([{ contents: [textContent('done')] }]);
     const agent = new Agent({ client });

--- a/packages/foundry/src/hosted-session.ts
+++ b/packages/foundry/src/hosted-session.ts
@@ -1,0 +1,126 @@
+import type {
+  AgentSession,
+  ChatClient,
+  ChatResponse,
+  ChatResponseStream,
+  ChatResponseUpdate,
+  Message,
+} from '@polymind-inc/agent-framework-core';
+import { ConfigurationError, createResponseStream } from '@polymind-inc/agent-framework-core';
+import { isRecord, updatesOf } from '@polymind-inc/agent-framework-core/internal';
+import type { OpenAIChatOptions } from '@polymind-inc/agent-framework-openai';
+
+/**
+ * Where the hosted-agent session id lives on an {@link AgentSession}.
+ *
+ * A `state` key rather than a field on the session: this is one provider's platform identifier,
+ * not a concept the framework has. Session state is serialized, so the pin survives persistence
+ * and restoration the same way the rest of a session does.
+ */
+export const FOUNDRY_HOSTED_SESSION_STATE_KEY = 'foundry_hosted_agent_session_id';
+
+/** The request and response field Foundry spells the hosted session id with. */
+const WIRE_KEY = 'agent_session_id';
+
+/** A non-empty string, or `undefined` for anything else. */
+function nonEmpty(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+/** The hosted session id a Foundry response reports, from either transport's raw payload. */
+function reportedHostedSessionId(raw: unknown): string | undefined {
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  // An awaited call carries the Responses object itself; a streamed event carries it under
+  // `response`, which is where Foundry stamps the id it minted for the run.
+  const direct = nonEmpty(raw[WIRE_KEY]);
+  if (direct !== undefined) {
+    return direct;
+  }
+  return isRecord(raw.response) ? nonEmpty(raw.response[WIRE_KEY]) : undefined;
+}
+
+/** The id already pinned to this session, if any. */
+export function pinnedHostedSessionId(session: AgentSession): string | undefined {
+  return nonEmpty(session.state[FOUNDRY_HOSTED_SESSION_STATE_KEY]);
+}
+
+/**
+ * Wraps a Foundry client so one run's hosted-agent session id is sent, captured and kept.
+ *
+ * The **hosted-agent session** is a Foundry sandbox — compute plus a persistent `$HOME` — and it
+ * is a different thing from the conversation the transcript lives in, which the framework tracks
+ * as `AgentSession.serviceSessionId`. A run may have either, both, or neither. Foundry owns the
+ * sandbox's lifecycle (provisioning, idle suspend, TTL); this layer only carries its id, and
+ * nothing here creates or releases one.
+ *
+ * The service mints the id on the first request that does not carry one, and reports it back. Every
+ * later request has to send it or Foundry may hand out a different sandbox — including the *next
+ * round of the same run*, which is why this is bound per run and sits inside the function-calling
+ * loop rather than around it.
+ *
+ * @param client - The Foundry client to wrap.
+ * @param session - The run's session. The id is read from and written to its `state`, never held
+ * on the client, so two sessions cannot see each other's sandbox.
+ */
+export function withHostedSessionId<TOptions extends OpenAIChatOptions>(
+  client: ChatClient<TOptions>,
+  session: AgentSession,
+): ChatClient<TOptions> {
+  /** Records an id the service reported, the first time one is seen. */
+  const capture = (raw: unknown): void => {
+    const reported = reportedHostedSessionId(raw);
+    if (reported !== undefined) {
+      session.state[FOUNDRY_HOSTED_SESSION_STATE_KEY] = reported;
+    }
+  };
+
+  return {
+    metadata: client.metadata,
+    getResponse(
+      messages: Message[],
+      options?: TOptions & { signal?: AbortSignal },
+    ): ChatResponseStream<unknown> {
+      const pinned = pinnedHostedSessionId(session);
+      const perCall = nonEmpty(options?.additionalProperties?.[WIRE_KEY]);
+      if (pinned !== undefined && perCall !== undefined && pinned !== perCall) {
+        // Sending either one would be a guess about which sandbox the caller meant, and the wrong
+        // guess reaches a different `$HOME`. Fail here rather than on the wire.
+        throw new ConfigurationError(
+          `This session is pinned to Foundry hosted agent session '${pinned}', but the request asks for ` +
+            `'${perCall}'. Use one or the other.`,
+        );
+      }
+      // An explicit per-call id wins over nothing at all and matches the pin otherwise, so either
+      // way it is what goes out; the pin is what fills the gap when the caller named none.
+      const send = perCall ?? pinned;
+      let next = options;
+      if (send !== undefined) {
+        // A copy: the caller's options object is theirs, and the agent hands the same one to every
+        // round of the run.
+        const copy = { ...options } as TOptions & { signal?: AbortSignal };
+        copy.additionalProperties = { ...options?.additionalProperties, [WIRE_KEY]: send };
+        next = copy;
+      }
+
+      const inner = client.getResponse(messages, next);
+      return createResponseStream<ChatResponseUpdate, ChatResponse<unknown>>({
+        start: async function* (ctx) {
+          for await (const update of updatesOf(inner, ctx.stream)) {
+            // Captured as it arrives, so an id the service already minted is kept even if the run
+            // fails afterwards or the caller stops reading.
+            capture(update.rawRepresentation);
+            yield update;
+          }
+        },
+        finalize: async () => {
+          const final = await inner.finalResponse();
+          // The awaited transport reports the id on the response rather than on any one update.
+          capture(final.rawRepresentation);
+          return final;
+        },
+      });
+    },
+  };
+}

--- a/packages/foundry/src/hosted-session.ts
+++ b/packages/foundry/src/hosted-session.ts
@@ -68,7 +68,15 @@ export function withHostedSessionId<TOptions extends OpenAIChatOptions>(
   client: ChatClient<TOptions>,
   session: AgentSession,
 ): ChatClient<TOptions> {
-  /** Records an id the service reported, the first time one is seen. */
+  /**
+   * Points the session at whichever sandbox the service says it is on.
+   *
+   * A reported id replaces what the session held, rather than being ignored once one is set. The
+   * service is the authority on which sandbox is answering: Foundry owns provisioning, idle
+   * suspend and TTL, so a recycled sandbox is replaced by a new one and reported under a new id,
+   * and a session still sending the old one would be asking for something that no longer exists.
+   * Both reference implementations assign unconditionally for the same reason.
+   */
   const capture = (raw: unknown): void => {
     const reported = reportedHostedSessionId(raw);
     if (reported !== undefined) {

--- a/packages/foundry/src/index.ts
+++ b/packages/foundry/src/index.ts
@@ -10,6 +10,11 @@
 export type { OpenAIChatOptions } from '@polymind-inc/agent-framework-openai';
 export type { FoundryChatClientConfig } from './chat-client.js';
 export { FoundryChatClient } from './chat-client.js';
+export {
+  FOUNDRY_HOSTED_SESSION_STATE_KEY,
+  pinnedHostedSessionId,
+  withHostedSessionId,
+} from './hosted-session.js';
 // The memory-store client itself (memory/client.ts) is the provider's transport, not a public
 // surface; only the error it raises and the store definition a caller has to supply are exported.
 export type { MemoryOperation, MemoryStoreDefinition, MemoryStoreObject } from './memory/client.js';


### PR DESCRIPTION
## What this changes

#111 track A, approved by the maintainer. Track B (conversation creation) follows separately, per
the one-concern rule in that issue.

Foundry mints a hosted-agent session — a sandbox with compute and a persistent `$HOME` — on the
first request that carries no `agent_session_id`, and reports the id back. A later request that
omits it can land on a different sandbox, so the id has to travel with the session. That includes
**the next round of the same run**: the id does not exist when the run starts, so nothing a caller
writes outside the run can put it on round two.

`FoundryChatClient` implements `SessionScopedChatClient` (added in #151). The bound view sits inside
the function-calling loop, reads the id from `session.state`, sends it, and records what the service
reports — from the response on an awaited call and from the event's `response` on a streamed one,
as each transport carries it.

A hosted-agent session is **not** the conversation the transcript lives in. That stays
`AgentSession.serviceSessionId`; this is a second, orthogonal identifier, and the README now says so
explicitly because conflating them is the easy mistake.

Naming an `agent_session_id` that differs from the one the session already holds fails with a
`ConfigurationError` before the request goes out. Either choice would be a guess, and the wrong
guess reaches a different `$HOME`.

## Parity

- Reference checked: **.NET** keeps it in `AgentSession.StateBag` under
  `FoundryAgentSessionExtensions.FoundryHostedAgentSessionIdKey` and puts it on the body via
  `FoundryChatOptionsExtensions.WithFoundryHostedAgentSessionId`. **Python** extracts it with
  `_extract_foundry_hosted_agent_session_id` and, in
  `_update_function_invocation_continuation_state`, writes it to **both** the session and the
  current run's options — its comment gives the reason this PR is built around: "function
  invocation can make another service call before the agent prepares a new run context". **Go**
  defines neither capability.
- Same reach, different seam: Python uses an agent-layer hook, which TypeScript does not have for
  Foundry (its Foundry integration is a chat client). The session-scoped client capability puts the
  layer in the same place — inside the loop, around every service call.
- Both raw shapes are read, matching Python: the id is at the top level of an awaited response and
  under `response` on a streamed event.
- Wire format affected: yes (`agent_session_id` is sent where the session holds one)
- Public API affected: yes (`withHostedSessionId`, `pinnedHostedSessionId`,
  `FOUNDRY_HOSTED_SESSION_STATE_KEY`)
- Breaking change: no

## Notes

`updatesOf` is now exported from `@polymind-inc/agent-framework-core/internal`. Its root export was
withdrawn in an earlier cleanup, but its own documentation describes a hazard worth not
reimplementing — iterating an inner stream when the caller awaited silently switches the provider to
a streaming transport. `/internal` is where the other shared helpers this package already imports
live.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`
