### PR TITLE
Answer an argument failure with its own result text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **`@polymind-inc/agent-framework-core`** — a tool call whose arguments fail to parse or fail
+  schema validation is answered with `Error: Argument parsing failed.` instead of the
+  `Error: Function failed.` a thrown tool body produces. The two failures call for opposite model
+  responses — a schema violation is worth retrying with corrected arguments, an execution failure
+  usually is not — and the shared text removed the one signal that distinguishes them. The wording
+  matches Python. The `exception` field still carries the validation detail, `includeDetailedErrors`
+  still appends the underlying message the same way, and the not-found, execution-failure and
+  success texts are unchanged.
+
 - **`@polymind-inc/agent-framework-foundry`** — `FoundryChatClient.createConversation()` creates a
   server-side conversation and returns its id, so a run can start on a conversation that already
   exists — and is already visible in the Foundry Project UI — instead of one the first response

--- a/packages/core/src/client/function-execution.ts
+++ b/packages/core/src/client/function-execution.ts
@@ -40,6 +40,16 @@ const USER_INPUT_UNAVAILABLE_RESULT_TEXT = 'Tool requires user input but no requ
 const USER_INPUT_REQUIRED_EXCEPTION = 'UserInputRequiredException';
 /** What a rejected call reports back to the model. Matches Python's `_tools.py` wording. */
 const REJECTED_RESULT_TEXT = 'Error: Tool call invocation was rejected by user.';
+/**
+ * What an argument parse or validation failure reports back to the model, in place of the generic
+ * execution-failure text.
+ *
+ * The two failures call for opposite responses — a schema violation is worth retrying with
+ * corrected arguments, a tool body that threw usually is not — so collapsing them would remove the
+ * signal the model acts on. The wording matches Python's `_tools.py`, the reference implementation
+ * whose loop parses and validates arguments itself the way this one does.
+ */
+const ARGUMENT_FAILURE_REPORT: ExceptionReport = { result: 'Error: Argument parsing failed.' };
 
 type InvocationStatus = 'completed' | 'not_found' | 'exception';
 
@@ -79,8 +89,9 @@ type SettledInvocation = Invocation<string | Content[]>;
 interface ExceptionReport {
   /** Replaces the generic `Error: Function failed.` text. */
   result: string;
-  /** Replaces the thrown error's message in `FunctionResultContent.exception`. */
-  exception: string;
+  /** Replaces the thrown error's message in `FunctionResultContent.exception`. Absent when the
+   * marker should stay the thrown error's own message, as it does for an argument failure. */
+  exception?: string;
 }
 
 /**
@@ -298,7 +309,7 @@ async function executeWithMiddleware(
 ): Promise<InvocationResult> {
   const args = await resolveArguments(call, target);
   if (!args.ok) {
-    return { status: 'exception', call, error: args.error };
+    return argumentFailure(call, args.error);
   }
 
   const ctx: FunctionMiddlewareContext = {
@@ -396,9 +407,20 @@ async function executeOne(
 ): Promise<InvocationResult> {
   const args = await resolveArguments(call, target);
   if (!args.ok) {
-    return { status: 'exception', call, error: args.error };
+    return argumentFailure(call, args.error);
   }
   return runTool(call, target, args.value, env);
+}
+
+/**
+ * The invocation outcome for a call whose arguments failed to parse or validate.
+ *
+ * One builder for both execution paths, so the model-facing text cannot drift between them. The
+ * `exception` marker stays the resolution error's own message — the validation detail a caller
+ * branches on — while the result text identifies the failure class.
+ */
+function argumentFailure(call: FunctionCallContent, error: ToolInvocationError): SettledInvocation {
+  return { status: 'exception', call, error, errorReport: ARGUMENT_FAILURE_REPORT };
 }
 
 /** Parses the model's argument JSON and validates it against the tool's schema. */

--- a/packages/core/src/client/function-invocation.test.ts
+++ b/packages/core/src/client/function-invocation.test.ts
@@ -1700,6 +1700,183 @@ describe('calls whose arguments are missing or null', () => {
   });
 });
 
+describe('argument failures are reported distinctly from execution failures', () => {
+  // The two failures call for opposite model responses: a schema violation is worth retrying with
+  // corrected arguments, a tool body that threw usually is not. Reporting both as
+  // "Error: Function failed." removes the one signal that changes what the model does next.
+
+  const strictParameters = {
+    type: 'object' as const,
+    properties: { resource: { type: 'string' } },
+    required: ['resource'],
+    additionalProperties: false,
+  };
+
+  function strictTool(execute: () => Promise<string> = async () => 'never') {
+    return tool({ name: 'strict', description: 'd', parameters: strictParameters, execute });
+  }
+
+  function scripted(...calls: FunctionCallContent[]): MockChatClient {
+    return new MockChatClient([
+      { contents: calls, finishReason: 'tool_calls' },
+      { contents: [textContent('done')], finishReason: 'stop' },
+    ]);
+  }
+
+  it('answers a schema validation failure with the argument-failure text', async () => {
+    const execute = vi.fn(async () => 'never');
+    const inner = scripted(call('c1', 'strict', '{}'));
+
+    const response = await withFunctionInvocation(inner).getResponse([], {
+      tools: [strictTool(execute)],
+    } as ChatOptions);
+
+    expect(execute).not.toHaveBeenCalled();
+    const results = resultsOf(response.messages.flatMap((m) => m.contents));
+    // Exact, whole-content match: with detailed errors off the text is fixed, and the `exception`
+    // marker still carries the validation message a caller branches on.
+    expect(results).toEqual([
+      {
+        type: 'function_result',
+        callId: 'c1',
+        result: 'Error: Argument parsing failed.',
+        exception: 'Invalid arguments: $.resource: required property is missing',
+      },
+    ]);
+    // The failure is reported to the model, not fatal: the loop carried on to the final answer.
+    expect(response.text).toBe('done');
+  });
+
+  it('answers malformed argument JSON with the argument-failure text', async () => {
+    const inner = scripted(call('c1', 'strict', '{"resource":'));
+
+    const response = await withFunctionInvocation(inner).getResponse([], {
+      tools: [strictTool()],
+    } as ChatOptions);
+
+    const results = resultsOf(response.messages.flatMap((m) => m.contents));
+    expect(results[0]?.result).toBe('Error: Argument parsing failed.');
+    expect(results[0]?.exception).toContain('Invalid JSON arguments');
+  });
+
+  it('answers a standard-schema validation failure with the argument-failure text', async () => {
+    const validating = tool({
+      name: 'strict',
+      description: 'd',
+      parameters: {
+        '~standard': {
+          version: 1 as const,
+          vendor: 'test',
+          validate: () => ({ issues: [{ message: 'value must be a string', path: ['value'] }] }),
+        },
+        toJsonSchema: () => echoSchema,
+      } as never,
+      execute: async () => 'never',
+    });
+    const inner = scripted(call('c1', 'strict', '{"value":123}'));
+
+    const response = await withFunctionInvocation(inner).getResponse([], {
+      tools: [validating],
+    } as ChatOptions);
+
+    expect(resultsOf(response.messages.flatMap((m) => m.contents))[0]?.result).toBe(
+      'Error: Argument parsing failed.',
+    );
+  });
+
+  it('appends the underlying message only with includeDetailedErrors', async () => {
+    const inner = scripted(call('c1', 'strict', '{}'));
+
+    const response = await withFunctionInvocation(inner, { includeDetailedErrors: true }).getResponse([], {
+      tools: [strictTool()],
+    } as ChatOptions);
+
+    const results = resultsOf(response.messages.flatMap((m) => m.contents));
+    expect(results[0]?.result).toBe(
+      'Error: Argument parsing failed. ' +
+        'Exception: Invalid arguments: $.resource: required property is missing',
+    );
+    expect(results[0]?.exception).toBe('Invalid arguments: $.resource: required property is missing');
+  });
+
+  it('reports the argument-failure text through the middleware path too', async () => {
+    // Arguments are resolved before the middleware chain runs, so the middleware execution path
+    // builds this result at its own site; both sites must report the same text.
+    const observed: string[] = [];
+    const inner = scripted(call('c1', 'strict', '{}'));
+
+    const response = await withFunctionInvocation(inner, {
+      middleware: [
+        functionMiddleware(async (ctx, next) => {
+          observed.push(ctx.tool.name);
+          await next();
+        }),
+      ],
+    }).getResponse([], { tools: [strictTool()] } as ChatOptions);
+
+    // The chain never ran: the call failed before the tool became invocable.
+    expect(observed).toEqual([]);
+    expect(resultsOf(response.messages.flatMap((m) => m.contents))[0]?.result).toBe(
+      'Error: Argument parsing failed.',
+    );
+  });
+
+  it('keeps the execution-failure text for a tool body that threw', async () => {
+    const inner = scripted(call('c1', 'strict', '{"resource":"r"}'));
+
+    const response = await withFunctionInvocation(inner).getResponse([], {
+      tools: [
+        strictTool(async () => {
+          throw new Error('kaboom');
+        }),
+      ],
+    } as ChatOptions);
+
+    const results = resultsOf(response.messages.flatMap((m) => m.contents));
+    expect(results).toEqual([
+      {
+        type: 'function_result',
+        callId: 'c1',
+        result: 'Error: Function failed.',
+        exception: 'kaboom',
+      },
+    ]);
+  });
+
+  it('keeps the execution-failure detail format with includeDetailedErrors', async () => {
+    const inner = scripted(call('c1', 'strict', '{"resource":"r"}'));
+
+    const response = await withFunctionInvocation(inner, { includeDetailedErrors: true }).getResponse([], {
+      tools: [
+        strictTool(async () => {
+          throw new Error('kaboom');
+        }),
+      ],
+    } as ChatOptions);
+
+    expect(resultsOf(response.messages.flatMap((m) => m.contents))[0]?.result).toBe(
+      'Error: Function failed. Exception: kaboom',
+    );
+  });
+
+  it('keeps the not-found and success texts unchanged', async () => {
+    const inner = new MockChatClient([
+      {
+        contents: [call('c1', 'missing', '{}'), call('c2', 'strict', '{"resource":"r"}')],
+        finishReason: 'tool_calls',
+      },
+      { contents: [textContent('done')], finishReason: 'stop' },
+    ]);
+
+    const response = await withFunctionInvocation(inner).getResponse([], {
+      tools: [strictTool(async () => 'pong')],
+    } as ChatOptions);
+
+    const results = resultsOf(response.messages.flatMap((m) => m.contents));
+    expect(results.map((r) => r.result)).toEqual(['Error: Requested function "missing" not found.', 'pong']);
+  });
+});
+
 describe('withFunctionInvocation at the iteration limit', () => {
   const FALLBACK_TEXT = 'Function invocation limit reached before a final answer could be produced.';
 


### PR DESCRIPTION
## What this changes

A tool call whose arguments fail to parse or fail schema validation is answered with `Error: Argument parsing failed.` instead of the `Error: Function failed.` a thrown tool body produces, so the model can tell whether to retry with corrected arguments or stop calling the tool. Closes #131.

## Parity

- Reference checked: Python `_tools.py` (the argument-resolution branch answers with this exact wording; malformed JSON reaches the same branch because `parse_arguments()` folds it into `{"raw": …}` and schema validation refuses it). .NET `FunctionInvokingChatClient.cs` (dotnet/extensions, read in full): its `FunctionInvocationStatus` is only RanToCompletion / NotFound / Exception — the loop never parses arguments (they arrive as a pre-parsed dictionary), so the branch structurally does not exist there. Go `toolautocall/autocall.go` maps every failure other than not-found to the execution text. Python is the only reference whose loop parses and validates arguments the way this one does, so its wording is followed; the three-way split is recorded rather than adopted silently.
- Wire format affected: yes
- Public API affected: no
- Breaking change: no

The `exception` field keeps carrying the validation detail, `includeDetailedErrors` appends the underlying message the same way it does for an execution failure, and the not-found, execution-failure and success texts are unchanged (each pinned by an exact-match test). The result is built at one site shared by the direct and middleware execution paths so the two cannot drift.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)