### PR TITLE
Share the MCP error-text assembly with the Foundry toolbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **`@polymind-inc/agent-framework-foundry`** — a Foundry toolbox tool that reports `isError` now
+  assembles its failure text by the same rule the MCP client applies, instead of an independent
+  second implementation that had drifted from it: each text block lands on its own line rather than
+  run together, `structuredContent` reaches the model as the last line rather than being dropped,
+  blocks without text contribute nothing, and a result that says nothing at all names the tool that
+  failed rather than producing an empty message. The rule is now literally shared — the toolbox
+  imports the MCP package's assembly rather than keeping a copy — so the two cannot drift apart
+  again.
+
 - **`@polymind-inc/agent-framework-foundry`** — `FoundryChatClient.createConversation()` creates a
   server-side conversation and returns its id, so a run can start on a conversation that already
   exists — and is already visible in the Foundry Project UI — instead of one the first response

--- a/packages/foundry/src/hosting/toolbox.test.ts
+++ b/packages/foundry/src/hosting/toolbox.test.ts
@@ -7,7 +7,12 @@ import {
   runWithRequestContext,
 } from '@polymind-inc/agent-framework-agentserver';
 import type { ContextProvider, Tool } from '@polymind-inc/agent-framework-core';
-import { AgentSession, ConfigurationError, isFunctionTool } from '@polymind-inc/agent-framework-core';
+import {
+  AgentSession,
+  ConfigurationError,
+  isFunctionTool,
+  ToolInvocationError,
+} from '@polymind-inc/agent-framework-core';
 import { assert, describe, expect, it, vi } from 'vitest';
 import { FoundryProject } from '../project.js';
 import { ToolboxConsentRequiredError } from './consent.js';
@@ -46,6 +51,8 @@ function stubToolbox(
     tools?: StubTool[];
     allowedTools?: string[];
     toolFails?: boolean;
+    /** Answer `tools/call` with exactly this result, verbatim. */
+    toolResult?: Record<string, unknown>;
     failFirstConnect?: boolean;
     /** 1-based `tools/call` indices answered with HTTP 404 — the expired-session signal. */
     dieOnToolCalls?: readonly number[];
@@ -143,9 +150,10 @@ function stubToolbox(
           }
         : request.method === 'tools/list'
           ? { tools }
-          : options.toolFails === true
-            ? { content: [{ type: 'text', text: 'the upstream API rejected it' }], isError: true }
-            : { content: [{ type: 'text', text: 'stub result' }] };
+          : (options.toolResult ??
+            (options.toolFails === true
+              ? { content: [{ type: 'text', text: 'the upstream API rejected it' }], isError: true }
+              : { content: [{ type: 'text', text: 'stub result' }] }));
 
     return new Response(JSON.stringify({ jsonrpc: '2.0', id: request.id, result }), {
       status: 200,
@@ -266,6 +274,72 @@ describe('FoundryToolbox tools', () => {
       /the upstream API rejected it/,
     );
     await toolbox.close();
+  });
+
+  describe('failure text of an isError result', () => {
+    // The rule is the one `McpClient` applies, shared rather than re-implemented: each text block
+    // on its own line, blocks without text contributing nothing, structured content as the last
+    // line, and a fallback naming the tool when the result said nothing. The reference
+    // implementation has no second assembly to drift — its toolbox inherits the plain MCP tool's.
+
+    async function failWith(toolResult: Record<string, unknown>): Promise<unknown> {
+      const { toolbox } = stubToolbox({ toolResult });
+      const [tool] = await toolbox.getTools();
+      try {
+        await tool?.execute?.({ q: 'x' }, { callId: 'c1' });
+        return undefined;
+      } catch (error) {
+        return error;
+      } finally {
+        await toolbox.close();
+      }
+    }
+
+    it('puts each text block on its own line', async () => {
+      const error = await failWith({
+        isError: true,
+        content: [
+          { type: 'text', text: 'the upstream API rejected it' },
+          { type: 'text', text: 'retry after 30s' },
+        ],
+      });
+
+      expect(error).toBeInstanceOf(ToolInvocationError);
+      expect((error as Error).message).toBe('the upstream API rejected it\nretry after 30s');
+    });
+
+    it('skips blocks with no text instead of contributing blank lines', async () => {
+      const error = await failWith({
+        isError: true,
+        content: [
+          { type: 'text', text: 'first' },
+          { type: 'text', text: '' },
+          { type: 'image', data: 'AA==', mimeType: 'image/png' },
+          { type: 'text', text: 'second' },
+        ],
+      });
+
+      expect((error as Error).message).toBe('first\nsecond');
+    });
+
+    it('reports structured content as the last line', async () => {
+      const error = await failWith({
+        isError: true,
+        content: [{ type: 'text', text: 'rate limited' }],
+        structuredContent: { retryAfter: 30 },
+      });
+
+      expect((error as Error).message).toBe('rate limited\n{"retryAfter":30}');
+    });
+
+    it('names the tool when the failure carries no text at all', async () => {
+      const error = await failWith({
+        isError: true,
+        content: [{ type: 'image', data: 'AA==', mimeType: 'image/png' }],
+      });
+
+      expect((error as Error).message).toBe('MCP tool "search_docs" reported an error.');
+    });
   });
 
   it('reconnects and retries once when the server has expired the session', async () => {

--- a/packages/foundry/src/hosting/toolbox.ts
+++ b/packages/foundry/src/hosting/toolbox.ts
@@ -1,21 +1,16 @@
 import type { CallToolResult } from '@modelcontextprotocol/client';
 import { platformHeaders } from '@polymind-inc/agent-framework-agentserver';
 import type {
-  Content,
   ContextProvider,
   FunctionTool,
   SkillsProviderConfig,
   SkillsSource,
   ToolContext,
 } from '@polymind-inc/agent-framework-core';
-import {
-  skillsProvider,
-  ToolInvocationError,
-  textOfContents,
-  tool,
-} from '@polymind-inc/agent-framework-core';
+import { skillsProvider, tool } from '@polymind-inc/agent-framework-core';
 import type { McpSkillsSourceConfig } from '@polymind-inc/agent-framework-mcp';
 import { McpConnection, mcpSkillsSource } from '@polymind-inc/agent-framework-mcp';
+import { callToolFailure, contentsOfCallToolResult } from '@polymind-inc/agent-framework-mcp/internal';
 import type { FoundryProject } from '../project.js';
 import { FOUNDRY_API_VERSION } from '../target.js';
 import { consentRequestsOf, ToolboxConsentRequiredError } from './consent.js';
@@ -168,8 +163,10 @@ export class FoundryToolbox {
             if (result.isError === true) {
               // MCP reports a tool failure in the payload, not by rejecting. Returning it as a
               // success would tell the model the call worked and hand it the error text as the
-              // answer; throwing routes it through the loop's error handling instead.
-              throw new ToolInvocationError(declared.name, textOfContents(result.content as Content[]));
+              // answer; throwing routes it through the loop's error handling instead. The text is
+              // assembled by the same shared rule `McpClient` applies — one line per text block,
+              // structured content last, a tool-naming fallback — not a second copy of it.
+              throw callToolFailure(declared.name, contentsOfCallToolResult(result));
             }
             return result.content;
           },

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -37,6 +37,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./internal": {
+      "types": "./dist/internal.d.ts",
+      "default": "./dist/internal.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",

--- a/packages/mcp/src/client.test.ts
+++ b/packages/mcp/src/client.test.ts
@@ -18,7 +18,7 @@ import { MockChatClient } from '@polymind-inc/agent-framework-core/testing';
 import { describe, expect, it, vi } from 'vitest';
 import { McpClient } from './client.js';
 import { McpConnection } from './connection.js';
-import { fromMcpContent, mcpErrorText } from './content.js';
+import { callToolFailure, contentsOfCallToolResult, fromMcpContent, mcpErrorText } from './content.js';
 import type { TestTool } from './test-server.js';
 import { SlowStartServer, TestMcpServer } from './test-server.js';
 
@@ -1058,5 +1058,51 @@ describe('mcpErrorText', () => {
         { type: 'text', text: 'retry after 30s' },
       ]),
     ).toBe('rejected it\nretry after 30s');
+  });
+});
+
+describe('contentsOfCallToolResult', () => {
+  // The one conversion every reader of a tool result shares — the MCP client here, the Foundry
+  // toolbox through the internal entry — pinned at the function so the readers cannot drift.
+
+  it('stamps the result _meta onto converted blocks but not onto the structured-content item', () => {
+    const contents = contentsOfCallToolResult({
+      content: [{ type: 'text', text: 'partial output' }],
+      structuredContent: { code: 'RATE_LIMITED' },
+      _meta: { 'ifc/labels': ['secret'] },
+    });
+
+    expect(contents).toEqual([
+      {
+        type: 'text',
+        text: 'partial output',
+        rawRepresentation: { type: 'text', text: 'partial output' },
+        additionalProperties: { _meta: { 'ifc/labels': ['secret'] } },
+      },
+      // Last, and deliberately unstamped: the reference implementation builds this one item
+      // without the `_meta` envelope, and the asymmetry is preserved.
+      { type: 'text', text: '{"code":"RATE_LIMITED"}' },
+    ]);
+  });
+
+  it('reads an absent content list as empty rather than throwing', () => {
+    expect(contentsOfCallToolResult({})).toEqual([]);
+  });
+});
+
+describe('callToolFailure', () => {
+  it('assembles one line per text block', () => {
+    const error = callToolFailure('search_docs', [
+      { type: 'text', text: 'rejected it' },
+      { type: 'text', text: 'retry after 30s' },
+    ]);
+
+    expect(error).toBeInstanceOf(ToolInvocationError);
+    expect(error.toolName).toBe('search_docs');
+    expect(error.message).toBe('rejected it\nretry after 30s');
+  });
+
+  it('names the tool when the result said nothing', () => {
+    expect(callToolFailure('search_docs', []).message).toBe('MCP tool "search_docs" reported an error.');
   });
 });

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -14,7 +14,7 @@ import {
 } from '@polymind-inc/agent-framework-core';
 import { errorMessageOf } from '@polymind-inc/agent-framework-core/internal';
 import { McpConnection } from './connection.js';
-import { fromMcpContents, mcpErrorText, mcpMetaProperties } from './content.js';
+import { callToolFailure, contentsOfCallToolResult, mcpMetaProperties } from './content.js';
 import type { McpHeaderProvider } from './headers.js';
 import type { McpSkillsSourceConfig } from './skills.js';
 import { mcpSkillsSource } from './skills.js';
@@ -348,32 +348,23 @@ export class McpClient {
             (input ?? {}) as Record<string, unknown>,
             ctx.signal === undefined ? undefined : { signal: ctx.signal },
           );
-          const meta = (result as { _meta?: unknown })._meta;
-          const contents = fromMcpContents(result.content as unknown[] | undefined, meta);
-          if (result.structuredContent !== undefined && result.structuredContent !== null) {
-            // A structured-only server would otherwise yield an empty result. The reference
-            // implementation surfaces it as a JSON text content (`_parse_tool_result_from_mcp`
-            // in Python's `_mcp.py`), placed before the isError check so an error's text
-            // includes it too. It is the one item Python builds *without* the `_meta` stamp;
-            // the asymmetry is preserved rather than tidied up.
-            contents.push({ type: 'text', text: JSON.stringify(result.structuredContent) });
-          }
+          const contents = contentsOfCallToolResult(result);
           if (result.isError === true) {
             // MCP reports a tool failure in the payload rather than by rejecting. Returning it
             // as a success would tell the model the call worked and hand it the error text as
             // the answer; throwing routes it through the loop's error handling instead. The
             // connection has already marked the span with `error.type = tool_error`.
-            const text = mcpErrorText(contents);
-            throw new ToolInvocationError(
-              declared.name,
-              text === '' ? `MCP tool "${declared.name}" reported an error.` : text,
-            );
+            throw callToolFailure(declared.name, contents);
           }
           if (contents.length === 0) {
             // Python parity: a successful call with nothing to say becomes a literal "null"
             // text, so the model sees an answer instead of an absent one. This one *does* carry
             // the result's `_meta`, as Python's fallback does.
-            contents.push({ type: 'text', text: 'null', ...mcpMetaProperties(meta) });
+            contents.push({
+              type: 'text',
+              text: 'null',
+              ...mcpMetaProperties((result as { _meta?: unknown })._meta),
+            });
           }
           return contents;
         } catch (error) {

--- a/packages/mcp/src/content.ts
+++ b/packages/mcp/src/content.ts
@@ -1,5 +1,5 @@
 import type { Content } from '@polymind-inc/agent-framework-core';
-import { unknownContent } from '@polymind-inc/agent-framework-core';
+import { ToolInvocationError, unknownContent } from '@polymind-inc/agent-framework-core';
 
 /** One entry of an MCP `CallToolResult.content`, kept loose so unmodelled blocks pass through. */
 export type McpContentBlock = Record<string, unknown>;
@@ -142,6 +142,45 @@ export function mcpMetaProperties(
   }
   const entries = { ...(meta as Record<string, unknown>) };
   return Object.keys(entries).length === 0 ? undefined : { additionalProperties: { _meta: entries } };
+}
+
+/** The parts of a `tools/call` result the framework reads. Structural, so any SDK's shape fits. */
+export interface CallToolResultShape {
+  content?: unknown;
+  structuredContent?: unknown;
+  _meta?: unknown;
+}
+
+/**
+ * Converts a whole `tools/call` result into framework contents.
+ *
+ * The content blocks are converted with the result's `_meta` stamp, and a non-null
+ * `structuredContent` is appended as a JSON text item — a structured-only server would otherwise
+ * yield an empty result. It comes last, and *before* any `isError` decision, so a failure's text
+ * includes it too. It is the one item built *without* the `_meta` stamp (the reference
+ * implementation's `_parse_tool_result_from_mcp` has the same asymmetry, preserved rather than
+ * tidied up).
+ *
+ * Every reader of a tool result — the MCP client and the Foundry toolbox — goes through this one
+ * function, so what a result means cannot drift between them.
+ */
+export function contentsOfCallToolResult(result: CallToolResultShape): Content[] {
+  const contents = fromMcpContents(result.content as readonly unknown[] | undefined, result._meta);
+  if (result.structuredContent !== undefined && result.structuredContent !== null) {
+    contents.push({ type: 'text', text: JSON.stringify(result.structuredContent) });
+  }
+  return contents;
+}
+
+/**
+ * The error an `isError` tool result raises, built from the result's converted contents.
+ *
+ * The text is {@link mcpErrorText}'s one-line-per-block assembly; a result that said nothing
+ * falls back to naming the tool that failed, so the model never reads an empty failure.
+ */
+export function callToolFailure(toolName: string, contents: readonly Content[]): ToolInvocationError {
+  const text = mcpErrorText(contents);
+  return new ToolInvocationError(toolName, text === '' ? `MCP tool "${toolName}" reported an error.` : text);
 }
 
 /**

--- a/packages/mcp/src/internal.ts
+++ b/packages/mcp/src/internal.ts
@@ -1,0 +1,12 @@
+/**
+ * Internal contract between the framework's own packages — not part of the documented surface.
+ *
+ * What an MCP tool result means — how its blocks convert, how a failure's text is assembled — is
+ * one rule with one implementation, and every package that reads such a result (the Foundry
+ * toolbox speaks MCP over its own connection) imports it from here instead of keeping a copy.
+ * Everything exported here may change or disappear in any release; import from
+ * `@polymind-inc/agent-framework-mcp` instead for the supported surface.
+ */
+
+export type { CallToolResultShape } from './content.js';
+export { callToolFailure, contentsOfCallToolResult } from './content.js';

--- a/packages/mcp/tsdown.config.ts
+++ b/packages/mcp/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { definePackageBuild } from '../../scripts/tsdown-config.ts';
 
 export default definePackageBuild({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/internal.ts'],
   platform: 'neutral',
   neverBundle: ['@polymind-inc/agent-framework-core', '@modelcontextprotocol/client'],
 });

--- a/scripts/vitest-config.ts
+++ b/scripts/vitest-config.ts
@@ -20,6 +20,7 @@ const workspaceAliases = {
   '@polymind-inc/agent-framework-openai/internal': source('openai/src/internal.ts'),
   '@polymind-inc/agent-framework-openai': source('openai/src/index.ts'),
   '@polymind-inc/agent-framework-anthropic': source('anthropic/src/index.ts'),
+  '@polymind-inc/agent-framework-mcp/internal': source('mcp/src/internal.ts'),
   '@polymind-inc/agent-framework-mcp': source('mcp/src/index.ts'),
   '@polymind-inc/agent-framework-a2a': source('a2a/src/index.ts'),
 };


### PR DESCRIPTION
## What this changes

`FoundryToolbox` assembled the failure text of an MCP `isError` result independently of `McpClient` and had drifted from it in four ways (blocks run together, `structuredContent` dropped, empty message when no text, no `_meta` stamp on the converted contents). The assembly is now one shared implementation the toolbox imports through a new `@polymind-inc/agent-framework-mcp/internal` subpath, so the two paths cannot drift again. Closes #137.

## Parity

- Reference checked: Python `_mcp.py` — `FoundryToolbox` extends `MCPStreamableHTTPTool` and inherits `_call_tool_with_retries`, so the reference has no second assembly at all; its rule (`"\n".join` of text blocks over the parsed contents, `structuredContent` appended last by `_parse_tool_result_from_mcp`, fallback when no text) is the one `McpClient` already implements and the toolbox now shares.
- Wire format affected: yes
- Public API affected: no

The failure text a hosted agent's model reads changes as described; the new `/internal` entry point is the same undocumented internal-contract channel the core, openai and agentserver packages already expose (everything in it may change in any release), and it does not appear on the documented meta-package surface. The `_meta` stamp rides on the shared conversion in both paths; in the error path neither path can carry it into the thrown error (it carries only text), which matches Python. This is the error-text half of the toolbox/client drift — #120 covers the tool-name and input-schema half and can share through the same entry point.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)