### PR TITLE
Fold an explicit null into the absence skill script arguments declare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **`@polymind-inc/agent-framework-core`** — a skill script no longer receives `null` as its
+  arguments. The `run_skill_script` tool's schema lets a model send an explicit `null` — the
+  advertised default — and that value used to be handed to `SkillScript.run` even though the
+  declared `SkillScriptArguments` type excludes it, so a `typeof args === 'object'` branch written
+  against the type met a `null` at runtime. An explicit `null` is the same absence as omitting the
+  argument and now arrives as `undefined`, matching the reference implementation, where an omitted
+  value defaults to `None` and an explicit JSON `null` deserializes to that same `None`. Only a
+  script that deliberately distinguished the two — against the declared type — observes a change.
+
 - **`@polymind-inc/agent-framework-foundry`** — `FoundryChatClient.createConversation()` creates a
   server-side conversation and returns its id, so a run can start on a conversation that already
   exists — and is already visible in the Foundry Project UI — instead of one the first response

--- a/packages/core/src/skills/provider.test.ts
+++ b/packages/core/src/skills/provider.test.ts
@@ -229,7 +229,8 @@ describe('skillsProvider tools', () => {
           description:
             'Arguments to pass to the script. Use an array of strings for CLI-style positional ' +
             'arguments (e.g. ["input.docx", "--output", "result.idx"]), or an object for named ' +
-            'parameters (e.g. {"length": 24, "uppercase": true}). How these values are mapped to ' +
+            'parameters (e.g. {"length": 24, "uppercase": true}). Omit this or pass null when the ' +
+            'script takes no arguments; both mean the same absence. How these values are mapped to ' +
             'the underlying script is determined by the script implementation or configured runner.',
         },
       },
@@ -237,10 +238,12 @@ describe('skillsProvider tools', () => {
     });
   });
 
-  it('hands the script exactly what the model sent for args, never the advertised default', async () => {
-    // `default` tells the model what omitting `args` means; it is not a value the tool substitutes.
-    // A script therefore still sees `undefined` for an omitted argument and `null` for an explicit
-    // one, and can tell the two apart.
+  it('hands the script one absent value: omitted args and an explicit null both arrive as undefined', async () => {
+    // The schema's `default: null` advertises that omitting `args` is supported; an explicit
+    // `null` is that same absence spelled out, so the script sees `undefined` for both — never a
+    // `null` its declared parameter type excludes. The reference implementation collapses the two
+    // the same way: an omitted value defaults to None and an explicit JSON null deserializes to
+    // that same None. Values the model actually sent pass through untouched.
     const seen: unknown[] = [];
     const probe = inlineSkill({
       name: 'probe-skill',
@@ -262,10 +265,11 @@ describe('skillsProvider tools', () => {
       { skill_name: 'probe-skill', script_name: 'probe' },
       { skill_name: 'probe-skill', script_name: 'probe', args: null },
       { skill_name: 'probe-skill', script_name: 'probe', args: ['--json'] },
+      { skill_name: 'probe-skill', script_name: 'probe', args: { length: 24 } },
     ]) {
       expect(await invoke(contribution, SKILL_TOOL_NAMES.runSkillScript, input)).toBe('recorded');
     }
-    expect(seen).toStrictEqual([undefined, null, ['--json']]);
+    expect(seen).toStrictEqual([undefined, undefined, ['--json'], { length: 24 }]);
   });
 
   it.each([

--- a/packages/core/src/skills/provider.ts
+++ b/packages/core/src/skills/provider.ts
@@ -2,6 +2,7 @@ import type { ContextProvider, ProviderRunContext } from '../context/context-pro
 import { ConfigurationError } from '../errors.js';
 import type { ApprovalMode, Tool, ToolContext } from '../tools/tool.js';
 import { tool } from '../tools/tool.js';
+import { isRecord } from '../types/content.js';
 import type { Skill, SkillAccessOptions, SkillInvocationContext, SkillScriptArguments } from './skill.js';
 import { xmlEscape } from './skill.js';
 import type { SkillLoadFailure, SkillsSource, SkillsSourceContext } from './source.js';
@@ -287,13 +288,15 @@ function skillTools(skills: readonly Skill[], approvals: SkillApprovalModes): To
             { type: 'null' },
           ],
           // Advertised only: omitting `args` is a supported call, and saying so keeps the model
-          // from inventing a placeholder for a script that takes nothing. The tool never
-          // substitutes the value — a script still sees `undefined` for an omitted argument.
+          // from inventing a placeholder for a script that takes nothing. An explicit `null` is
+          // that same absence spelled out — the script sees `undefined` for both, as
+          // `scriptArguments` documents.
           default: null,
           description:
             'Arguments to pass to the script. Use an array of strings for CLI-style positional ' +
             'arguments (e.g. ["input.docx", "--output", "result.idx"]), or an object for named ' +
-            'parameters (e.g. {"length": 24, "uppercase": true}). How these values are mapped to ' +
+            'parameters (e.g. {"length": 24, "uppercase": true}). Omit this or pass null when the ' +
+            'script takes no arguments; both mean the same absence. How these values are mapped to ' +
             'the underlying script is determined by the script implementation or configured runner.',
         },
       },
@@ -316,16 +319,35 @@ function skillTools(skills: readonly Skill[], approvals: SkillApprovalModes): To
       if (script === undefined) {
         return `Error: Script '${scriptName}' not found in skill '${skillName}'.`;
       }
-      // The cast is wider than the truth: the schema's null branch means a model can send an
-      // explicit `null`, which reaches the script even though the declared type excludes it. The
-      // test driving all three shapes through this call pins that. Reconciling the two — widening
-      // the type or folding `null` into `undefined` — changes the published surface or what a
-      // script observes, so it is decided separately rather than here.
-      return await script.run(input.args as SkillScriptArguments, invocationContext(skill, toolCtx));
+      return await script.run(scriptArguments(input.args), invocationContext(skill, toolCtx));
     },
   });
 
   return [loadSkill, readSkillResource, runSkillScript];
+}
+
+/**
+ * What the model's `args` value hands the script.
+ *
+ * An explicit JSON `null` — the schema's advertised default — collapses to the same absence an
+ * omitted `args` produces, so a script author handles one absent value and the declared
+ * {@link SkillScriptArguments} parameter type is true at runtime: nothing reaches `run` that the
+ * type excludes. The reference implementation makes the same collapse — its `args` parameter
+ * defaults to `None`, and an explicit JSON `null` deserializes to that same `None`.
+ *
+ * The predicates re-establish for the compiler what the tool's schema (`oneOf` of object, string
+ * array, null) already validated before execution, so no assertion is needed. A caller invoking
+ * `execute` directly with a value the schema would have refused gets the absent case rather than
+ * a script receiving a type its signature was promised never to see.
+ */
+function scriptArguments(args: unknown): SkillScriptArguments {
+  if (isRecord(args)) {
+    return args;
+  }
+  if (Array.isArray(args) && args.every((item): item is string => typeof item === 'string')) {
+    return args;
+  }
+  return undefined;
 }
 
 function compareNames(left: string, right: string): number {

--- a/packages/core/src/skills/skill.ts
+++ b/packages/core/src/skills/skill.ts
@@ -37,6 +37,11 @@ export interface SkillResource {
  *
  * Two shapes, because scripts come in two flavours: named parameters for a function, and a
  * positional argv for anything shaped like a command line.
+ *
+ * `null` is deliberately not part of this type. The `run_skill_script` tool's schema lets a model
+ * send an explicit `null` — the advertised default — but that is the same absence as omitting the
+ * argument, and it reaches a script as this type's `undefined`, so an implementation handles one
+ * absent value.
  */
 export type SkillScriptArguments = Record<string, unknown> | readonly string[] | undefined;
 


### PR DESCRIPTION
## What this changes

`SkillScript.run` can no longer receive a `null` its declared `SkillScriptArguments` parameter type excludes: the `run_skill_script` tool folds a model's explicit JSON `null` — the schema's advertised default — into the same `undefined` an omitted argument produces, and the unsound cast is removed. Closes #143.

## Parity

- Reference checked: Python `agent_framework/_tools.py` — the skill-script tool's `args` defaults to `None`, and an explicit JSON `null` deserializes to that same `None`, so a script there has exactly one absent value. Widening the TypeScript type to admit `null` was the other way to close the gap; it was rejected because it is a breaking change for every existing `SkillScript` implementation and would make script authors handle two absent values where the reference has one.
- Wire format affected: no
- Public API affected: no
- Breaking change: no

The declared type is unchanged; the runtime now honours it. Only a script that deliberately distinguished `null` from `undefined` — against the declared type — observes a change. The cast is replaced by predicate narrowing that re-establishes what the schema's `oneOf` already validated before execution; a value invoked past the schema degrades to the absent case rather than reaching a script as a type its signature excludes. The tool's parameter description and the `SkillScriptArguments` TSDoc both state that omitting `args` and passing `null` mean the same absence, so the model-facing schema, the type a script author reads, and the runtime agree. Omitted, explicit-null, array and object arguments are each pinned by test.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)