### PR TITLE
Emit server.port on MCP spans as the integer the convention defines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **`@polymind-inc/agent-framework-mcp`** — MCP client spans emit `server.port` as an integer, as
+  the OpenTelemetry semantic conventions define the attribute, instead of the string the WHATWG URL
+  API reports. **Dashboard migration:** a query that compared the attribute as a string
+  (`server.port = "8443"`) must compare it as a number; numeric filters and range aggregations that
+  silently matched nothing now work. A URL that does not state an explicit port still reports no
+  `server.port` at all, and `server.address` is unchanged.
+
 - **`@polymind-inc/agent-framework-core`** — a skill script no longer receives `null` as its
   arguments. The `run_skill_script` tool's schema lets a model send an explicit `null` — the
   advertised default — and that value used to be handed to `SkillScript.run` even though the

--- a/packages/mcp/src/connection.test.ts
+++ b/packages/mcp/src/connection.test.ts
@@ -354,12 +354,31 @@ describe('telemetry', () => {
     for (const span of spans) {
       expect(span.kind).toBe(SpanKind.CLIENT);
       expect(span.attributes['server.address']).toBe('mcp.example.com');
-      expect(span.attributes['server.port']).toBe('8443');
+      // The semantic conventions define `server.port` as an int, and the key is stable: a backend
+      // that types it numerically rejects or coerces a string, and numeric filters break on one.
+      expect(span.attributes['server.port']).toBe(8443);
     }
     const call = spans.find((s) => s.name === 'tools/call echo');
     expect(call?.attributes['mcp.method.name']).toBe('tools/call');
     expect(call?.attributes['gen_ai.tool.name']).toBe('echo');
     expect(call?.attributes['gen_ai.tool.type']).toBe('mcp');
+  });
+
+  it('omits server.port when the URL does not state one explicitly', async () => {
+    // `URL.port` is the empty string for a default-scheme port, so `https://…/mcp` reports no
+    // port. The convention allows the omission; inventing 443 here would claim knowledge the URL
+    // never stated.
+    const connection = new McpConnection({
+      transport: () => new TestMcpServer([echoTool()]),
+      url: 'https://mcp.example.com/mcp',
+    });
+    await connection.listTools();
+    await connection.close();
+
+    for (const span of exporter.getFinishedSpans()) {
+      expect(span.attributes['server.address']).toBe('mcp.example.com');
+      expect('server.port' in span.attributes).toBe(false);
+    }
   });
 
   it('marks an isError result tool_error even though the result is returned', async () => {

--- a/packages/mcp/src/connection.ts
+++ b/packages/mcp/src/connection.ts
@@ -192,14 +192,20 @@ export class McpConnection {
   }
 
   /** Attributes every span of this connection carries. */
-  #spanAttributes(): Record<string, string> {
+  #spanAttributes(): Record<string, string | number> {
     if (this.#url === undefined) {
       return {};
     }
     const url = new URL(String(this.#url));
+    // `server.port` is an int in the semantic conventions, so the WHATWG URL's string port is
+    // converted. A URL that states no explicit port reports none — `URL.port` is the empty string
+    // for a default-scheme port, and inventing the default would claim what the URL never said.
+    // The parser only admits digits in a port, so the finite check is a guard against emitting a
+    // broken value, not a branch a valid URL can reach.
+    const port = Number(url.port);
     return {
       [MCP.serverAddress]: url.hostname,
-      ...(url.port === '' ? {} : { [MCP.serverPort]: url.port }),
+      ...(url.port === '' || !Number.isFinite(port) ? {} : { [MCP.serverPort]: port }),
     };
   }
 


### PR DESCRIPTION
## What this changes

MCP client spans emit `server.port` as a number instead of the string `URL.port` reports, matching the OpenTelemetry semantic conventions' int definition for the stable `server.port` key. Closes #125.

## Parity

- Reference checked: OpenTelemetry semantic conventions (`server.port`, type int, stability stable). This is a conventions-conformance fix rather than a cross-implementation one; `server.address` on the same span already carries the host the convention defines and is unchanged.
- Wire format affected: no (telemetry attribute type only)
- Public API affected: no
- Breaking change: no

A URL with no explicit port still emits no `server.port` — `URL.port` is the empty string for a default-scheme port, and inventing the default would claim what the URL never stated; that behaviour is now pinned by a test as a decision. The CHANGELOG entry carries a dashboard migration note because the attribute's type changes.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)