### PR TITLE
Stop the foundry test suites leaving temp directories behind

### DIFF
--- a/packages/foundry/src/hosting/hosting.test.ts
+++ b/packages/foundry/src/hosting/hosting.test.ts
@@ -1,5 +1,4 @@
-import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type {
   CreateResponseRequest,
@@ -49,6 +48,10 @@ import { OutputBuilder } from './output.js';
 import { FoundryResponseStore } from './response-store.js';
 import { ResponsesHostServer } from './server.js';
 import { FileSystemAgentSessionStore, InMemoryAgentSessionStore } from './session-store.js';
+import { scratchRoot } from './test-scratch.js';
+
+/** Every on-disk fixture of this file lives under one root, removed when its tests finish. */
+const scratch = scratchRoot('afjs-fdry');
 
 function say(text: string): MockTurn {
   return { contents: [textContent(text)], finishReason: 'stop' };
@@ -399,7 +402,7 @@ describe('hosted agent over the protocol', () => {
   });
 
   it('partitions session files by user and rejects a traversal key', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'af-sessions-'));
+    const root = await scratch.dir();
     const sessionStore = new FileSystemAgentSessionStore({ root });
     const app = server({ client: new MockChatClient([say('a')]), sessionStore });
 
@@ -721,44 +724,36 @@ describe('environment defaults', () => {
   it('persists a local run’s responses to the state root, so a restart can be continued', async () => {
     // The composition, not just `defaultStore(false)`: what a caller gets from
     // `new ResponsesHostServer({ agent })` with no `store` is what the matrix is about.
-    const root = await mkdtemp(join(tmpdir(), 'afjs-host-store-'));
+    const root = await scratch.dir();
     vi.stubEnv('AGENTSERVER_STATE_ROOT', root);
-    try {
-      const app = new ResponsesHostServer({
-        agent: new Agent({ client: new MockChatClient([say('Hello there')]), instructions: 'Be helpful.' }),
-        sessionStore: new InMemoryAgentSessionStore(),
-        approvalStorage: new InMemoryApprovalStorage(),
-        hosted: false,
-      });
+    const app = new ResponsesHostServer({
+      agent: new Agent({ client: new MockChatClient([say('Hello there')]), instructions: 'Be helpful.' }),
+      sessionStore: new InMemoryAgentSessionStore(),
+      approvalStorage: new InMemoryApprovalStorage(),
+      hosted: false,
+    });
 
-      const created = (await (await app.handle(post({ input: 'Hi' }))).json()) as ResponseObject;
+    const created = (await (await app.handle(post({ input: 'Hi' }))).json()) as ResponseObject;
 
-      // Clear text on disk, under the documented root — the transcript is readable by anyone who
-      // can read the directory, and nothing here ever removes it.
-      expect(await readFile(join(root, 'responses', `${created.id}.json`), 'utf8')).toContain('Hello there');
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    // Clear text on disk, under the documented root — the transcript is readable by anyone who
+    // can read the directory, and nothing here ever removes it.
+    expect(await readFile(join(root, 'responses', `${created.id}.json`), 'utf8')).toContain('Hello there');
   });
 
   it('keeps an explicitly in-memory local run off the filesystem', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'afjs-host-store-'));
+    const root = await scratch.dir();
     vi.stubEnv('AGENTSERVER_STATE_ROOT', root);
-    try {
-      const app = new ResponsesHostServer({
-        agent: new Agent({ client: new MockChatClient([say('Hello there')]), instructions: 'Be helpful.' }),
-        sessionStore: new InMemoryAgentSessionStore(),
-        approvalStorage: new InMemoryApprovalStorage(),
-        hosted: false,
-        store: new InMemoryResponseProvider(),
-      });
+    const app = new ResponsesHostServer({
+      agent: new Agent({ client: new MockChatClient([say('Hello there')]), instructions: 'Be helpful.' }),
+      sessionStore: new InMemoryAgentSessionStore(),
+      approvalStorage: new InMemoryApprovalStorage(),
+      hosted: false,
+      store: new InMemoryResponseProvider(),
+    });
 
-      await app.handle(post({ input: 'Hi' }));
+    await app.handle(post({ input: 'Hi' }));
 
-      await expect(readdir(join(root, 'responses'))).rejects.toMatchObject({ code: 'ENOENT' });
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    await expect(readdir(join(root, 'responses'))).rejects.toMatchObject({ code: 'ENOENT' });
   });
 });
 
@@ -1710,7 +1705,7 @@ describe('background execution with the Foundry store', () => {
         getToken: async () => ({ token: 'mi-token', expiresOnTimestamp: Date.now() + 3_600_000 }),
       }),
       fetch: service.fetch,
-      replayRoot: await mkdtemp(join(tmpdir(), 'afjs-fdry-')),
+      replayRoot: await scratch.dir(),
       retry: { baseDelayMs: 0 },
     });
     const app = new ResponsesServer({
@@ -2299,7 +2294,7 @@ describe('streamed event sequences for provider tool items', () => {
 
 describe('file approval storage concurrency', () => {
   it('keeps both approvals when two saves race', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'af-approvals-'));
+    const root = await scratch.dir();
     const storage = new FileApprovalStorage({ root });
     const request = (id: string): FunctionApprovalRequestContent => ({
       type: 'function_approval_request',

--- a/packages/foundry/src/hosting/response-store.test.ts
+++ b/packages/foundry/src/hosting/response-store.test.ts
@@ -1,5 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { AccessToken, TokenCredential } from '@azure/identity';
 import type { ResponseObject } from '@polymind-inc/agent-framework-agentserver';
@@ -13,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FoundryProject } from '../project.js';
 import { FoundryResponseStore } from './response-store.js';
 import { defaultStore } from './server.js';
+import { scratchRoot } from './test-scratch.js';
 
 const PROJECT = 'https://my-resource.services.ai.azure.com/api/projects/my-project';
 
@@ -31,8 +31,15 @@ interface Call {
   reply?: Response;
 }
 
-/** One shared scratch directory per test file run; each store() call gets its own subdirectory. */
-const replayScratch = await mkdtemp(join(tmpdir(), 'afjs-replay-'));
+/**
+ * One shared scratch root per test file run; each store() call names its own subdirectory.
+ *
+ * Nothing under the root exists until a test writes there — the store's own writes create their
+ * directory recursively, and the tests that plant fixtures call `mkdir` themselves — so the root
+ * is a name, not a directory, until then, and the whole tree is removed after the file's tests.
+ */
+const scratch = scratchRoot('afjs-replay');
+const replayScratch = scratch.root;
 let replayDirCount = 0;
 
 /** A store whose every request is recorded, with scripted replies. */
@@ -623,7 +630,7 @@ describe('replay mirror integrity', () => {
   });
 
   it('keeps a remote delete a success when the mirror cannot be cleaned', async () => {
-    const blockedRoot = join(replayScratch, `blocked-del-${replayDirCount++}`);
+    const blockedRoot = join(await scratch.ensureRoot(), `blocked-del-${replayDirCount++}`);
     await writeFile(blockedRoot, 'a file where the directory should be');
     const { store: subject } = store([{ status: 204 }], { replayRoot: blockedRoot });
 
@@ -651,7 +658,7 @@ describe('replay mirror integrity', () => {
   it('keeps remote persistence a success when the local mirror cannot be written', async () => {
     // The mirror is auxiliary: replay becomes unavailable (fail closed), but the response is
     // durably stored and the turn must not be reported as a storage failure.
-    const blockedRoot = join(replayScratch, `blocked-${replayDirCount++}`);
+    const blockedRoot = join(await scratch.ensureRoot(), `blocked-${replayDirCount++}`);
     await writeFile(blockedRoot, 'a file where the directory should be');
     const { store: subject } = store(
       [

--- a/packages/foundry/src/hosting/test-scratch.ts
+++ b/packages/foundry/src/hosting/test-scratch.ts
@@ -1,0 +1,50 @@
+import { mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll } from 'vitest';
+
+/** A per-file scratch root under the OS temp directory, removed when the file's tests finish. */
+export interface ScratchRoot {
+  /** The root path. A name until something creates it — see {@link scratchRoot}. */
+  readonly root: string;
+  /** A fresh subdirectory under the root, created on demand. */
+  dir(): Promise<string>;
+  /** Creates the root itself and returns it, for a test that writes directly under it. */
+  ensureRoot(): Promise<string>;
+}
+
+/**
+ * Declares one scratch root for the calling test file and registers its removal.
+ *
+ * The root is only *named* here, never created up front: a fully skipped test file runs no
+ * hooks at all, so a root created eagerly at module scope would be left behind on every skipped
+ * run — which is exactly how these directories used to accumulate by the thousand. Everything
+ * under the root is created on demand, and the registered `afterAll` removes the whole tree
+ * whether the file's tests passed or failed. A removal failure — a Windows handle still open —
+ * never fails a suite that already passed.
+ *
+ * Call at module scope of a test file; the cleanup hook binds to that file.
+ */
+export function scratchRoot(prefix: string): ScratchRoot {
+  const root = join(tmpdir(), `${prefix}-${crypto.randomUUID()}`);
+  let count = 0;
+  afterAll(async () => {
+    try {
+      await rm(root, { recursive: true, force: true });
+    } catch {
+      // Best-effort by design: anything left is bounded to this run's root, not unbounded growth.
+    }
+  });
+  return {
+    root,
+    async dir(): Promise<string> {
+      const dir = join(root, String(++count));
+      await mkdir(dir, { recursive: true });
+      return dir;
+    },
+    async ensureRoot(): Promise<string> {
+      await mkdir(root, { recursive: true });
+      return root;
+    },
+  };
+}

--- a/packages/foundry/src/hosting/test-scratch.ts
+++ b/packages/foundry/src/hosting/test-scratch.ts
@@ -31,7 +31,11 @@ export interface ScratchRoot {
  * Call at module scope of a test file; the cleanup hook binds to that file.
  */
 export function scratchRoot(prefix: string): ScratchRoot {
-  const root = join(tmpdir(), `${prefix}-${crypto.randomUUID()}`);
+  // The prefix names a directory and nothing more. Stripping everything path-like keeps a
+  // mistaken `/tmp/foo` or `..\bar` from letting the recursive removal below reach outside the
+  // OS temp directory.
+  const name = prefix.replace(/[^A-Za-z0-9_-]/g, '-');
+  const root = join(tmpdir(), `${name}-${crypto.randomUUID()}`);
   let count = 0;
   afterAll(async () => {
     try {

--- a/packages/foundry/src/hosting/test-scratch.ts
+++ b/packages/foundry/src/hosting/test-scratch.ts
@@ -1,3 +1,8 @@
+/**
+ * Test-only module: imports `vitest` and is reachable from test files alone. It is not part of
+ * any build entry point and must never be imported from runtime code, which would pull a
+ * dev-only dependency into the published package.
+ */
 import { mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';


### PR DESCRIPTION
## What this changes

The foundry hosting suites no longer leak temporary directories: one shared per-file scratch root (named up front, created on demand, removed in `afterAll`) replaces the four `mkdtemp` sites that never cleaned up. Closes #124.

## Parity

- Reference checked: not applicable — test infrastructure only; no runtime behaviour changes. The pattern follows the repository's own `scripts/test-state-root.ts` (name the root rather than creating it eagerly, remove recursively afterwards).
- Wire format affected: no
- Public API affected: no

Measured on the machine the issue was filed from: one run of `hosting.test.ts` + `response-store.test.ts` left **9 new directories before the change and 0 after** (all 140 tests passing), and a fully skipped run of both files creates nothing. Sweep result: the remaining `mkdtemp` sites — the agentserver store suites and the core `node/` suites — already remove their directories in `afterEach`, which also runs on failure, and `scripts/test-state-root.ts` already cleans the state root. The `afjs-bg-*` / `afjs-conv-*` / `afjs-cont-*` prefixes measured in the issue no longer have any generator in the tree or its history — they are leftovers of earlier revisions, and per the issue's out-of-scope note, existing leftovers are not deleted here.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change (measurement-based: before/after leftover counts above)
- [x] Public API changes are reflected in the package README and `CHANGELOG.md` (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)