### PR TITLE
Normalize Foundry toolbox declarations by the shared MCP rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ contain breaking changes**; patch releases are fixes only.
   `[A-Za-z0-9_.-]`) is exposed with those characters replaced by `-`, and a bare
   `{ "type": "object" }` schema — the common spelling for "takes no arguments" — gains the empty
   `properties` map OpenAI requires. Both defects previously made such a tool unreachable with a
-  provider 400. `tools/call`, `allowedTools` and error messages keep using the toolbox's own names,
+  provider 400. `tools/call`, `allowedTools` and error messages keep using the tool names the server declared,
   the server-owned schema object is never modified, and consent correlation is unaffected (it rides
   on the call id). New public API: `FoundryToolboxConfig.toolNamePrefix` namespaces the exposed
   names as `<prefix>_<name>`, with the same joining rules as `McpClientConfig.toolNamePrefix`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ contain breaking changes**; patch releases are fixes only.
   `properties` map OpenAI requires. Both defects previously made such a tool unreachable with a
   provider 400. `tools/call`, `allowedTools` and error messages keep using the tool names the server declared,
   the server-owned schema object is never modified, and consent correlation is unaffected (it rides
-  on the call id). New public API: `FoundryToolboxConfig.toolNamePrefix` namespaces the exposed
-  names as `<prefix>_<name>`, with the same joining rules as `McpClientConfig.toolNamePrefix`.
+  on the call id). Like `McpClient.getTools`, `getTools()` now throws when two remote names would
+  be exposed under the same normalized name — previously both were exposed and one was silently
+  unreachable, decided by listing order. New public API: `FoundryToolboxConfig.toolNamePrefix`
+  namespaces the exposed names as `<prefix>_<name>`, with the same joining rules as
+  `McpClientConfig.toolNamePrefix`.
 
 - **`@polymind-inc/agent-framework-core`** — a skill script no longer receives `null` as its
   arguments. The `run_skill_script` tool's schema lets a model send an explicit `null` — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **`@polymind-inc/agent-framework-foundry`** — `FoundryToolbox` now normalizes the tool
+  declarations it exposes by the same shared rules the MCP client applies, instead of passing them
+  through raw: a remote name containing characters providers refuse (anything outside
+  `[A-Za-z0-9_.-]`) is exposed with those characters replaced by `-`, and a bare
+  `{ "type": "object" }` schema — the common spelling for "takes no arguments" — gains the empty
+  `properties` map OpenAI requires. Both defects previously made such a tool unreachable with a
+  provider 400. `tools/call`, `allowedTools` and error messages keep using the toolbox's own names,
+  the server-owned schema object is never modified, and consent correlation is unaffected (it rides
+  on the call id). New public API: `FoundryToolboxConfig.toolNamePrefix` namespaces the exposed
+  names as `<prefix>_<name>`, with the same joining rules as `McpClientConfig.toolNamePrefix`.
+
 - **`@polymind-inc/agent-framework-core`** — a skill script no longer receives `null` as its
   arguments. The `run_skill_script` tool's schema lets a model send an explicit `null` — the
   advertised default — and that value used to be handed to `SkillScript.run` even though the

--- a/packages/foundry/README.md
+++ b/packages/foundry/README.md
@@ -33,6 +33,13 @@ project over MCP. A toolbox publishes two independent things and the class expos
 the same connection, so skills need no separate credential — and `loadTools: false` gives an agent
 the skills without exposing the tools.
 
+Tool declarations are normalized by the same rules the MCP client applies: a name is exposed with
+every character outside `[A-Za-z0-9_.-]` replaced by `-` (providers accept nothing else in a
+function name), and a bare `{ "type": "object" }` schema gains the empty `properties` map providers
+require — while `tools/call`, `allowedTools` and error messages keep using the toolbox's own names.
+`toolNamePrefix` namespaces the exposed names as `<prefix>_<name>`, the way it does on `McpClient`,
+for the moment two toolboxes both advertise a `search`.
+
 ## Starting on a conversation that already exists
 
 A run continues whatever conversation its session names, and by default the first response mints

--- a/packages/foundry/README.md
+++ b/packages/foundry/README.md
@@ -36,7 +36,7 @@ the skills without exposing the tools.
 Tool declarations are normalized by the same rules the MCP client applies: a name is exposed with
 every character outside `[A-Za-z0-9_.-]` replaced by `-` (providers accept nothing else in a
 function name), and a bare `{ "type": "object" }` schema gains the empty `properties` map providers
-require — while `tools/call`, `allowedTools` and error messages keep using the toolbox's own names.
+require — while `tools/call`, `allowedTools` and error messages keep using the tool names the server declared.
 `toolNamePrefix` namespaces the exposed names as `<prefix>_<name>`, the way it does on `McpClient`,
 for the moment two toolboxes both advertise a `search`.
 

--- a/packages/foundry/src/hosting/toolbox.test.ts
+++ b/packages/foundry/src/hosting/toolbox.test.ts
@@ -31,6 +31,8 @@ const credential: TokenCredential = {
 interface RecordedCall {
   method: string;
   headers: Record<string, string>;
+  /** The tool name a `tools/call` request carried, absent for other methods. */
+  toolName?: string;
 }
 
 /** An MCP tool declaration. `inputSchema` is required by the protocol. */
@@ -62,6 +64,8 @@ function stubToolbox(
     resources?: Record<string, string>;
     /** Passed straight to the toolbox; `false` hides its tools from the model. */
     loadTools?: boolean;
+    /** Passed straight to the toolbox: namespaces the exposed tool names. */
+    toolNamePrefix?: string;
     /** The first request awaits this before reaching the stub, so a test can race `close()` in. */
     holdFirstRequest?: Promise<void>;
     /** `tools/call` requests await this forever, so a test can abort one in flight. */
@@ -93,7 +97,11 @@ function stubToolbox(
       failedOnce = true;
       throw new Error('connection reset');
     }
-    const request = JSON.parse(String(init?.body ?? '{}')) as { id?: number; method?: string };
+    const request = JSON.parse(String(init?.body ?? '{}')) as {
+      id?: number;
+      method?: string;
+      params?: { name?: string };
+    };
     if (request.method === 'tools/call' && (options.dieOnToolCalls ?? []).includes(++toolCallCount)) {
       // What a Foundry toolbox answers once it has expired the MCP session.
       return new Response('Session terminated', { status: 404 });
@@ -102,7 +110,13 @@ function stubToolbox(
     new Headers(init?.headers).forEach((value, name) => {
       headers[name] = value;
     });
-    calls.push({ method: request.method ?? '(none)', headers });
+    calls.push({
+      method: request.method ?? '(none)',
+      headers,
+      ...(typeof request.params?.name === 'string' && request.method === 'tools/call'
+        ? { toolName: request.params.name }
+        : {}),
+    });
 
     if (request.method === 'tools/call' && options.holdToolCalls !== undefined) {
       options.onToolCall?.();
@@ -168,6 +182,7 @@ function stubToolbox(
       fetch: fetchStub,
       ...(options.allowedTools === undefined ? {} : { allowedTools: options.allowedTools }),
       ...(options.loadTools === undefined ? {} : { loadTools: options.loadTools }),
+      ...(options.toolNamePrefix === undefined ? {} : { toolNamePrefix: options.toolNamePrefix }),
     }),
     calls,
   };
@@ -339,6 +354,83 @@ describe('FoundryToolbox tools', () => {
       });
 
       expect((error as Error).message).toBe('MCP tool "search_docs" reported an error.');
+    });
+  });
+
+  describe('declaration normalization', () => {
+    // The same rules `McpClient` applies, shared rather than re-implemented: a provider only
+    // accepts `[A-Za-z0-9_.-]` in a function name and refuses an object schema without
+    // `properties`, so an unnormalized declaration makes the tool unreachable with a 400.
+
+    it('normalizes a bare zero-argument schema so providers accept the declaration', async () => {
+      const { toolbox } = stubToolbox({
+        tools: [{ name: 'ping', inputSchema: { type: 'object' } }],
+      });
+
+      const [tool] = await toolbox.getTools();
+
+      expect(tool?.jsonSchema).toEqual({ type: 'object', properties: {} });
+      await toolbox.close();
+    });
+
+    it('exposes a normalized name while calling the server with the remote one', async () => {
+      const { toolbox, calls } = stubToolbox({
+        tools: [{ name: 'search docs!', description: 'Search the docs' }],
+      });
+
+      const [tool] = await toolbox.getTools();
+      expect(tool?.name).toBe('search-docs-');
+
+      await tool?.execute?.({ q: 'hello' }, { callId: 'c1' });
+      expect(calls.find((c) => c.method === 'tools/call')?.toolName).toBe('search docs!');
+      await toolbox.close();
+    });
+
+    it('namespaces the exposed names under the configured prefix', async () => {
+      const { toolbox, calls } = stubToolbox({
+        tools: [{ name: 'search docs!' }],
+        toolNamePrefix: 'github',
+      });
+
+      const [tool] = await toolbox.getTools();
+      expect(tool?.name).toBe('github_search-docs-');
+
+      await tool?.execute?.({ q: 'hello' }, { callId: 'c1' });
+      expect(calls.find((c) => c.method === 'tools/call')?.toolName).toBe('search docs!');
+      await toolbox.close();
+    });
+
+    it('filters allowedTools by the remote name, prefix or not', async () => {
+      const { toolbox } = stubToolbox({
+        tools: [{ name: 'search docs!' }, { name: 'other' }],
+        allowedTools: ['search docs!'],
+        toolNamePrefix: 'github',
+      });
+
+      const tools = await toolbox.getTools();
+
+      expect(tools.map((t) => t.name)).toEqual(['github_search-docs-']);
+      await toolbox.close();
+    });
+
+    it('still raises the typed consent refusal for a tool exposed under a normalized name', async () => {
+      // Consent correlation rides on the call id, not the tool name, so renaming must not turn
+      // the gateway's refusal into an ordinary tool failure — and the request that triggered it
+      // must still name the remote tool.
+      const { toolbox, calls } = stubToolbox({
+        tools: [{ name: 'search docs!' }],
+        consentOn: 'tools/call',
+      });
+
+      const [tool] = await toolbox.getTools();
+      const failure = tool?.execute?.({ q: 'x' }, { callId: 'c1' });
+
+      await expect(failure).rejects.toBeInstanceOf(ToolboxConsentRequiredError);
+      await expect(failure).rejects.toMatchObject({
+        consents: [{ serverLabel: 'github', consentLink: 'https://consent.example.com/auth' }],
+      });
+      expect(calls.find((c) => c.method === 'tools/call')?.toolName).toBe('search docs!');
+      await toolbox.close();
     });
   });
 

--- a/packages/foundry/src/hosting/toolbox.test.ts
+++ b/packages/foundry/src/hosting/toolbox.test.ts
@@ -35,7 +35,7 @@ interface RecordedCall {
   toolName?: string;
 }
 
-/** An MCP tool declaration. `inputSchema` is required by the protocol. */
+/** An MCP tool declaration. `inputSchema` is required by the protocol; the stub fills a default. */
 interface StubTool {
   name: string;
   description?: string;

--- a/packages/foundry/src/hosting/toolbox.test.ts
+++ b/packages/foundry/src/hosting/toolbox.test.ts
@@ -400,6 +400,26 @@ describe('FoundryToolbox tools', () => {
       await toolbox.close();
     });
 
+    it('refuses two remote names that collide on one exposed name', async () => {
+      // The MCP client's claim rule, shared: silently keeping one would make the other
+      // unreachable, and which survived would depend on the server's listing order.
+      const { toolbox } = stubToolbox({ tools: [{ name: 'a b' }, { name: 'a-b' }] });
+
+      await expect(toolbox.getTools()).rejects.toThrow(/exposed name is the same "a-b"/);
+      await toolbox.close();
+    });
+
+    it('keeps the first entry when the same tool is listed twice', async () => {
+      const { toolbox } = stubToolbox({
+        tools: [{ name: 'search_docs' }, { name: 'search_docs' }],
+      });
+
+      const tools = await toolbox.getTools();
+
+      expect(tools.map((t) => t.name)).toEqual(['search_docs']);
+      await toolbox.close();
+    });
+
     it('filters allowedTools by the remote name, prefix or not', async () => {
       const { toolbox } = stubToolbox({
         tools: [{ name: 'search docs!' }, { name: 'other' }],

--- a/packages/foundry/src/hosting/toolbox.ts
+++ b/packages/foundry/src/hosting/toolbox.ts
@@ -170,7 +170,9 @@ export class FoundryToolbox {
           // A tool declared without a description gets an empty one — the name is not reused as a
           // stand-in (Python parity: `tool.description or ""`).
           description: declared.description ?? '',
-          parameters: normalizeInputSchema(declared.inputSchema as Record<string, unknown> | undefined),
+          parameters: normalizeInputSchema(
+            declared.inputSchema as Record<string, unknown> | null | undefined,
+          ),
           execute: async (input: unknown, ctx: ToolContext) => {
             let result: CallToolResult;
             try {

--- a/packages/foundry/src/hosting/toolbox.ts
+++ b/packages/foundry/src/hosting/toolbox.ts
@@ -60,7 +60,8 @@ export interface FoundryToolboxConfig {
    * plain MCP servers — the joining and normalization rules are the same shared implementation.
    *
    * Only the exposed name changes. `tools/call`, {@link FoundryToolboxConfig.allowedTools} and
-   * error messages all keep using the toolbox's own name.
+   * error messages all keep using the tool name the server declared — not the prefixed name, and
+   * not {@link FoundryToolboxConfig.name}.
    */
   toolNamePrefix?: string;
   /**

--- a/packages/foundry/src/hosting/toolbox.ts
+++ b/packages/foundry/src/hosting/toolbox.ts
@@ -12,6 +12,7 @@ import type { McpSkillsSourceConfig } from '@polymind-inc/agent-framework-mcp';
 import { McpConnection, mcpSkillsSource } from '@polymind-inc/agent-framework-mcp';
 import {
   callToolFailure,
+  claimLocalName,
   contentsOfCallToolResult,
   localToolName,
   normalizeInputSchema,
@@ -147,13 +148,25 @@ export class FoundryToolbox {
       throw withConsentTyped(error);
     });
 
-    return tools
-      .filter((declared) => this.#allowedTools?.has(declared.name) ?? true)
-      .map((declared) =>
+    // The same claim rule the MCP client applies: a collision between exposed names throws, and
+    // the same remote tool listed twice keeps its first entry.
+    const claims = new Map<string, string>();
+    const exposed: Array<FunctionTool<Record<string, unknown>, unknown>> = [];
+    for (const declared of tools) {
+      if (!(this.#allowedTools?.has(declared.name) ?? true)) {
+        continue;
+      }
+      const localName = localToolName(declared.name, this.#toolNamePrefix);
+      if (
+        claimLocalName(claims, localName, declared.name, `Foundry toolbox '${this.#name}'`) === 'duplicate'
+      ) {
+        continue;
+      }
+      exposed.push(
         tool({
           // Exposed under the provider-safe name the shared MCP rules produce; every request to
           // the toolbox below keeps using `declared.name`, the name the server owns.
-          name: localToolName(declared.name, this.#toolNamePrefix),
+          name: localName,
           // A tool declared without a description gets an empty one — the name is not reused as a
           // stand-in (Python parity: `tool.description or ""`).
           description: declared.description ?? '',
@@ -193,6 +206,8 @@ export class FoundryToolbox {
           },
         }),
       );
+    }
+    return exposed;
   }
 
   /**

--- a/packages/foundry/src/hosting/toolbox.ts
+++ b/packages/foundry/src/hosting/toolbox.ts
@@ -10,7 +10,12 @@ import type {
 import { skillsProvider, tool } from '@polymind-inc/agent-framework-core';
 import type { McpSkillsSourceConfig } from '@polymind-inc/agent-framework-mcp';
 import { McpConnection, mcpSkillsSource } from '@polymind-inc/agent-framework-mcp';
-import { callToolFailure, contentsOfCallToolResult } from '@polymind-inc/agent-framework-mcp/internal';
+import {
+  callToolFailure,
+  contentsOfCallToolResult,
+  localToolName,
+  normalizeInputSchema,
+} from '@polymind-inc/agent-framework-mcp/internal';
 import type { FoundryProject } from '../project.js';
 import { FOUNDRY_API_VERSION } from '../target.js';
 import { consentRequestsOf, ToolboxConsentRequiredError } from './consent.js';
@@ -48,6 +53,17 @@ export interface FoundryToolboxConfig {
    */
   loadTools?: boolean;
   /**
+   * Namespaces the tool names this toolbox exposes to the model, as `<prefix>_<name>`.
+   *
+   * Two toolboxes that both advertise `search` collide the moment their tools reach one agent; a
+   * prefix is how the caller separates them, exactly as `McpClientConfig.toolNamePrefix` does for
+   * plain MCP servers — the joining and normalization rules are the same shared implementation.
+   *
+   * Only the exposed name changes. `tools/call`, {@link FoundryToolboxConfig.allowedTools} and
+   * error messages all keep using the toolbox's own name.
+   */
+  toolNamePrefix?: string;
+  /**
    * Replaces the transport's `fetch`, for proxies and tests.
    *
    * The per-call authorization wrapper is applied *around* whatever is supplied here, so a
@@ -76,6 +92,7 @@ export class FoundryToolbox {
   readonly #endpoint: string;
   readonly #allowedTools: ReadonlySet<string> | undefined;
   readonly #loadTools: boolean;
+  readonly #toolNamePrefix: string | undefined;
   readonly #connection: McpConnection;
 
   constructor(options: FoundryToolboxConfig) {
@@ -84,6 +101,7 @@ export class FoundryToolbox {
     this.#endpoint = project.endpoint;
     this.#allowedTools = options.allowedTools === undefined ? undefined : new Set(options.allowedTools);
     this.#loadTools = options.loadTools ?? true;
+    this.#toolNamePrefix = options.toolNamePrefix;
 
     const fetch = options.fetch ?? project.fetch;
     this.#connection = new McpConnection({
@@ -132,11 +150,13 @@ export class FoundryToolbox {
       .filter((declared) => this.#allowedTools?.has(declared.name) ?? true)
       .map((declared) =>
         tool({
-          name: declared.name,
+          // Exposed under the provider-safe name the shared MCP rules produce; every request to
+          // the toolbox below keeps using `declared.name`, the name the server owns.
+          name: localToolName(declared.name, this.#toolNamePrefix),
           // A tool declared without a description gets an empty one — the name is not reused as a
           // stand-in (Python parity: `tool.description or ""`).
           description: declared.description ?? '',
-          parameters: (declared.inputSchema ?? { type: 'object' }) as Record<string, unknown>,
+          parameters: normalizeInputSchema(declared.inputSchema as Record<string, unknown> | undefined),
           execute: async (input: unknown, ctx: ToolContext) => {
             let result: CallToolResult;
             try {

--- a/packages/foundry/src/hosting/toolbox.ts
+++ b/packages/foundry/src/hosting/toolbox.ts
@@ -134,6 +134,10 @@ export class FoundryToolbox {
    * Called on the first request rather than at startup: a toolbox that is briefly unreachable
    * would otherwise keep `/readiness` red and fail every invocation with `session_not_ready`,
    * instead of failing the one request that needed it.
+   *
+   * @throws {AgentFrameworkError} When two of the toolbox's tools would be exposed under the same
+   *   name — the same claim rule `McpClient.getTools` applies. Silently keeping one of them would
+   *   make the other unreachable, and which one survived would depend on the listing order.
    */
   async getTools(): Promise<Array<FunctionTool<Record<string, unknown>, unknown>>> {
     if (!this.#loadTools) {

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -15,6 +15,7 @@ import {
 import { errorMessageOf } from '@polymind-inc/agent-framework-core/internal';
 import { McpConnection } from './connection.js';
 import { callToolFailure, contentsOfCallToolResult, mcpMetaProperties } from './content.js';
+import { localToolName, normalizeInputSchema } from './declarations.js';
 import type { McpHeaderProvider } from './headers.js';
 import type { McpSkillsSourceConfig } from './skills.js';
 import { mcpSkillsSource } from './skills.js';
@@ -100,62 +101,6 @@ export interface McpClientConfig {
    * {@link McpClientConfig.approvalMode} and error messages all keep using the server's own name.
    */
   toolNamePrefix?: string;
-}
-
-/** Characters a provider accepts in a function name; everything else normalizes to `-`. */
-const DISALLOWED_NAME_CHARACTERS = /[^A-Za-z0-9_.-]/g;
-/** The separators trimmed off each side of the `<prefix>_<name>` join. */
-const LEADING_SEPARATORS = /^[_.-]+/;
-const TRAILING_SEPARATORS = /[_.-]+$/;
-
-/**
- * Rewrites a server-chosen name into the identifier pattern providers accept.
- *
- * MCP puts no restriction on a tool name, while OpenAI and the other providers only accept
- * `[A-Za-z0-9_.-]` in a function name — so a server offering `search docs!` would otherwise turn
- * into a request the provider rejects. The rule is the reference implementations': Python's
- * `_normalize_mcp_name` and Go's `normalizeMCPName` both replace every other character with `-`,
- * so the same remote tool surfaces under the same name across the SDKs.
- */
-function normalizeToolName(name: string): string {
-  return name.replace(DISALLOWED_NAME_CHARACTERS, '-');
-}
-
-/** The name a tool is exposed to the model under, given the configured prefix. */
-function localToolName(remoteName: string, toolNamePrefix: string | undefined): string {
-  const normalized = normalizeToolName(remoteName);
-  if (toolNamePrefix === undefined) {
-    return normalized;
-  }
-  const prefix = normalizeToolName(toolNamePrefix).replace(TRAILING_SEPARATORS, '');
-  if (prefix === '') {
-    return normalized;
-  }
-  const trimmed = normalized.replace(LEADING_SEPARATORS, '');
-  return trimmed === '' ? prefix : `${prefix}_${trimmed}`;
-}
-
-/**
- * Copies a declared input schema into one every provider accepts.
- *
- * A tool that takes no arguments is commonly declared as a bare `{ "type": "object" }`, which
- * OpenAI answers with a 400 because the object form requires `properties`. Adding the empty map is
- * what Python's MCP loader does, and it says exactly what the server meant. A schema that is
- * absent altogether is treated as that same zero-argument declaration; Python leaves it as an
- * empty schema, which says nothing about the arguments at all. Any other schema is passed through.
- *
- * The copy is shallow — only the top-level `properties` key is ever written — so the schema the
- * server owns is left as it was; nothing nested is modified.
- */
-function normalizeInputSchema(schema: Record<string, unknown> | null | undefined): Record<string, unknown> {
-  if (schema === undefined || schema === null) {
-    return { type: 'object', properties: {} };
-  }
-  const normalized = { ...schema };
-  if (normalized.type === 'object' && !Object.hasOwn(normalized, 'properties')) {
-    normalized.properties = {};
-  }
-  return normalized;
 }
 
 function approvalModeFor(policy: ApprovalPolicy | undefined, toolName: string): ApprovalMode {

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -6,16 +6,11 @@ import type {
   SkillsSource,
   ToolContext,
 } from '@polymind-inc/agent-framework-core';
-import {
-  AgentFrameworkError,
-  ConfigurationError,
-  ToolInvocationError,
-  tool,
-} from '@polymind-inc/agent-framework-core';
+import { ConfigurationError, ToolInvocationError, tool } from '@polymind-inc/agent-framework-core';
 import { errorMessageOf } from '@polymind-inc/agent-framework-core/internal';
 import { McpConnection } from './connection.js';
 import { callToolFailure, contentsOfCallToolResult, mcpMetaProperties } from './content.js';
-import { localToolName, normalizeInputSchema } from './declarations.js';
+import { claimLocalName, localToolName, normalizeInputSchema } from './declarations.js';
 import type { McpHeaderProvider } from './headers.js';
 import type { McpSkillsSourceConfig } from './skills.js';
 import { mcpSkillsSource } from './skills.js';
@@ -237,21 +232,10 @@ export class McpClient {
         continue;
       }
       const localName = localToolName(entry.name, this.#config.toolNamePrefix);
-      const claimedBy = remoteByLocalName.get(localName);
-      if (claimedBy !== undefined) {
-        if (claimedBy !== entry.name) {
-          throw new AgentFrameworkError(
-            `MCP server ${this.#target} advertises two tools whose exposed name is the same ` +
-              `"${localName}": "${claimedBy}" and "${entry.name}". Both cannot be offered to the ` +
-              'model, so neither is: restrict `allowedTools` to one of them, or have the server ' +
-              'rename one.',
-          );
-        }
-        // The same tool listed twice names the same target, so the first entry stands. Offering it
-        // twice would be the duplicate-name rejection this normalization exists to avoid.
+      const claim = claimLocalName(remoteByLocalName, localName, entry.name, `MCP server ${this.#target}`);
+      if (claim === 'duplicate') {
         continue;
       }
-      remoteByLocalName.set(localName, entry.name);
       exposed.push(this.#toFunctionTool(entry, localName));
     }
     return exposed;

--- a/packages/mcp/src/declarations.ts
+++ b/packages/mcp/src/declarations.ts
@@ -67,8 +67,9 @@ export function localToolName(remoteName: string, toolNamePrefix: string | undef
  * A tool that takes no arguments is commonly declared as a bare `{ "type": "object" }`, which
  * OpenAI answers with a 400 because the object form requires `properties`. Adding the empty map is
  * what Python's MCP loader does, and it says exactly what the server meant. A schema that is
- * absent altogether is treated as that same zero-argument declaration; Python leaves it as an
- * empty schema, which says nothing about the arguments at all. Any other schema is passed through.
+ * absent altogether gets that same zero-argument declaration here — a deliberate divergence from
+ * Python, which leaves it as an empty schema that says nothing about the arguments at all. Any
+ * other schema is passed through.
  *
  * The copy is shallow — only the top-level `properties` key is ever written — so the schema the
  * server owns is left as it was; nothing nested is modified.

--- a/packages/mcp/src/declarations.ts
+++ b/packages/mcp/src/declarations.ts
@@ -1,11 +1,11 @@
 /**
  * How an MCP tool declaration becomes one a model provider accepts.
  *
- * Two rules, shared by every consumer of a `tools/list` result — the MCP client and the Foundry
- * toolbox, which speaks MCP over its own connection — so the same remote tool surfaces under the
- * same name and schema wherever it is loaded from, and a defect fixed in one place cannot survive
- * in a copy.
+ * Shared by every consumer of a `tools/list` result — the MCP client and the Foundry toolbox,
+ * which speaks MCP over its own connection — so the same remote tool surfaces under the same name
+ * and schema wherever it is loaded from, and a defect fixed in one place cannot survive in a copy.
  */
+import { AgentFrameworkError } from '@polymind-inc/agent-framework-core';
 
 /** Characters a provider accepts in a function name; everything else normalizes to `-`. */
 const DISALLOWED_NAME_CHARACTERS = /[^A-Za-z0-9_.-]/g;
@@ -15,9 +15,10 @@ const SEPARATORS = new Set(['_', '.', '-']);
 /**
  * Trims separators off one end of a name.
  *
- * A scan rather than an anchored `[_.-]+` regex: the name is server-chosen, and end-anchored
- * repetition backtracks polynomially on a long run of separators, which would let a hostile
- * declaration stall the loader.
+ * A scan rather than an anchored `[_.-]+` regex: the name is server-chosen, and `replace` retries
+ * an end-anchored pattern at every start position, rescanning a long separator run once per
+ * position — quadratic overall even though each attempt is linear, which is what lets a hostile
+ * declaration stall the loader. The scan reads each character once.
  */
 function trimSeparators(value: string, from: 'start' | 'end'): string {
   if (from === 'start') {
@@ -45,6 +46,39 @@ function trimSeparators(value: string, from: 'start' | 'end'): string {
  */
 function normalizeToolName(name: string): string {
   return name.replace(DISALLOWED_NAME_CHARACTERS, '-');
+}
+
+/**
+ * Claims one exposed name for a remote tool, refusing a collision.
+ *
+ * Normalization can land two different remote names on the same exposed name (`a b` and `a-b`
+ * both become `a-b`). Silently keeping one would make the other unreachable, and which one
+ * survived would depend on the order the server happened to list them in — so a collision throws,
+ * naming both remote tools. The same remote name listed twice names the same target; its later
+ * copies answer `'duplicate'` so the caller skips them, since offering the name twice is the
+ * duplicate-name rejection the normalization exists to avoid.
+ *
+ * `origin` names the tool source in the error — the MCP server, or the Foundry toolbox.
+ */
+export function claimLocalName(
+  claims: Map<string, string>,
+  localName: string,
+  remoteName: string,
+  origin: string,
+): 'claimed' | 'duplicate' {
+  const claimedBy = claims.get(localName);
+  if (claimedBy === undefined) {
+    claims.set(localName, remoteName);
+    return 'claimed';
+  }
+  if (claimedBy === remoteName) {
+    return 'duplicate';
+  }
+  throw new AgentFrameworkError(
+    `${origin} advertises two tools whose exposed name is the same "${localName}": ` +
+      `"${claimedBy}" and "${remoteName}". Both cannot be offered to the model, so neither is: ` +
+      'restrict `allowedTools` to one of them, or have the server rename one.',
+  );
 }
 
 /** The name a tool is exposed to the model under, given the configured prefix. */

--- a/packages/mcp/src/declarations.ts
+++ b/packages/mcp/src/declarations.ts
@@ -1,0 +1,66 @@
+/**
+ * How an MCP tool declaration becomes one a model provider accepts.
+ *
+ * Two rules, shared by every consumer of a `tools/list` result — the MCP client and the Foundry
+ * toolbox, which speaks MCP over its own connection — so the same remote tool surfaces under the
+ * same name and schema wherever it is loaded from, and a defect fixed in one place cannot survive
+ * in a copy.
+ */
+
+/** Characters a provider accepts in a function name; everything else normalizes to `-`. */
+const DISALLOWED_NAME_CHARACTERS = /[^A-Za-z0-9_.-]/g;
+/** The separators trimmed off each side of the `<prefix>_<name>` join. */
+const LEADING_SEPARATORS = /^[_.-]+/;
+const TRAILING_SEPARATORS = /[_.-]+$/;
+
+/**
+ * Rewrites a server-chosen name into the identifier pattern providers accept.
+ *
+ * MCP puts no restriction on a tool name, while OpenAI and the other providers only accept
+ * `[A-Za-z0-9_.-]` in a function name — so a server offering `search docs!` would otherwise turn
+ * into a request the provider rejects. The rule is the reference implementations': Python's
+ * `_normalize_mcp_name` and Go's `normalizeMCPName` both replace every other character with `-`,
+ * so the same remote tool surfaces under the same name across the SDKs.
+ */
+function normalizeToolName(name: string): string {
+  return name.replace(DISALLOWED_NAME_CHARACTERS, '-');
+}
+
+/** The name a tool is exposed to the model under, given the configured prefix. */
+export function localToolName(remoteName: string, toolNamePrefix: string | undefined): string {
+  const normalized = normalizeToolName(remoteName);
+  if (toolNamePrefix === undefined) {
+    return normalized;
+  }
+  const prefix = normalizeToolName(toolNamePrefix).replace(TRAILING_SEPARATORS, '');
+  if (prefix === '') {
+    return normalized;
+  }
+  const trimmed = normalized.replace(LEADING_SEPARATORS, '');
+  return trimmed === '' ? prefix : `${prefix}_${trimmed}`;
+}
+
+/**
+ * Copies a declared input schema into one every provider accepts.
+ *
+ * A tool that takes no arguments is commonly declared as a bare `{ "type": "object" }`, which
+ * OpenAI answers with a 400 because the object form requires `properties`. Adding the empty map is
+ * what Python's MCP loader does, and it says exactly what the server meant. A schema that is
+ * absent altogether is treated as that same zero-argument declaration; Python leaves it as an
+ * empty schema, which says nothing about the arguments at all. Any other schema is passed through.
+ *
+ * The copy is shallow — only the top-level `properties` key is ever written — so the schema the
+ * server owns is left as it was; nothing nested is modified.
+ */
+export function normalizeInputSchema(
+  schema: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  if (schema === undefined || schema === null) {
+    return { type: 'object', properties: {} };
+  }
+  const normalized = { ...schema };
+  if (normalized.type === 'object' && !Object.hasOwn(normalized, 'properties')) {
+    normalized.properties = {};
+  }
+  return normalized;
+}

--- a/packages/mcp/src/declarations.ts
+++ b/packages/mcp/src/declarations.ts
@@ -10,8 +10,29 @@
 /** Characters a provider accepts in a function name; everything else normalizes to `-`. */
 const DISALLOWED_NAME_CHARACTERS = /[^A-Za-z0-9_.-]/g;
 /** The separators trimmed off each side of the `<prefix>_<name>` join. */
-const LEADING_SEPARATORS = /^[_.-]+/;
-const TRAILING_SEPARATORS = /[_.-]+$/;
+const SEPARATORS = new Set(['_', '.', '-']);
+
+/**
+ * Trims separators off one end of a name.
+ *
+ * A scan rather than an anchored `[_.-]+` regex: the name is server-chosen, and end-anchored
+ * repetition backtracks polynomially on a long run of separators, which would let a hostile
+ * declaration stall the loader.
+ */
+function trimSeparators(value: string, from: 'start' | 'end'): string {
+  if (from === 'start') {
+    let start = 0;
+    while (start < value.length && SEPARATORS.has(value[start] as string)) {
+      start++;
+    }
+    return value.slice(start);
+  }
+  let end = value.length;
+  while (end > 0 && SEPARATORS.has(value[end - 1] as string)) {
+    end--;
+  }
+  return value.slice(0, end);
+}
 
 /**
  * Rewrites a server-chosen name into the identifier pattern providers accept.
@@ -32,11 +53,11 @@ export function localToolName(remoteName: string, toolNamePrefix: string | undef
   if (toolNamePrefix === undefined) {
     return normalized;
   }
-  const prefix = normalizeToolName(toolNamePrefix).replace(TRAILING_SEPARATORS, '');
+  const prefix = trimSeparators(normalizeToolName(toolNamePrefix), 'end');
   if (prefix === '') {
     return normalized;
   }
-  const trimmed = normalized.replace(LEADING_SEPARATORS, '');
+  const trimmed = trimSeparators(normalized, 'start');
   return trimmed === '' ? prefix : `${prefix}_${trimmed}`;
 }
 

--- a/packages/mcp/src/internal.ts
+++ b/packages/mcp/src/internal.ts
@@ -10,3 +10,4 @@
 
 export type { CallToolResultShape } from './content.js';
 export { callToolFailure, contentsOfCallToolResult } from './content.js';
+export { localToolName, normalizeInputSchema } from './declarations.js';

--- a/packages/mcp/src/internal.ts
+++ b/packages/mcp/src/internal.ts
@@ -10,4 +10,4 @@
 
 export type { CallToolResultShape } from './content.js';
 export { callToolFailure, contentsOfCallToolResult } from './content.js';
-export { localToolName, normalizeInputSchema } from './declarations.js';
+export { claimLocalName, localToolName, normalizeInputSchema } from './declarations.js';

--- a/packages/meta/src/foundry-toolbox-openai-tools.test.ts
+++ b/packages/meta/src/foundry-toolbox-openai-tools.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Cross-package check: what `FoundryToolbox` exposes is what the OpenAI request conversion accepts.
+ *
+ * The foundry and openai packages never validate each other's shapes, so this lives in the
+ * umbrella package, the one that depends on both. The toolbox shares the MCP package's
+ * declaration rules; this test carries a declaration the rest of the way, into the Responses
+ * request body a provider would receive — the same journey `mcp-openai-tools.test.ts` covers for
+ * `McpClient`, pinned separately so the two loaders cannot drift apart.
+ */
+import { textContent } from '@polymind-inc/agent-framework-core';
+import { FoundryProject } from '@polymind-inc/agent-framework-foundry';
+import { FoundryToolbox } from '@polymind-inc/agent-framework-foundry/hosting';
+import { McpConnection } from '@polymind-inc/agent-framework-mcp';
+import { OpenAIChatClient } from '@polymind-inc/agent-framework-openai';
+import { describe, expect, it, vi } from 'vitest';
+
+/** A Responses tool declaration, as far as these assertions read it. */
+interface ToolDeclaration {
+  type?: string;
+  name?: string;
+  parameters?: Record<string, unknown>;
+}
+
+type ListToolsResult = Awaited<ReturnType<McpConnection['listTools']>>;
+
+// Structurally a TokenCredential; the meta package does not depend on @azure/identity itself.
+const credential = {
+  async getToken(): Promise<{ token: string; expiresOnTimestamp: number }> {
+    return { token: 'test-token', expiresOnTimestamp: Date.now() + 3_600_000 };
+  },
+};
+
+describe('Foundry toolbox tools through the OpenAI request conversion', () => {
+  it('declares a zero-argument toolbox tool in the shape the Responses API accepts', async () => {
+    // What a zero-argument tool looks like as MCP declares it: `properties` omitted, and a name
+    // no provider accepts as a function name. Either one passed through is a 400.
+    const listTools = vi.spyOn(McpConnection.prototype, 'listTools').mockResolvedValue({
+      tools: [{ name: 'search docs!', description: 'Search the docs', inputSchema: { type: 'object' } }],
+    } as unknown as ListToolsResult);
+    const toolbox = new FoundryToolbox({
+      name: 'my-toolbox',
+      project: new FoundryProject(
+        'https://my-resource.services.ai.azure.com/api/projects/my-project',
+        credential,
+      ),
+    });
+    try {
+      const tools = await toolbox.getTools();
+      const client = new OpenAIChatClient({ apiKey: 'test-key', model: 'gpt-4o' });
+
+      const request = client.buildRequest([{ role: 'user', contents: [textContent('hi')] }], { tools });
+
+      const declared = (request.tools as ToolDeclaration[]).find((entry) => entry.type === 'function');
+      expect(declared?.name).toBe('search-docs-');
+      expect(declared?.parameters).toEqual({
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      });
+    } finally {
+      await toolbox.close();
+      listTools.mockRestore();
+    }
+  });
+});

--- a/packages/meta/src/foundry-toolbox-openai-tools.test.ts
+++ b/packages/meta/src/foundry-toolbox-openai-tools.test.ts
@@ -37,14 +37,16 @@ describe('Foundry toolbox tools through the OpenAI request conversion', () => {
     const listTools = vi.spyOn(McpConnection.prototype, 'listTools').mockResolvedValue({
       tools: [{ name: 'search docs!', description: 'Search the docs', inputSchema: { type: 'object' } }],
     } as unknown as ListToolsResult);
-    const toolbox = new FoundryToolbox({
-      name: 'my-toolbox',
-      project: new FoundryProject(
-        'https://my-resource.services.ai.azure.com/api/projects/my-project',
-        credential,
-      ),
-    });
+    // Constructed inside the try: a construction failure must still restore the prototype spy.
+    let toolbox: FoundryToolbox | undefined;
     try {
+      toolbox = new FoundryToolbox({
+        name: 'my-toolbox',
+        project: new FoundryProject(
+          'https://my-resource.services.ai.azure.com/api/projects/my-project',
+          credential,
+        ),
+      });
       const tools = await toolbox.getTools();
       const client = new OpenAIChatClient({ apiKey: 'test-key', model: 'gpt-4o' });
 
@@ -58,7 +60,7 @@ describe('Foundry toolbox tools through the OpenAI request conversion', () => {
         additionalProperties: false,
       });
     } finally {
-      await toolbox.close();
+      await toolbox?.close();
       listTools.mockRestore();
     }
   });


### PR DESCRIPTION
## What this changes

`FoundryToolbox` now exposes tool declarations through the same name-normalization and schema-normalization rules `McpClient` uses — shared via the mcp package's `/internal` entry rather than copied a third time — and gains `toolNamePrefix`, the `McpClientConfig` counterpart. Closes #120.

## Parity

- Reference checked: Python `_normalize_mcp_name` and Go `normalizeMCPName` (every character outside `[A-Za-z0-9_.-]` becomes `-`) and Python's MCP loader schema handling (a bare object schema gains the empty `properties` map) — the same references the `McpClient` implementation already cites; the point of this PR is that the toolbox now runs that one implementation. Python's `FoundryToolbox` extends its plain MCP tool and has no second mapping to drift.
- Wire format affected: yes
- Public API affected: yes

The three decisions the issue gates on: (1) `toolNamePrefix` is added, owner-approved, with the joining rules shared with `McpClient`; (2) a normalization collision (two remote names landing on one exposed name) is refused: review caught that `McpClient.getTools()` already throws on it — the original description here claimed otherwise, wrongly — so the claim rule is extracted to the shared `claimLocalName` and both loaders run it, a collision throwing with both remote names and a same-name duplicate listing keeping its first entry; (3) consent/approval correlation was verified to ride on the call id and `ficc_` framework ids, never tool names — a test pins that a renamed tool still raises the typed consent refusal while the wire carries the remote name. The exposed-name change only affects names that previously produced a provider 400, so nothing that worked changes. A declaration missing `inputSchema` entirely cannot reach the toolbox (the MCP SDK's own `tools/list` validation refuses it), so that branch is pinned on the `McpClient` side only. The cross-package check that a toolbox declaration passes the OpenAI request conversion lives in the meta package, which depends on both.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
