### PR TITLE
Omit an unanswered tool call from the Anthropic request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ contain breaking changes**; patch releases are fixes only.
   tool answered after the session was saved — and the OpenAI conversion already filters them the
   same way, so one rule now governs both providers. A call answered in a later message is kept, a
   call with an empty `callId` is always omitted, and `FunctionCallContent` and serialized sessions
-  are never rewritten — the call stays in the transcript and only leaves the wire. A request that
+  are never rewritten — the call stays in the transcript; it just never goes on the wire. A request that
   used to fail with the 400 above now goes through without the dangling call.
 
 - **`@polymind-inc/agent-framework-core`** — a skill script no longer receives `null` as its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **`@polymind-inc/agent-framework-anthropic`** — a `function_call` that no `function_result`
+  anywhere in the transcript answers is omitted from the request instead of being sent as a
+  `tool_use` the Messages API refuses with a 400 (`Each tool_use block must have a corresponding
+  tool_result block`, measured 2026-08-31). Transcripts legitimately hold such calls — an approval
+  pause, the iteration limit, an abandoned stream, a fatal middleware abort, a declaration-only
+  tool answered after the session was saved — and the OpenAI conversion already filters them the
+  same way, so one rule now governs both providers. A call answered in a later message is kept, a
+  call with an empty `callId` is always omitted, and `FunctionCallContent` and serialized sessions
+  are never rewritten — the call stays in the transcript and only leaves the wire. A request that
+  used to fail with the 400 above now goes through without the dangling call.
+
 - **`@polymind-inc/agent-framework-core`** — a skill script no longer receives `null` as its
   arguments. The `run_skill_script` tool's schema lets a model send an explicit `null` — the
   advertised default — and that value used to be handed to `SkillScript.run` even though the

--- a/packages/anthropic/README.md
+++ b/packages/anthropic/README.md
@@ -60,6 +60,22 @@ the model like a call with `raw` set. Rename the parameter if that ambiguity mat
 `FunctionCallContent.arguments` and serialized sessions are never rewritten — this applies only to
 what goes on the wire.
 
+## Tool calls without a result
+
+The Messages API refuses a transcript in which a `tool_use` has no matching `tool_result`, with a
+400 naming the call. A transcript legitimately reaches that state: an approval pause suspends the
+run with the call unanswered, the iteration limit ends a round holding calls it will not execute, a
+caller abandons a stream partway, a middleware aborts the batch, or a declaration-only tool hands
+its call back to the caller who saves the session before answering.
+
+The conversion therefore omits a `function_call` that no `function_result` anywhere in the
+transcript answers — the same send-time filtering the OpenAI conversion applies, so one rule
+governs every provider. A call whose result arrives in a later message is kept; a call with an
+empty `callId` is always omitted, because an empty id is not a pairable identity. As with argument
+handling, `FunctionCallContent` and serialized sessions are never rewritten: the call stays in your
+transcript, it just does not go on the wire. Previously such a transcript was sent as-is and the
+API rejected the whole request.
+
 ---
 
 Part of [Agent Framework for TypeScript](https://github.com/polymind-inc/agent-framework-js) — an

--- a/packages/anthropic/src/chat-client.test.ts
+++ b/packages/anthropic/src/chat-client.test.ts
@@ -486,12 +486,14 @@ describe('message conversion', () => {
     });
 
     it('keeps a call whose result arrives in a later message', () => {
+      // The answered-call scan covers the whole transcript, not just the message holding the
+      // call: the result living in the following tool message — the ordinary shape — must keep
+      // the call on the wire.
       const converted = toAnthropicMessages([
         {
           role: 'assistant',
           contents: [{ type: 'function_call', callId: 'c1', name: 'search', arguments: { q: 'x' } }],
         },
-        { role: 'user', contents: [textContent('a nudge in between')] },
         { role: 'tool', contents: [{ type: 'function_result', callId: 'c1', result: 'found' }] },
       ]);
 

--- a/packages/anthropic/src/chat-client.test.ts
+++ b/packages/anthropic/src/chat-client.test.ts
@@ -516,9 +516,10 @@ describe('message conversion', () => {
       expect(converted).toEqual([{ role: 'user', content: [{ type: 'text', text: 'hi' }] }]);
     });
 
-    it('drops a call with an empty callId even when an empty-id result exists', () => {
+    it('drops both halves of an empty-callId exchange', () => {
       // An empty id is not an identity: the OpenAI conversion refuses to treat two '' as a pair,
-      // and this conversion follows the same rule.
+      // and this conversion follows the same rule — for the result as much as the call, since a
+      // `tool_result` whose call was omitted is the same unpairable shape from the other side.
       const converted = toAnthropicMessages([
         {
           role: 'assistant',
@@ -529,6 +530,7 @@ describe('message conversion', () => {
 
       const blocks = converted.flatMap((m) => (Array.isArray(m.content) ? m.content : []));
       expect(blocks).not.toContainEqual(expect.objectContaining({ type: 'tool_use' }));
+      expect(blocks).not.toContainEqual(expect.objectContaining({ type: 'tool_result' }));
     });
 
     it('does not mutate the transcript it filters', () => {

--- a/packages/anthropic/src/chat-client.test.ts
+++ b/packages/anthropic/src/chat-client.test.ts
@@ -414,16 +414,21 @@ describe('message conversion', () => {
         { type: 'function_call', callId: 'c2', name: 'search', arguments: '"text"' },
       ],
     };
+    const results: Message = {
+      role: 'tool',
+      contents: [
+        { type: 'function_result', callId: 'c1', result: 'a' },
+        { type: 'function_result', callId: 'c2', result: 'b' },
+      ],
+    };
 
-    expect(toAnthropicMessages([calls])).toEqual([
-      {
-        role: 'assistant',
-        content: [
-          { type: 'tool_use', id: 'c1', name: 'search', input: { raw: [] } },
-          { type: 'tool_use', id: 'c2', name: 'search', input: { raw: 'text' } },
-        ],
-      },
-    ]);
+    expect(toAnthropicMessages([calls, results])[0]).toEqual({
+      role: 'assistant',
+      content: [
+        { type: 'tool_use', id: 'c1', name: 'search', input: { raw: [] } },
+        { type: 'tool_use', id: 'c2', name: 'search', input: { raw: 'text' } },
+      ],
+    });
   });
 
   it('splits a mixed message into the roles the API requires', () => {
@@ -452,16 +457,88 @@ describe('message conversion', () => {
     expect(converted.at(-1)).toEqual({ role: 'user', content: 'Continue' });
   });
 
-  it('leaves a pending tool call as the last turn, so the pairing survives', () => {
-    const converted = toAnthropicMessages([
-      { role: 'user', contents: [textContent('hi')] },
-      {
+  describe('unanswered tool calls are dropped at send time', () => {
+    // The Messages API refuses a transcript holding a `tool_use` with no `tool_result` — measured
+    // 2026-08-31: "Each `tool_use` block must have a corresponding `tool_result` block." A
+    // transcript legitimately reaches that state (an approval pause, the iteration limit, an
+    // abandoned stream, a fatal middleware abort, a declaration-only tool handed back to the
+    // caller), so the conversion removes the one block the API cannot accept instead of letting
+    // the request fail — the same send-time filtering the OpenAI conversion applies.
+
+    it('omits an unanswered call while keeping the rest of the transcript', () => {
+      const messages: Message[] = [
+        { role: 'user', contents: [textContent('hi')] },
+        {
+          role: 'assistant',
+          contents: [
+            textContent('let me check'),
+            { type: 'function_call', callId: 'c1', name: 'search', arguments: { q: 'x' } },
+          ],
+        },
+        { role: 'user', contents: [textContent('never mind')] },
+      ];
+
+      expect(toAnthropicMessages(messages)).toEqual([
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'let me check' }] },
+        { role: 'user', content: [{ type: 'text', text: 'never mind' }] },
+      ]);
+    });
+
+    it('keeps a call whose result arrives in a later message', () => {
+      const converted = toAnthropicMessages([
+        {
+          role: 'assistant',
+          contents: [{ type: 'function_call', callId: 'c1', name: 'search', arguments: { q: 'x' } }],
+        },
+        { role: 'user', contents: [textContent('a nudge in between')] },
+        { role: 'tool', contents: [{ type: 'function_result', callId: 'c1', result: 'found' }] },
+      ]);
+
+      expect(converted[0]).toEqual({
         role: 'assistant',
-        contents: [{ type: 'function_call', callId: 'call_1', name: 'search', arguments: {} }],
-      },
-    ]);
-    expect(converted).toHaveLength(2);
-    expect(converted.at(-1)?.role).toBe('assistant');
+        content: [{ type: 'tool_use', id: 'c1', name: 'search', input: { q: 'x' } }],
+      });
+    });
+
+    it('drops a trailing pending call and closes the transcript on a user turn', () => {
+      // The pending call used to be left as the last turn; sending it is exactly the pairing the
+      // API refuses, so the call is dropped and the assistant turn that held only that call
+      // disappears with it.
+      const converted = toAnthropicMessages([
+        { role: 'user', contents: [textContent('hi')] },
+        {
+          role: 'assistant',
+          contents: [{ type: 'function_call', callId: 'call_1', name: 'search', arguments: {} }],
+        },
+      ]);
+
+      expect(converted).toEqual([{ role: 'user', content: [{ type: 'text', text: 'hi' }] }]);
+    });
+
+    it('drops a call with an empty callId even when an empty-id result exists', () => {
+      // An empty id is not an identity: the OpenAI conversion refuses to treat two '' as a pair,
+      // and this conversion follows the same rule.
+      const converted = toAnthropicMessages([
+        {
+          role: 'assistant',
+          contents: [{ type: 'function_call', callId: '', name: 'search', arguments: {} }],
+        },
+        { role: 'tool', contents: [{ type: 'function_result', callId: '', result: 'found' }] },
+      ]);
+
+      const blocks = converted.flatMap((m) => (Array.isArray(m.content) ? m.content : []));
+      expect(blocks).not.toContainEqual(expect.objectContaining({ type: 'tool_use' }));
+    });
+
+    it('does not mutate the transcript it filters', () => {
+      const call: Content = { type: 'function_call', callId: 'c1', name: 'search', arguments: {} };
+      const messages: Message[] = [{ role: 'assistant', contents: [call] }];
+
+      toAnthropicMessages(messages);
+
+      expect(messages[0]?.contents).toEqual([call]);
+    });
   });
 
   it('drops empty text, which the API rejects', () => {

--- a/packages/anthropic/src/to-anthropic.ts
+++ b/packages/anthropic/src/to-anthropic.ts
@@ -365,8 +365,8 @@ function hasToolUse(msg: AnthropicMessage): boolean {
  * Converts the framework transcript into the Messages API `messages` array.
  *
  * A leading system message is *not* included: it belongs in the `system` request parameter (see
- * {@link toAnthropicSystem}). A local `function_call` no result in the transcript answers is
- * omitted — see the `function_call` case in {@link appendContent}. A conversation that would end
+ * {@link toAnthropicSystem}). A local `function_call` that no `function_result` in the transcript
+ * answers is omitted — see the `function_call` case in {@link appendContent}. A conversation that would end
  * on an assistant turn gets a synthetic `"Continue"` user turn, because Messages API requires the
  * last message to be a user one — unless that turn still holds a `tool_use` block (a hosted or
  * raw-replayed call), where appending would break the call/result pairing (Python

--- a/packages/anthropic/src/to-anthropic.ts
+++ b/packages/anthropic/src/to-anthropic.ts
@@ -220,7 +220,7 @@ function appendContent(blocks: AnthropicBlock[], content: Content, answered: Rea
       return;
     }
     case 'function_call': {
-      // A call no `function_result` anywhere in the transcript answers is omitted: the Messages
+      // A call that no `function_result` anywhere in the transcript answers is omitted: the Messages
       // API refuses the request outright when a `tool_use` has no `tool_result` — so the choice is
       // not between sending and filtering but between a defined omission and a provider 400. A
       // transcript legitimately holds such a call (an approval pause, the iteration limit, an

--- a/packages/anthropic/src/to-anthropic.ts
+++ b/packages/anthropic/src/to-anthropic.ts
@@ -13,7 +13,12 @@ import {
   serializeContent,
   textOfContents,
 } from '@polymind-inc/agent-framework-core';
-import { isRecord, safeStringify, topLevelMediaType } from '@polymind-inc/agent-framework-core/internal';
+import {
+  answeredCallIds,
+  isRecord,
+  safeStringify,
+  topLevelMediaType,
+} from '@polymind-inc/agent-framework-core/internal';
 import { MCP_SERVER_SPEC_TYPE } from './hosted-tools.js';
 
 /** A Messages API content block, kept loose so unmodelled block types pass through. */
@@ -174,7 +179,7 @@ function providerExecutedBlock(content: Content): AnthropicBlock | undefined {
  * the `thinking` block before it instead of producing one of its own (Python
  * `_prepare_message_for_anthropic`).
  */
-function appendContent(blocks: AnthropicBlock[], content: Content): void {
+function appendContent(blocks: AnthropicBlock[], content: Content, answered: ReadonlySet<string>): void {
   const providerExecuted = providerExecutedBlock(content);
   if (providerExecuted !== undefined) {
     blocks.push(providerExecuted);
@@ -215,6 +220,16 @@ function appendContent(blocks: AnthropicBlock[], content: Content): void {
       return;
     }
     case 'function_call': {
+      // A call no `function_result` anywhere in the transcript answers is omitted: the Messages
+      // API refuses the request outright when a `tool_use` has no `tool_result` — so the choice is
+      // not between sending and filtering but between a defined omission and a provider 400. A
+      // transcript legitimately holds such a call (an approval pause, the iteration limit, an
+      // abandoned stream, a fatal middleware abort, a declaration-only tool), and the OpenAI
+      // conversion already filters it the same way, so one rule governs every provider. An empty
+      // callId is never a pairable identity and is dropped on the same grounds.
+      if (content.callId === '' || !answered.has(content.callId)) {
+        return;
+      }
       blocks.push({
         type: 'tool_use',
         id: content.callId,
@@ -302,11 +317,11 @@ function roleForBlock(block: AnthropicBlock, fallback: 'user' | 'assistant'): 'u
  * framework models a whole exchange as content — but Messages API insists that tool calls are
  * assistant turns and results are user turns (Python `_prepare_message_groups_for_anthropic`).
  */
-function messageGroups(msg: Message): AnthropicMessage[] {
+function messageGroups(msg: Message, answered: ReadonlySet<string>): AnthropicMessage[] {
   const fallback = ROLE_MAP[msg.role] ?? 'user';
   const blocks: AnthropicBlock[] = [];
   for (const content of msg.contents) {
-    appendContent(blocks, content);
+    appendContent(blocks, content, answered);
   }
   if (blocks.length === 0) {
     return [];
@@ -344,16 +359,20 @@ function hasToolUse(msg: AnthropicMessage): boolean {
  * Converts the framework transcript into the Messages API `messages` array.
  *
  * A leading system message is *not* included: it belongs in the `system` request parameter (see
- * {@link toAnthropicSystem}). A conversation that would end on an assistant turn gets a synthetic
- * `"Continue"` user turn, because Messages API requires the last message to be a user one — unless
- * that turn is a pending tool call, where appending would break the call/result pairing (Python
+ * {@link toAnthropicSystem}). A local `function_call` no result in the transcript answers is
+ * omitted — see the `function_call` case in {@link appendContent}. A conversation that would end
+ * on an assistant turn gets a synthetic `"Continue"` user turn, because Messages API requires the
+ * last message to be a user one — unless that turn still holds a `tool_use` block (a hosted or
+ * raw-replayed call), where appending would break the call/result pairing (Python
  * `_prepare_messages_for_anthropic`).
  */
 export function toAnthropicMessages(messages: readonly Message[]): AnthropicMessage[] {
   const rest = messages[0]?.role === 'system' ? messages.slice(1) : messages;
+  // Collected across the whole transcript, so a call answered in a later message stays a call.
+  const answered = answeredCallIds(rest);
   const out: AnthropicMessage[] = [];
   for (const msg of rest) {
-    out.push(...messageGroups(msg));
+    out.push(...messageGroups(msg, answered));
   }
   const last = out[out.length - 1];
   if (last !== undefined && last.role === 'assistant' && !hasToolUse(last)) {

--- a/packages/anthropic/src/to-anthropic.ts
+++ b/packages/anthropic/src/to-anthropic.ts
@@ -239,6 +239,12 @@ function appendContent(blocks: AnthropicBlock[], content: Content, answered: Rea
       return;
     }
     case 'function_result': {
+      // The same grounds the empty-id call is dropped on: an empty id is not a pairable
+      // identity, and with its call omitted above this `tool_result` would answer nothing —
+      // exactly the shape the API refuses from the other direction.
+      if (content.callId === '') {
+        return;
+      }
       blocks.push({
         type: 'tool_result',
         tool_use_id: content.callId,

--- a/packages/anthropic/src/to-anthropic.wire-fallbacks.test.ts
+++ b/packages/anthropic/src/to-anthropic.wire-fallbacks.test.ts
@@ -20,8 +20,16 @@ function blocksOf(contents: Message['contents']): Record<string, unknown>[] {
 
 describe('tool_use input parsing', () => {
   function inputOf(args: Record<string, unknown> | string): unknown {
-    const [block] = blocksOf([{ type: 'function_call', callId: 'c1', name: 'f', arguments: args }]);
-    return block?.input;
+    // Answered in a later message, because an unanswered call never reaches the wire at all.
+    const [first] = toAnthropicMessages([
+      {
+        role: 'assistant',
+        contents: [{ type: 'function_call', callId: 'c1', name: 'f', arguments: args }],
+      },
+      { role: 'tool', contents: [{ type: 'function_result', callId: 'c1', result: 'ok' }] },
+    ]);
+    if (first === undefined || typeof first.content === 'string') throw new Error('expected blocks');
+    return first.content[0]?.input;
   }
 
   it('parses a JSON object string back to the object the API wants', () => {
@@ -65,7 +73,7 @@ describe('tool_use input parsing', () => {
 
   it('leaves the source content untouched', () => {
     const content = { type: 'function_call', callId: 'c1', name: 'f', arguments: '[1,2]' } as const;
-    blocksOf([{ ...content }]);
+    blocksOf([{ ...content }, { type: 'function_result', callId: 'c1', result: 'ok' }]);
     expect(content.arguments).toBe('[1,2]');
   });
 });


### PR DESCRIPTION
## What this changes

The Anthropic conversion drops a `function_call` that no `function_result` anywhere in the transcript answers, instead of sending a `tool_use` the Messages API refuses with a 400. This is the decision #150 gates on, resolved as option 2 (drop), matching the OpenAI conversion's intentional send-time filtering. Closes #150.

## Parity

- Reference checked: Python `agent_framework_anthropic/_chat_client.py` (`_prepare_messages_for_anthropic` and the block grouping) has no unanswered-call handling — the same transcript fails at the API there too — so no reference has an opinion at this layer and the rule is this repository's own. The precedent followed is internal: the OpenAI conversion omits a `function_call` whose `callId` is empty or unanswered (pinned by the wire-conformance tests of #142), and this PR applies the identical predicate so one rule governs both providers. Synthesizing a result (option 1) would fabricate model-visible content asymmetrically with OpenAI; failing before the request (option 3) would re-introduce the hard-fail on legitimate transcripts the framework already rejected.
- Wire format affected: yes
- Public API affected: no
- Breaking change: no

Every listed producer of an unanswered call — approval pause, iteration limit, abandoned stream, fatal middleware abort, declaration-only tool — reduces to the same transcript state at the conversion, which the tests pin: an unanswered call is omitted while the rest of the transcript survives, a call answered in a later message is kept, a trailing pending call disappears with the assistant turn that held only it (and the synthetic `Continue` rule then applies correctly), an empty `callId` is always omitted, and the input transcript is not mutated. Two existing tests that pinned the old pass-through (`leaves a pending tool call as the last turn`) are rewritten as part of the recorded decision, not silently. A request that used to fail with the 400 now goes through without the dangling call — the migration note is in the Anthropic README and `CHANGELOG.md`.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)