### PR TITLE
Settle dangling tool calls when the service owns the transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ contain breaking changes**; patch releases are fixes only.
 
 ## Unreleased
 
+- **`@polymind-inc/agent-framework-core`** — dangling tool calls are settled when the service owns
+  the transcript. A fatal `MiddlewareFailed` abort — mid-round or during an approved-replay batch —
+  and the final over-budget round can leave `function_call`s that never produce a result; on a
+  service-managed conversation those calls sit on the service's side, and the next request over
+  that conversation is rejected by providers that require every call to be answered. The loop now
+  submits one error `function_result` per dangling call with `toolChoice: 'none'` before the abort
+  propagates, matching the reference implementation's settlement path, and advances the session's
+  persisted continuation to the settlement response so response-id chaining starts from the
+  endpoint whose chain includes the synthetic outputs — a conversation anchor the provider declares
+  stable stays put. The original failure still reaches the caller unchanged, a settlement failure
+  never masks it, nothing is sent when the framework owns the transcript, and the extra request
+  exists only on these failure paths. A run abandoned mid-stream is deliberately not settled: no
+  code runs on the consumer's behalf after it walks away, and issuing fresh requests from a
+  cancelled run would invert what cancellation means — the dangling state there is unchanged.
+
 - **`@polymind-inc/agent-framework-core`** — a skill script no longer receives `null` as its
   arguments. The `run_skill_script` tool's schema lets a model send an explicit `null` — the
   advertised default — and that value used to be handed to `SkillScript.run` even though the

--- a/packages/core/src/client/function-invocation.ts
+++ b/packages/core/src/client/function-invocation.ts
@@ -1,5 +1,5 @@
 import type { AgentSession } from '../agent/session.js';
-import { validateSafeInteger } from '../errors.js';
+import { MiddlewareFailed, validateSafeInteger } from '../errors.js';
 import type { FunctionMiddleware } from '../middleware/middleware.js';
 import { createResponseStream } from '../streaming/response-stream.js';
 import {
@@ -123,6 +123,30 @@ function withoutFunctionTools<TOptions extends ChatOptions>(options: TOptions): 
 /** The answer a run ends with when the iteration budget ran out before the model produced one. */
 const FUNCTION_INVOCATION_LIMIT_FALLBACK_TEXT =
   'Function invocation limit reached before a final answer could be produced.';
+
+/** The two strings a settlement `function_result` carries for one class of dangling call. */
+interface SettlementReport {
+  result: string;
+  exception: string;
+}
+
+/**
+ * What settlement reports for a call a fatal abort left unanswered.
+ *
+ * Verbatim from the reference implementation's `MiddlewareFailure` settlement path, marker
+ * included — a consumer that branches on `function_result.exception` reads the same string here
+ * as there, not this build's class name.
+ */
+const ABORTED_SETTLEMENT_REPORT: SettlementReport = {
+  result: 'Error: Tool execution was aborted by middleware before a result was produced.',
+  exception: 'MiddlewareFailure',
+};
+
+/** What settlement reports for a call the final, toolless round produced anyway. */
+const LIMIT_SETTLEMENT_REPORT: SettlementReport = {
+  result: 'Error: Function invocation limit reached before a result was produced.',
+  exception: 'FunctionInvocationLimitError',
+};
 
 /**
  * Content types that are an answer in themselves, alongside non-blank text.
@@ -436,6 +460,77 @@ export function createFunctionInvocationClientFactory<TOptions extends ChatOptio
   ): Promise<RoundOutcome> => runInvocationRound(calls, tools, errorCount, env, roundConfig);
 
   /**
+   * Resolves dangling calls on a service-managed conversation.
+   *
+   * A round can end holding calls that never produced a result — a fatal abort mid-batch, or the
+   * final toolless round producing calls anyway. While the framework owns the transcript that is
+   * harmless: the next request is assembled locally and the unanswerable call is filtered out. On
+   * a service-managed conversation the calls are on the *service's* side, the framework cannot
+   * filter them, and the next request over that conversation continues from them — which at least
+   * one provider rejects outright rather than tolerating.
+   *
+   * So the thread is settled with one error `function_result` per dangling call, sent with
+   * `toolChoice: 'none'` so the settlement request cannot ask for more calls, exactly as the
+   * reference implementation settles an aborted batch. The persisted continuation then advances
+   * to the settlement response: for response-id chaining that is the first endpoint whose chain
+   * includes the synthetic outputs, while an anchor the provider declares stable stays put. The
+   * settlement response is otherwise discarded. Everything here is best-effort — a settlement
+   * failure never replaces or masks the failure that caused it — and costs one extra request,
+   * only on this path and only when a service-managed conversation is in play.
+   */
+  async function settleDanglingServiceCalls(
+    calls: readonly FunctionCallContent[],
+    options: TOptions,
+    conversationId: string | undefined,
+    session: AgentSession | undefined,
+    report: SettlementReport,
+  ): Promise<void> {
+    if (conversationId === undefined || conversationId === '') {
+      return;
+    }
+    const contents: Content[] = [];
+    for (const call of calls) {
+      if (call.callId === '') {
+        continue;
+      }
+      contents.push({
+        type: 'function_result',
+        callId: call.callId,
+        result: report.result,
+        exception: report.exception,
+        ...(call.additionalProperties === undefined
+          ? {}
+          : { additionalProperties: call.additionalProperties }),
+      });
+    }
+    if (contents.length === 0) {
+      return;
+    }
+    try {
+      const settleOptions = { ...options, toolChoice: 'none', conversationId } as TOptions;
+      delete (settleOptions as ChatOptions).continuationToken;
+      const settled = await client.getResponse(
+        [{ role: 'tool', contents, messageId: crypto.randomUUID() }],
+        settleOptions,
+      );
+      const settledId = settled.conversationId;
+      const current = session?.serviceSessionId;
+      if (
+        session !== undefined &&
+        settledId !== undefined &&
+        settledId !== '' &&
+        settledId !== current &&
+        !(current !== undefined && client.metadata.stableConversationId?.(current) === true)
+      ) {
+        session.serviceSessionId = settledId;
+      }
+    } catch {
+      // Best-effort by design: a settlement failure must never replace or mask the failure that
+      // caused it. The next request over this conversation may still be rejected by the service.
+    }
+  }
+
+  /**
    * Resolves approval decisions the caller sent in with this run.
    *
    * Mirrors Go `processToolApprovalResponses`: approval request/response content is removed from
@@ -451,6 +546,7 @@ export function createFunctionInvocationClientFactory<TOptions extends ChatOptio
     messages: Message[],
     tools: Map<string, AnyFunctionTool>,
     env: InvocationEnv,
+    settleDanglingCalls?: (calls: readonly FunctionCallContent[]) => Promise<void>,
   ): Promise<
     | {
         history: Message[];
@@ -638,10 +734,20 @@ export function createFunctionInvocationClientFactory<TOptions extends ChatOptio
     const approved = decisions.filter((decision) => decision.approved).map((decision) => decision.call);
     let outcome: RoundOutcome | undefined;
     if (approved.length > 0) {
-      outcome = await runRound(approved, tools, 0, {
-        ...env,
-        approvedCallIds: new Set(approved.map((call) => call.callId)),
-      });
+      try {
+        outcome = await runRound(approved, tools, 0, {
+          ...env,
+          approvedCallIds: new Set(approved.map((call) => call.callId)),
+        });
+      } catch (error) {
+        if (error instanceof MiddlewareFailed) {
+          // Fail-closed abort during an approved replay: the calls belong to an earlier,
+          // already-persisted model turn, so a service-managed conversation is settled before
+          // the abort propagates (best-effort inside the callback).
+          await settleDanglingCalls?.(approved);
+        }
+        throw error;
+      }
       contents.push(...outcome.contents);
     }
 
@@ -713,6 +819,14 @@ export function createFunctionInvocationClientFactory<TOptions extends ChatOptio
       messages,
       buildToolMap(current.tools, additionalTools),
       env,
+      (approvedCalls) =>
+        settleDanglingServiceCalls(
+          approvedCalls,
+          current,
+          current.conversationId,
+          session,
+          ABORTED_SETTLEMENT_REPORT,
+        ),
     );
     // Calls resolved from inbound approvals are part of the same run, so their failures count
     // toward the same budget the loop below spends.
@@ -761,10 +875,16 @@ export function createFunctionInvocationClientFactory<TOptions extends ChatOptio
 
       const inner = client.getResponse(history, roundOptions);
       const updates: ChatResponseUpdate[] = [];
+      // Only the final round keeps its raw updates: what `retained` removed there is exactly what
+      // may need settling on a service-managed conversation below.
+      const rawUpdates: ChatResponseUpdate[] = [];
       let flushed = 0;
       let buffering = false;
       if (stream) {
         for await (const raw of inner) {
+          if (isFinalIteration) {
+            rawUpdates.push(raw);
+          }
           const update = retained(raw);
           if (update === undefined) {
             continue;
@@ -778,6 +898,9 @@ export function createFunctionInvocationClientFactory<TOptions extends ChatOptio
         }
       } else {
         for (const raw of chatResponseToUpdates(await inner)) {
+          if (isFinalIteration) {
+            rawUpdates.push(raw);
+          }
           const update = retained(raw);
           if (update !== undefined) {
             updates.push(update);
@@ -813,13 +936,41 @@ export function createFunctionInvocationClientFactory<TOptions extends ChatOptio
         if (!hasUserVisibleAnswer(roundResponse) && !hasHostedApprovalRequest(roundResponse)) {
           yield limitFallbackUpdate(roundResponse);
         }
+        // A call the model produced anyway was removed from what the caller sees — but on a
+        // service-managed conversation the service still holds it, so it is settled like an
+        // aborted batch, or the next run over this conversation is rejected.
+        const withdrawn = collectExecutableCalls(mergeChatUpdates(rawUpdates).messages);
+        if (withdrawn.length > 0) {
+          const settleId = optionsForNextIteration(
+            current,
+            roundResponse.conversationId,
+            client.metadata.stableConversationId,
+          ).conversationId;
+          await settleDanglingServiceCalls(withdrawn, current, settleId, session, LIMIT_SETTLEMENT_REPORT);
+        }
         return;
       }
       if (shouldStop(calls, tools)) {
         return;
       }
 
-      const outcome = await runRound(calls, tools, errorCount, env);
+      let outcome: RoundOutcome;
+      try {
+        outcome = await runRound(calls, tools, errorCount, env);
+      } catch (error) {
+        if (error instanceof MiddlewareFailed) {
+          // The batch aborted with its calls unanswered. On a service-managed conversation those
+          // calls sit on the service's side, where the next request continues from them — settle
+          // them before the abort propagates; the failure still reaches the caller unchanged.
+          const settleId = optionsForNextIteration(
+            current,
+            roundResponse.conversationId,
+            client.metadata.stableConversationId,
+          ).conversationId;
+          await settleDanglingServiceCalls(calls, current, settleId, session, ABORTED_SETTLEMENT_REPORT);
+        }
+        throw error;
+      }
       const contents = outcome.contents;
       errorCount = outcome.errorCount;
 

--- a/packages/core/src/client/function-settlement.test.ts
+++ b/packages/core/src/client/function-settlement.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Settling dangling tool calls on a service-managed conversation.
+ *
+ * A fatal abort can end a tool round with calls that never produced a result. While the framework
+ * owns the transcript that is harmless — the next request is assembled locally and filters the
+ * unanswerable call — but once the service owns the transcript the dangling call is on the
+ * service's side, and the next request over that conversation is rejected (measured against the
+ * Anthropic Messages API, 2026-08-31: every `tool_use` must have a corresponding `tool_result`).
+ * The loop therefore settles the calls with one error `function_result` each before the abort
+ * propagates, exactly as the reference implementation's `MiddlewareFailure` settlement path does.
+ */
+import { assert, describe, expect, it } from 'vitest';
+import { AgentSession } from '../agent/session.js';
+import { MiddlewareFailed } from '../errors.js';
+import { functionMiddleware } from '../middleware/middleware.js';
+import { createResponseStream } from '../streaming/response-stream.js';
+import { tool } from '../tools/tool.js';
+import type { Content, FunctionResultContent } from '../types/content.js';
+import { textContent } from '../types/content.js';
+import type { Message } from '../types/message.js';
+import type { ChatResponseUpdate } from '../types/response.js';
+import { chatResponseUpdate, mergeChatUpdates } from '../types/response.js';
+import type { ChatClient, ChatClientMetadata, ChatOptions } from './chat-client.js';
+import { createFunctionInvocationClientFactory, withFunctionInvocation } from './function-invocation.js';
+
+const ABORT_RESULT_TEXT = 'Error: Tool execution was aborted by middleware before a result was produced.';
+
+function call(callId: string, name = 'echo'): Content {
+  return { type: 'function_call', callId, name, arguments: '{}' };
+}
+
+const echo = tool({
+  name: 'echo',
+  description: 'echo',
+  parameters: { type: 'object', properties: {}, additionalProperties: false },
+  execute: async () => 'ok',
+});
+
+const abortingMiddleware = functionMiddleware(async () => {
+  throw new MiddlewareFailed('policy says stop');
+});
+
+interface ScriptedTurn {
+  contents: Content[];
+  conversationId?: string;
+  /** Reject this request instead of answering it. */
+  fail?: boolean;
+}
+
+/** A scripted provider that reports conversation ids and records every request it receives. */
+function scriptedClient(
+  turns: ScriptedTurn[],
+  metadata: ChatClientMetadata = { providerName: 'mock' },
+): {
+  client: ChatClient<ChatOptions>;
+  requests: Array<ChatOptions | undefined>;
+  sent: Message[][];
+} {
+  let index = 0;
+  const requests: Array<ChatOptions | undefined> = [];
+  const sent: Message[][] = [];
+  const client: ChatClient<ChatOptions> = {
+    metadata,
+    getResponse: (messages, options) => {
+      requests.push(options);
+      sent.push(messages);
+      const turn = turns[Math.min(index++, turns.length - 1)] ?? { contents: [] };
+      return createResponseStream({
+        start: () =>
+          (async function* (): AsyncGenerator<ChatResponseUpdate> {
+            if (turn.fail === true) {
+              throw new Error('service unavailable');
+            }
+            yield chatResponseUpdate({
+              contents: turn.contents,
+              role: 'assistant',
+              ...(turn.conversationId === undefined ? {} : { conversationId: turn.conversationId }),
+            });
+          })(),
+        finalize: (updates) => mergeChatUpdates(updates),
+      });
+    },
+  };
+  return { client, requests, sent };
+}
+
+function resultsOf(messages: Message[]): FunctionResultContent[] {
+  return messages
+    .flatMap((msg) => msg.contents)
+    .filter((content): content is FunctionResultContent => content.type === 'function_result');
+}
+
+describe('settlement on a fatal middleware abort', () => {
+  it('answers each dangling call exactly once and still rethrows the original failure', async () => {
+    const { client, requests, sent } = scriptedClient([
+      { contents: [call('c1'), call('c2')], conversationId: 'resp_1' },
+      { contents: [textContent('settled')], conversationId: 'resp_settle' },
+    ]);
+
+    await expect(
+      withFunctionInvocation(client, { middleware: [abortingMiddleware] }).getResponse([], {
+        tools: [echo],
+      } as ChatOptions),
+    ).rejects.toBeInstanceOf(MiddlewareFailed);
+
+    // One settlement request: the batch's calls each answered by an error result, with the tool
+    // choice pinned so the settlement response cannot ask for more calls.
+    expect(requests).toHaveLength(2);
+    expect(requests[1]?.toolChoice).toBe('none');
+    expect(requests[1]?.conversationId).toBe('resp_1');
+    const settlement = sent[1];
+    assert.exists(settlement);
+    expect(settlement.map((msg) => msg.role)).toEqual(['tool']);
+    expect(resultsOf(settlement)).toEqual([
+      { type: 'function_result', callId: 'c1', result: ABORT_RESULT_TEXT, exception: 'MiddlewareFailure' },
+      { type: 'function_result', callId: 'c2', result: ABORT_RESULT_TEXT, exception: 'MiddlewareFailure' },
+    ]);
+  });
+
+  it('sends nothing when the framework owns the transcript', async () => {
+    const { client, requests } = scriptedClient([{ contents: [call('c1')] }]);
+
+    await expect(
+      withFunctionInvocation(client, { middleware: [abortingMiddleware] }).getResponse([], {
+        tools: [echo],
+      } as ChatOptions),
+    ).rejects.toBeInstanceOf(MiddlewareFailed);
+
+    expect(requests).toHaveLength(1);
+  });
+
+  it('settles on the streamed path the same way', async () => {
+    const { client, requests, sent } = scriptedClient([
+      { contents: [call('c1')], conversationId: 'resp_1' },
+      { contents: [textContent('settled')] },
+    ]);
+
+    const stream = withFunctionInvocation(client, { middleware: [abortingMiddleware] }).getResponse([], {
+      tools: [echo],
+    } as ChatOptions);
+    await expect(
+      (async () => {
+        for await (const _update of stream) {
+          // consume to the failure
+        }
+      })(),
+    ).rejects.toBeInstanceOf(MiddlewareFailed);
+
+    expect(requests).toHaveLength(2);
+    expect(resultsOf(sent[1] ?? []).map((result) => result.callId)).toEqual(['c1']);
+  });
+
+  it('never lets a settlement failure mask the abort', async () => {
+    const { client, requests } = scriptedClient([
+      { contents: [call('c1')], conversationId: 'resp_1' },
+      { contents: [], fail: true },
+    ]);
+
+    await expect(
+      withFunctionInvocation(client, { middleware: [abortingMiddleware] }).getResponse([], {
+        tools: [echo],
+      } as ChatOptions),
+    ).rejects.toBeInstanceOf(MiddlewareFailed);
+
+    expect(requests).toHaveLength(2);
+  });
+
+  it('advances the persisted continuation to the settlement response', async () => {
+    // For response-id chaining the settlement response is the first endpoint whose chain includes
+    // the synthetic outputs, so the next run must start from it.
+    const { client } = scriptedClient([
+      { contents: [call('c1')], conversationId: 'resp_1' },
+      { contents: [textContent('settled')], conversationId: 'resp_settle' },
+    ]);
+    const session = new AgentSession();
+    const bound = createFunctionInvocationClientFactory(client, { middleware: [abortingMiddleware] })(
+      session,
+    );
+
+    await expect(bound.getResponse([], { tools: [echo] } as ChatOptions)).rejects.toBeInstanceOf(
+      MiddlewareFailed,
+    );
+
+    expect(session.serviceSessionId).toBe('resp_settle');
+  });
+
+  it('does not displace a conversation anchor the provider declares stable', async () => {
+    // A conversation-object id resolves across responses; the settlement lands on it and no
+    // advance is needed — displacing it would unhook the session from the stored conversation.
+    const { client, requests } = scriptedClient(
+      [
+        { contents: [call('c1')], conversationId: 'resp_1' },
+        { contents: [textContent('settled')], conversationId: 'resp_settle' },
+      ],
+      { providerName: 'mock', stableConversationId: (id) => id.startsWith('conv_') },
+    );
+    const session = new AgentSession({ serviceSessionId: 'conv_1' });
+    const bound = createFunctionInvocationClientFactory(client, { middleware: [abortingMiddleware] })(
+      session,
+    );
+
+    await expect(
+      bound.getResponse([], { tools: [echo], conversationId: 'conv_1' } as ChatOptions),
+    ).rejects.toBeInstanceOf(MiddlewareFailed);
+
+    expect(requests[1]?.conversationId).toBe('conv_1');
+    expect(session.serviceSessionId).toBe('conv_1');
+  });
+});
+
+describe('settlement of an aborted approval replay', () => {
+  it('settles the approved calls of an already-persisted turn', async () => {
+    // The replayed calls belong to an earlier model turn the service already stored; when
+    // executing the approved batch aborts, those calls are what dangles.
+    const { client, requests, sent } = scriptedClient([
+      { contents: [textContent('settled')], conversationId: 'resp_settle' },
+    ]);
+    const gated = tool({
+      name: 'gated',
+      description: 'd',
+      parameters: { type: 'object', properties: {}, additionalProperties: false },
+      approvalMode: 'always_require',
+      execute: async () => 'ran',
+    });
+
+    await expect(
+      withFunctionInvocation(client, { middleware: [abortingMiddleware] }).getResponse(
+        [
+          { role: 'user', contents: [textContent('go')] },
+          {
+            role: 'user',
+            contents: [
+              {
+                type: 'function_approval_response',
+                id: 'a1',
+                approved: true,
+                functionCall: { type: 'function_call', callId: 'c1', name: 'gated', arguments: '{}' },
+              },
+            ],
+          },
+        ],
+        { tools: [gated], conversationId: 'conv_1' } as ChatOptions,
+      ),
+    ).rejects.toBeInstanceOf(MiddlewareFailed);
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.toolChoice).toBe('none');
+    expect(requests[0]?.conversationId).toBe('conv_1');
+    expect(resultsOf(sent[0] ?? [])).toEqual([
+      { type: 'function_result', callId: 'c1', result: ABORT_RESULT_TEXT, exception: 'MiddlewareFailure' },
+    ]);
+  });
+
+  it('sends nothing for an aborted replay when no conversation is in play', async () => {
+    const { client, requests } = scriptedClient([{ contents: [textContent('never')] }]);
+    const gated = tool({
+      name: 'gated',
+      description: 'd',
+      parameters: { type: 'object', properties: {}, additionalProperties: false },
+      approvalMode: 'always_require',
+      execute: async () => 'ran',
+    });
+
+    await expect(
+      withFunctionInvocation(client, { middleware: [abortingMiddleware] }).getResponse(
+        [
+          {
+            role: 'user',
+            contents: [
+              {
+                type: 'function_approval_response',
+                id: 'a1',
+                approved: true,
+                functionCall: { type: 'function_call', callId: 'c1', name: 'gated', arguments: '{}' },
+              },
+            ],
+          },
+        ],
+        { tools: [gated] } as ChatOptions,
+      ),
+    ).rejects.toBeInstanceOf(MiddlewareFailed);
+
+    expect(requests).toHaveLength(0);
+  });
+});
+
+describe('settlement of calls withdrawn at the iteration limit', () => {
+  it('answers the calls the final toolless round still produced', async () => {
+    // The final round forbids tools, but a model can answer with a call anyway; the call is
+    // removed from what the caller sees, and on a service-managed conversation the service still
+    // holds it — so it is settled the same way an aborted batch is.
+    const { client, requests, sent } = scriptedClient([
+      { contents: [call('c1')], conversationId: 'resp_1' },
+      { contents: [call('c9', 'echo')], conversationId: 'resp_2' },
+      { contents: [textContent('settled')], conversationId: 'resp_settle' },
+    ]);
+
+    const response = await withFunctionInvocation(client, { maxIterations: 1 }).getResponse([], {
+      tools: [echo],
+    } as ChatOptions);
+
+    expect(requests).toHaveLength(3);
+    expect(requests[2]?.toolChoice).toBe('none');
+    expect(requests[2]?.conversationId).toBe('resp_2');
+    const settlement = resultsOf(sent[2] ?? []);
+    expect(settlement.map((result) => result.callId)).toEqual(['c9']);
+    expect(settlement[0]?.result).toBe(
+      'Error: Function invocation limit reached before a result was produced.',
+    );
+    // The run's own answer is unchanged: the withdrawn call is absent and the fallback stands.
+    expect(response.text).toContain('Function invocation limit reached');
+  });
+
+  it('settles nothing at the limit when the framework owns the transcript', async () => {
+    const { client, requests } = scriptedClient([
+      { contents: [call('c1')] },
+      { contents: [call('c9', 'echo')] },
+    ]);
+
+    await withFunctionInvocation(client, { maxIterations: 1 }).getResponse([], {
+      tools: [echo],
+    } as ChatOptions);
+
+    expect(requests).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## What this changes

When a tool round ends holding calls that never produced a result and the service owns the transcript, the loop settles them — one error `function_result` per call, sent with `toolChoice: 'none'` — before the failure propagates, and advances the persisted continuation to the settlement response. Closes #149.

## Parity

- Reference checked: Python `_tools.py` `_settle_dangling_service_function_calls` and its two call sites (a `MiddlewareFailure` out of a model turn's batch, and out of an approved-replay batch via the `settle_dangling_calls` callback) — the result text and the `MiddlewareFailure` exception marker are carried verbatim as wire literals, the tool-choice pin, the best-effort error handling, and the continuation advance (`_update_function_invocation_continuation_state`) all match, with the stable-anchor guard this codebase's session adoption already applies. A third site is this implementation's own: the final over-budget round forbids tools, but a call the model produces anyway is only filtered locally, so on a service-managed conversation it is settled with its own result text — Python's `tool_choice: 'none'` final phase makes this structurally rarer there, and leaving it dangling here reproduces exactly the rejection this issue measures.
- Wire format affected: yes
- Public API affected: no
- Breaking change: no

Two producers from the issue's list are deliberately not settled, with the reasoning recorded: an **abandoned stream** (no reference implementation settles it; nothing runs on the consumer's behalf after it walks away, and issuing a fresh request from a cancelled run would invert what cancellation means) and an **approval pause** (the resume's re-materialized call-and-result exchange is its settlement — settling at pause time would answer the call twice — while an abort during that replay is covered by the second site). The `maxConsecutiveErrors` abort also stays unsettled, as in Python: its results existed and were discarded, and the middleware wording would be false for them. Tests pin: each dangling call answered exactly once with the exact text and marker, the tool-choice pin, the original failure reaching the caller unchanged, a failing settlement not masking it, nothing sent for a framework-owned transcript, continuation advance and the stable-anchor hold, both transports, the approval-replay site, and the iteration-limit site.

## Checklist

- [x] `pnpm check` passes (lint, typecheck, build, test)
- [x] Behaviour changes are covered by a test that fails without the change
- [x] Public API changes are reflected in the package README and `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)